### PR TITLE
Example client: Rename Stream() to Consume()  to avoid confusion with RabbitMQ streams

### DIFF
--- a/example_client_test.go
+++ b/example_client_test.go
@@ -254,11 +254,11 @@ func (session *Session) UnsafePush(data []byte) error {
 	)
 }
 
-// Stream will continuously put queue items on the channel.
+// Consume will continuously put queue items on the channel.
 // It is required to call delivery.Ack when it has been
 // successfully processed, or delivery.Nack when it fails.
 // Ignoring this will cause data to build up on the server.
-func (session *Session) Stream() (<-chan amqp.Delivery, error) {
+func (session *Session) Consume() (<-chan amqp.Delivery, error) {
 	if !session.isReady {
 		return nil, errNotConnected
 	}


### PR DESCRIPTION
The example client names its functionality to consume messages from a queue `Stream()`.
With one of the latest versions of RabbitMQ, [RabbitMQ Streams](https://www.rabbitmq.com/streams.html) have been introduced.

From what I can see, the API is also using `Consume`, but requires custom arguments like `x-queue-type`. In the example client, these arguments are not used so far.

To avoid confusion between "simple" consuming and the new Streaming functionality, this PR renames `Stream()` to `Consume()`.