### PR TITLE
Exporting Channel State

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -432,6 +432,12 @@ func (ch *Channel) Close() error {
 	)
 }
 
+// IsClosed returns true if the channel is marked as closed, otherwise false
+// is returned.
+func (ch *Channel) IsClosed() bool {
+	return atomic.LoadInt32(&ch.closed) == 1
+}
+
 /*
 NotifyClose registers a listener for when the server sends a channel or
 connection exception in the form of a Connection.Close or Channel.Close method.

--- a/connection_test.go
+++ b/connection_test.go
@@ -192,3 +192,19 @@ func TestIsClosed(t *testing.T) {
 		t.Fatal("connection expected to be marked as closed")
 	}
 }
+
+// TestChannelIsClosed will test the public method IsClosed on a channel.
+func TestChannelIsClosed(t *testing.T) {
+	conn := integrationConnection(t, "public channel.IsClosed()")
+	ch, _ := conn.Channel()
+
+	if ch.IsClosed() {
+		t.Fatalf("channel expected to not be marked as closed")
+	}
+
+	ch.Close()
+
+	if !ch.IsClosed() {
+		t.Fatal("channel expected to be marked as closed")
+	}
+}


### PR DESCRIPTION
Hey Guys, this is an old PR from streadway, and since we have this "official" fork, I'd still think is a good idea (and I need this haha)

I needed to access the Channel state on a project that I'm participating in. So, I just made the "closed" field public on channel.go in the same way as it is on connection.go. Nothing too fancy, but I think it is important to get the actual status of the channel.

Something that we have on RabbitMQ's client on Python (pika) and .Net (RabbitMQ) and I missed here.

Hope this helps,
Best regards. 

[Original Pull Request](https://github.com/streadway/amqp/pull/486)