### PR TITLE
Heartbeat interval should be timeout/2

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -783,7 +783,7 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 
 	// "The client should start sending heartbeats after receiving a
 	// Connection.Tune method"
-	go c.heartbeater(c.Config.Heartbeat, c.NotifyClose(make(chan *Error, 1)))
+	go c.heartbeater(c.Config.Heartbeat/2, c.NotifyClose(make(chan *Error, 1)))
 
 	if err := c.send(&methodFrame{
 		ChannelId: 0,


### PR DESCRIPTION
This pull request resolves https://github.com/streadway/amqp/issues/493

As per https://www.rabbitmq.com/heartbeats.html#heartbeats-interval

>Heartbeat frames are sent about every heartbeat timeout / 2 seconds. This value is sometimes referred to as the heartbeat interval. After two missed heartbeats, the peer is considered to be unreachable. Different clients manifest this differently but the TCP connection will be closed. When a client detects that RabbitMQ node is unreachable due to a heartbeat, it needs to re-connect.
It is important to not confuse the timeout value with the interval one. RabbitMQ configuration exposes the timeout value, so do the officially supported client libraries. However some clients might expose the interval, potentially causing confusion.

[I did my best to follow the guidelines - I am not sure what tests/example would be appropriate to add here, hence I haven't added any...]