### PR TITLE
Expose a method to enable out-of-order Publisher Confirms

### DIFF
--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ package amqp091
 import (
 	"fmt"
 	"io"
+	"sync"
 	"time"
 )
 
@@ -177,6 +178,15 @@ type Publishing struct {
 type Blocking struct {
 	Active bool   // TCP pushback active/inactive on server
 	Reason string // Server reason for activation
+}
+
+// DeferredConfirmation represents a future publisher confirm for a message. It
+// allows users to directly correlate a publishing to a confirmation. These are
+// returned from PublishWithDeferredConfirm on Channels.
+type DeferredConfirmation struct {
+	wg           sync.WaitGroup
+	DeliveryTag  uint64
+	confirmation Confirmation
 }
 
 // Confirmation notifies the acknowledgment or negative acknowledgement of a


### PR DESCRIPTION
Adds a new method, PublishAndAwaitConfirm, to channels which allows users to publish a message and wait on its confirmation.

There are two problems with the existing mechanisms, [NotifyPublish](https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.NotifyPublish) and [NotifyConfirm](https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Channel.NotifyConfirm). The first is that they both only expose confirmations to the user _in-order_, making it impossible to wait for a single confirmation without also waiting for every previous confirmation. The second is that the way they relay the confirmation back to the user is difficult to correlate to the published message. They expose the delivery tag through the [Confirmation struct](https://pkg.go.dev/github.com/rabbitmq/amqp091-go#Confirmation), but the [delivery tag of the publish](https://github.com/rabbitmq/amqp091-go/blob/v1.2.0/confirms.go#L42) is [not exposed](https://github.com/rabbitmq/amqp091-go/blob/v1.2.0/channel.go#L1366), forcing the user to implement their own delivery tag accounting in order to correlate a publish and a confirm.

This implementation essentially returns a [future](https://en.wikipedia.org/wiki/Futures_and_promises) for the confirmation from the `PublishAndAwaitConfirm` call, making it easy for users to correlate the publish to the confirm and hiding all of the delivery tag accounting to inside the library.

cc @ChunyiLyu @ikvmw 

Sample usage:
```go
ch.Confirm(false)
confirm, _ := ch.ConfirmPublish(...)
if !confirm.Wait() {
  log.Fatal("publish was nacked!")
}
```

One remaining question I have is if we want to deprecate `NotifyPublish`/`NotifyConfirm`. I believe that it'd be pretty straightforward to build in-order confirmations on top of this, so it's a superset of those APIs.