### PR TITLE
Add a link to pkg.go.dev API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Go RabbitMQ Client Library
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/rabbitmq/amqp091-go.svg)](https://pkg.go.dev/github.com/rabbitmq/amqp091-go)
+
 This is a Go AMQP 0.9.1 client maintained by the [RabbitMQ core team](https://github.com/rabbitmq).
 It was [originally developed by Sean Treadway](https://github.com/streadway/amqp).
 


### PR DESCRIPTION
Add a link to Go API references from https://pkg.go.dev.

Preview available here: https://github.com/benmoss/amqp091-go/blob/add-godoc-link/README.md 😄 