### PR TITLE
Add GetNextPublishSeqNo for channel in confirm mode

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1597,3 +1597,12 @@ func (ch *Channel) Reject(tag uint64, requeue bool) error {
 		Requeue:     requeue,
 	})
 }
+
+// GetNextPublishSeqNo returns the sequence number of the next message to be
+// published, when in confirm mode.
+func (ch *Channel) GetNextPublishSeqNo() uint64 {
+	ch.confirms.m.Lock()
+	defer ch.confirms.m.Unlock()
+
+	return ch.confirms.published + 1
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1776,6 +1776,38 @@ func TestConcurrentChannelAndConnectionClose(t *testing.T) {
 	}
 }
 
+func TestIntegrationGetNextPublishSeqNo(t *testing.T) {
+	if c := integrationConnection(t, "GetNextPublishSeqNo"); c != nil {
+		defer c.Close()
+
+		ch, err := c.Channel()
+		if err != nil {
+			t.Fatalf("channel: %v", err)
+		}
+
+		if err = ch.Confirm(false); err != nil {
+			t.Fatalf("could not confirm")
+		}
+
+		ex := "test-get-next-pub"
+		if err = ch.ExchangeDeclare(ex, "direct", false, false, false, false, nil); err != nil {
+			t.Fatalf("cannot declare %v: got: %v", ex, err)
+		}
+
+		n := ch.GetNextPublishSeqNo()
+		if n != 1 {
+			t.Errorf("wrong next publish seqence number before any publish, expected: %d, got: %d", 1, n)
+		}
+
+		ch.Publish("test-get-next-pub-seq", "", false, false, Publishing{})
+
+		n = ch.GetNextPublishSeqNo()
+		if n != 2 {
+			t.Errorf("wrong next publish seqence number after 1 publishing, expected: %d, got: %d", 2, n)
+		}
+	}
+}
+
 /*
  * Support for integration tests
  */


### PR DESCRIPTION
`GetNextPublishSeqNo` method on `Channel` will be very useful for handling of especially NACKed messages to keep track of message going to be published so that those can be republished or acted upon. The `confirms.published` counter is already there and this method will just return the same counter.


PS: This PR is moved from https://github.com/streadway/amqp/pull/478