### PR TITLE
connection: clarify documented behavior of NotifyClose

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -262,7 +262,8 @@ func (c *Connection) ConnectionState() tls.ConnectionState {
 NotifyClose registers a listener for close events either initiated by an error
 accompanying a connection.close method or by a normal shutdown.
 
-On normal shutdowns, the chan will be closed.
+The chan provided will be closed when the Channel is closed and on a
+graceful close, no error will be sent.
 
 To reconnect after a transport or protocol error, register a listener here and
 re-run your setup process.


### PR DESCRIPTION
The documentation for `NotifyClose()` differs between [Channel](https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.NotifyClose):

> The chan provided will be closed when the Channel is closed and on a graceful close, no error will be sent.

and [Connection](https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Connection.NotifyClose):

> On normal shutdowns, the chan will be closed.

The latter wording suggests that on abnormal shutdowns the chan will remain open, with two expected features:
* A non-blocking chan could be registered and the error notification would still be available to the application; and
* a new Connection could pass that same chan to `NotifyClose()` so an existing select statement need not update the chan it monitors.

In fact the logic for maintaining close notifiers appears identical for both Channel and Connection: both are closed as a result of the underlying object being closed.

This PR updates to use the Channel description in the Connection function to avoid the misleading interpretation.