### PR TITLE
 Fix AMQPLAIN authentication mechanism

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -5,6 +5,7 @@
 package amqp091
 
 import (
+	"bytes"
 	"fmt"
 )
 
@@ -42,9 +43,14 @@ func (auth *AMQPlainAuth) Mechanism() string {
 	return "AMQPLAIN"
 }
 
-// Response returns the null character delimited encoding for the SASL PLAIN Mechanism.
+// Response returns an AMQP encoded credentials table, without the field table size.
 func (auth *AMQPlainAuth) Response() string {
-	return fmt.Sprintf("LOGIN:%sPASSWORD:%s", auth.Username, auth.Password)
+	var buf bytes.Buffer
+	table := Table{"LOGIN": auth.Username, "PASSWORD": auth.Password}
+	if err := writeTable(&buf, table); err != nil {
+		return ""
+	}
+	return buf.String()[4:]
 }
 
 // Finds the first mechanism preferred by the client that the server supports.

--- a/client_test.go
+++ b/client_test.go
@@ -24,9 +24,20 @@ type server struct {
 	tune  connectionTuneOk
 }
 
+var defaultLogin = "guest"
+var defaultPassword = "guest"
+
 func defaultConfig() Config {
 	return Config{
-		SASL:   []Authentication{&PlainAuth{"guest", "guest"}},
+		SASL:   []Authentication{&PlainAuth{defaultLogin, defaultPassword}},
+		Vhost:  "/",
+		Locale: defaultLocale,
+	}
+}
+
+func amqplainConfig() Config {
+	return Config{
+		SASL:   []Authentication{&AMQPlainAuth{defaultLogin, defaultPassword}},
 		Vhost:  "/",
 		Locale: defaultLocale,
 	}
@@ -294,6 +305,42 @@ func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
 	c, err := Open(rwc, defaultConfig())
 	if err != ErrSASL {
 		t.Fatalf("expected ErrSASL got: %+v on %+v", err, c)
+	}
+}
+
+func TestOpenAMQPlainAuth(t *testing.T) {
+	auth := make(chan Table)
+	rwc, srv := newSession(t)
+
+	go func() {
+		srv.expectAMQP()
+		srv.send(0, &connectionStart{
+			VersionMajor: 0,
+			VersionMinor: 9,
+			Mechanisms:   "AMQPLAIN",
+			Locales:      "en_US",
+		})
+		srv.recv(0, &srv.start)
+		var authresp bytes.Buffer
+		_ = writeLongstr(&authresp, srv.start.Response)
+		table, _ := readTable(&authresp)
+		srv.connectionTune()
+
+		srv.recv(0, &connectionOpen{})
+		srv.send(0, &connectionOpenOk{})
+		rwc.Close()
+		auth <- table
+	}()
+
+	if c, err := Open(rwc, amqplainConfig()); err != nil {
+		t.Fatalf("could not create connection: %v (%s)", c, err)
+	}
+	table := <-auth
+	if table["LOGIN"] != defaultLogin {
+		t.Fatalf("unexpected login: want: %s, got: %s", defaultLogin, table["LOGIN"])
+	}
+	if table["PASSWORD"] != defaultPassword {
+		t.Fatalf("unexpected password: want: %s, got: %s", defaultPassword, table["PASSWORD"])
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -26,21 +26,23 @@ type server struct {
 
 var defaultLogin = "guest"
 var defaultPassword = "guest"
+var defaultPlainAuth = &PlainAuth{defaultLogin, defaultPassword}
+var defaultAMQPlainAuth = &AMQPlainAuth{defaultLogin, defaultPassword}
 
-func defaultConfig() Config {
+func defaultConfigWithAuth(auth Authentication) Config {
 	return Config{
-		SASL:   []Authentication{&PlainAuth{defaultLogin, defaultPassword}},
+		SASL:   []Authentication{auth},
 		Vhost:  "/",
 		Locale: defaultLocale,
 	}
 }
 
+func defaultConfig() Config {
+	return defaultConfigWithAuth(defaultPlainAuth)
+}
+
 func amqplainConfig() Config {
-	return Config{
-		SASL:   []Authentication{&AMQPlainAuth{defaultLogin, defaultPassword}},
-		Vhost:  "/",
-		Locale: defaultLocale,
-	}
+	return defaultConfigWithAuth(defaultAMQPlainAuth)
 }
 
 func newServer(t *testing.T, serverIO, clientIO io.ReadWriteCloser) *server {
@@ -164,15 +166,21 @@ func (t *server) expectAMQP() {
 	t.expectBytes([]byte{'A', 'M', 'Q', 'P', 0, 0, 9, 1})
 }
 
-func (t *server) connectionStart() {
+func (t *server) connectionStartWithMechanisms(mechs string, recv bool) {
 	t.send(0, &connectionStart{
 		VersionMajor: 0,
 		VersionMinor: 9,
-		Mechanisms:   "PLAIN",
-		Locales:      "en_US",
+		Mechanisms:   mechs,
+		Locales:      defaultLocale,
 	})
 
-	t.recv(0, &t.start)
+	if recv {
+		t.recv(0, &t.start)
+	}
+}
+
+func (t *server) connectionStart() {
+	t.connectionStartWithMechanisms("PLAIN", true)
 }
 
 func (t *server) connectionTune() {
@@ -294,12 +302,7 @@ func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
 
 	go func() {
 		srv.expectAMQP()
-		srv.send(0, &connectionStart{
-			VersionMajor: 0,
-			VersionMinor: 9,
-			Mechanisms:   "KERBEROS NTLM",
-			Locales:      "en_US",
-		})
+		srv.connectionStartWithMechanisms("KERBEROS NTLM", false)
 	}()
 
 	c, err := Open(rwc, defaultConfig())
@@ -314,13 +317,7 @@ func TestOpenAMQPlainAuth(t *testing.T) {
 
 	go func() {
 		srv.expectAMQP()
-		srv.send(0, &connectionStart{
-			VersionMajor: 0,
-			VersionMinor: 9,
-			Mechanisms:   "AMQPLAIN",
-			Locales:      "en_US",
-		})
-		srv.recv(0, &srv.start)
+		srv.connectionStartWithMechanisms("AMQPLAIN", true)
 		var authresp bytes.Buffer
 		_ = writeLongstr(&authresp, srv.start.Response)
 		table, _ := readTable(&authresp)


### PR DESCRIPTION
I'm copying and pasting from streadway/amqp#515, since I guess this fork is more actively maintained :)
Fixes #15.

The current AMQPLAIN implementation does not work with `rabbitmq` out-of-the-box.

I could not find an official reference for that authentication mechanism. Looking at other implementations ([rust](https://github.com/CleverCloud/amq-protocol/blob/master/protocol/src/auth.rs#L45), [python](https://github.com/celery/py-amqp/blob/7300741f9fc202083e87abd10e1cb38c28efad92/amqp/sasl.py#L48)) it seems that AMQPLAIN uses an AMQP table (`LOGIN` and `PASSWORD` fields), omitting the table length.