### PR TITLE
Client Example: Fix closing order

### DIFF
--- a/example_client_test.go
+++ b/example_client_test.go
@@ -278,6 +278,7 @@ func (session *Session) Close() error {
 	if !session.isReady {
 		return errAlreadyClosed
 	}
+	close(session.done)
 	err := session.channel.Close()
 	if err != nil {
 		return err
@@ -286,7 +287,7 @@ func (session *Session) Close() error {
 	if err != nil {
 		return err
 	}
-	close(session.done)
+
 	session.isReady = false
 	return nil
 }


### PR DESCRIPTION
In the client example, the order on how to close elements of the session is wrong:

https://github.com/rabbitmq/amqp091-go/blob/21ccfdea51148da4de39d35975fdd44480e979e2/example_client_test.go#L277-L292

If you first close the channel and after consider the session as done, the reconnection logic will try to re-create the channel and re-init the queue (in the example).
if you first close the done channel, you indicate that we are done with the session and the reconnection logic will end.