### PR TITLE
Added support for cert-only login without user and password

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -54,8 +54,23 @@ func (auth *AMQPlainAuth) Response() string {
 	return buf.String()[4:]
 }
 
+// ExternalAuth for RabbitMQ-auth-mechanism-ssl.
+type ExternalAuth struct {
+}
+
+// Mechanism returns "EXTERNAL"
+func (*ExternalAuth) Mechanism() string {
+	return "EXTERNAL"
+}
+
+// Response returns an AMQP encoded credentials table, without the field table size.
+func (*ExternalAuth) Response() string {
+	return "\000*\000*"
+}
+
 // Finds the first mechanism preferred by the client that the server supports.
 func pickSASLMechanism(client []Authentication, serverMechanisms []string) (auth Authentication, ok bool) {
+
 	for _, auth = range client {
 		for _, mech := range serverMechanisms {
 			if auth.Mechanism() == mech {

--- a/connection.go
+++ b/connection.go
@@ -157,6 +157,23 @@ func DialTLS(url string, amqps *tls.Config) (*Connection, error) {
 	})
 }
 
+// DialTLS_ExternalAuth accepts a string in the AMQP URI format and returns a
+// new Connection over TCP using EXTERNAL auth. Defaults to a server heartbeat
+// interval of 10 seconds and sets the initial read deadline to 30 seconds.
+//
+// This mechanism is used, when RabbitMQ is configured for EXTERNAL auth with
+// ssl_cert_login plugin for userless/passwordless logons
+//
+// DialTLS_ExternalAuth uses the provided tls.Config when encountering an
+// amqps:// scheme.
+func DialTLS_ExternalAuth(url string, amqps *tls.Config) (*Connection, error) {
+	return DialConfig(url, Config{
+		Heartbeat:       defaultHeartbeat,
+		TLSClientConfig: amqps,
+		SASL:            []Authentication{&ExternalAuth{}},
+	})
+}
+
 // DialConfig accepts a string in the AMQP URI format and a configuration for
 // the transport and connection setup, returning a new Connection.  Defaults to
 // a server heartbeat interval of 10 seconds and sets the initial read deadline


### PR DESCRIPTION
This PR contains the changes proposed in https://github.com/streadway/amqp/pull/121 together with the changes that @wolf-james requested and some small comment additions for consistency.

Note that I'm not really familiar with this protocol and I haven't looked into setting up a test environment for this setup. People have confirmed that the changes are correct in the original PR, but please let me know if you'd prefer some extra validation and I'll look into it when I'll have some time.