### PR TITLE
Example client: Rename `name` to `queueName` to make the usage clear and explicit

### DIFF
--- a/example_client_test.go
+++ b/example_client_test.go
@@ -243,10 +243,10 @@ func (client *Client) UnsafePush(data []byte) error {
 		return errNotConnected
 	}
 	return client.channel.Publish(
-		"",          // Exchange
+		"",               // Exchange
 		client.queueName, // Routing key
-		false,       // Mandatory
-		false,       // Immediate
+		false,            // Mandatory
+		false,            // Immediate
 		amqp.Publishing{
 			ContentType: "text/plain",
 			Body:        data,

--- a/example_client_test.go
+++ b/example_client_test.go
@@ -244,7 +244,7 @@ func (client *Client) UnsafePush(data []byte) error {
 	}
 	return client.channel.Publish(
 		"",          // Exchange
-		client.name, // Routing key
+		client.queueName, // Routing key
 		false,       // Mandatory
 		false,       // Immediate
 		amqp.Publishing{

--- a/example_client_test.go
+++ b/example_client_test.go
@@ -165,7 +165,7 @@ func (client *Client) init(conn *amqp.Connection) error {
 		return err
 	}
 	_, err = ch.QueueDeclare(
-		session.queueName,
+		client.queueName,
 		false, // Durable
 		false, // Delete when unused
 		false, // Exclusive
@@ -242,7 +242,7 @@ func (client *Client) UnsafePush(data []byte) error {
 	if !client.isReady {
 		return errNotConnected
 	}
-	return session.channel.Publish(
+	return client.channel.Publish(
 		"",          // Exchange
 		client.name, // Routing key
 		false,       // Mandatory
@@ -262,8 +262,8 @@ func (client *Client) Stream() (<-chan amqp.Delivery, error) {
 	if !client.isReady {
 		return nil, errNotConnected
 	}
-	return session.channel.Consume(
-		session.queueName,
+	return client.channel.Consume(
+		client.queueName,
 		"",    // Consumer
 		false, // Auto-Ack
 		false, // Exclusive


### PR DESCRIPTION
The client example uses a variable called `name`.
Reading through example, questions will arise "What name is it?".
Especially in the context of AMQP/RabbitMQ this can be the Exchange name, the queue name, the routing key name, the consumer name, etc.

To make the usage clear and explicit, we rename `name` to `queueName`.