### PR TITLE
add test go version 1.16.x and 1.17.x

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,21 +2,26 @@ name: PR
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   tests:
     name: tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
     services:
       rabbitmq:
         image: rabbitmq
         ports:
           - 5672:5672
     steps:
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-    - name: Set up Go environment
-      uses: actions/setup-go@v2
-    - name: Tests
-      run: AMQP_URL=amqp://guest:guest@localhost:5672/ go test -cpu=1,2 -v -tags integration
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Set up Go environment
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Tests
+        run: AMQP_URL=amqp://guest:guest@localhost:5672/ go test -cpu=1,2 -v -tags integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
+  - 1.17.x
   - 1.16.x
-  - 1.15.x
 
 addons:
   apt:


### PR DESCRIPTION
I've made the following modifications.
* add mutiple go-version 1.16 and 1.17 to `pr.yml`. (I refered to `Supported Go Versions` on README. )
* add go-version 1.17 to `travis.yml`.
* fix indent. 