### PR TITLE
Solve the problem that the connection is closed but waiting will always wait

### DIFF
--- a/confirms.go
+++ b/confirms.go
@@ -103,11 +103,20 @@ func (c *confirms) Close() error {
 	c.m.Lock()
 	defer c.m.Unlock()
 
+	c.releaseWaitConfirms()
+
 	for _, l := range c.listeners {
 		close(l)
 	}
 	c.listeners = nil
 	return nil
+}
+
+func (c *confirms) releaseWaitConfirms() {
+	c.deferredConfirmations.ConfirmMultiple(Confirmation{
+		DeliveryTag: c.published,
+		Ack:         false,
+	})
 }
 
 type deferredConfirmations struct {


### PR DESCRIPTION
steps:
1.connected
2.select confirm
3.publishwithconfirm (network error， connection closed)
4.wait （always wait forever）
