### PR TITLE
Fix deadlock on DeferredConfirmations

### DIFF
--- a/confirms.go
+++ b/confirms.go
@@ -103,11 +103,20 @@ func (c *confirms) Close() error {
 	c.m.Lock()
 	defer c.m.Unlock()
 
+	c.releaseWaitConfirms()
+
 	for _, l := range c.listeners {
 		close(l)
 	}
 	c.listeners = nil
 	return nil
+}
+
+func (c *confirms) releaseWaitConfirms() {
+	c.deferredConfirmations.ConfirmMultiple(Confirmation{
+		DeliveryTag: c.published,
+		Ack:         false,
+	})
 }
 
 type deferredConfirmations struct {

--- a/confirms_test.go
+++ b/confirms_test.go
@@ -216,3 +216,22 @@ func TestDeferredConfirmationsConfirmMultiple(t *testing.T) {
 		t.Fatal("expected to receive true for result, received false")
 	}
 }
+
+func TestDeferredConfirmationsClose(t *testing.T) {
+	dcs := newDeferredConfirmations()
+	var wg sync.WaitGroup
+	var result bool
+	dc1 := dcs.Add(1)
+	dc2 := dcs.Add(2)
+	dc3 := dcs.Add(3)
+	wg.Add(1)
+	go func() {
+		result = dc1.Wait() && dc2.Wait() && dc3.Wait()
+		wg.Done()
+	}()
+	dcs.Close()
+	wg.Wait()
+	if result {
+		t.Fatal("expected to receive false for nacked confirmations, received true")
+	}
+}

--- a/confirms_test.go
+++ b/confirms_test.go
@@ -226,12 +226,12 @@ func TestDeferredConfirmationsClose(t *testing.T) {
 	dc3 := dcs.Add(3)
 	wg.Add(1)
 	go func() {
-		result = dc1.Wait() && dc2.Wait() && dc3.Wait()
+		result = !dc1.Wait() && !dc2.Wait() && !dc3.Wait()
 		wg.Done()
 	}()
 	dcs.Close()
 	wg.Wait()
-	if result {
+	if !result {
 		t.Fatal("expected to receive false for nacked confirmations, received true")
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -1826,7 +1826,7 @@ func TestShouldNotWaitAfterConnectionClosedIssue44(t *testing.T) {
 		<-closed
 	}()
 
-	confirm, err := ch.PublishWithDeferredConfirm("amqp.direct", "issue44", false, false, Publishing{Body: []byte("abc")})
+	confirm, err := ch.PublishWithDeferredConfirm("amq.direct", "issue44", false, false, Publishing{Body: []byte("abc")})
 	if err != nil {
 		t.Fatalf("PublishWithDeferredConfirm error: %v", err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1810,6 +1810,37 @@ func TestIntegrationGetNextPublishSeqNo(t *testing.T) {
 	}
 }
 
+// https://github.com/rabbitmq/amqp091-go/pull/44
+func TestShouldNotWaitAfterConnectionClosedIssue44(t *testing.T) {
+	conn := integrationConnection(t, "TestShouldNotWaitAfterConnectionClosedIssue44")
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("channel error: %v", err)
+	}
+	err = ch.Confirm(false)
+	if err != nil {
+		t.Fatalf("confirm error: %v", err)
+	}
+	closed := conn.NotifyClose(make(chan *Error, 1))
+	go func() {
+		<-closed
+	}()
+
+	confirm, err := ch.PublishWithDeferredConfirm("amqp.direct", "issue44", false, false, Publishing{Body: []byte("abc")})
+	if err != nil {
+		t.Fatalf("PublishWithDeferredConfirm error: %v", err)
+	}
+
+	ch.Close()
+	conn.Close()
+
+	ack := confirm.Wait()
+
+	if ack != false {
+		t.Fatalf("ack returned should be false %v", ack)
+	}
+}
+
 /*
  * Support for integration tests
  */

--- a/integration_test.go
+++ b/integration_test.go
@@ -1826,7 +1826,7 @@ func TestShouldNotWaitAfterConnectionClosedIssue44(t *testing.T) {
 		<-closed
 	}()
 
-	confirm, err := ch.PublishWithDeferredConfirm("nonexistent", "issue44", false, false, Publishing{Body: []byte("abc")})
+	confirm, err := ch.PublishWithDeferredConfirm("test-issue44", "issue44", false, false, Publishing{Body: []byte("abc")})
 	if err != nil {
 		t.Fatalf("PublishWithDeferredConfirm error: %v", err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1826,7 +1826,7 @@ func TestShouldNotWaitAfterConnectionClosedIssue44(t *testing.T) {
 		<-closed
 	}()
 
-	confirm, err := ch.PublishWithDeferredConfirm("amq.direct", "issue44", false, false, Publishing{Body: []byte("abc")})
+	confirm, err := ch.PublishWithDeferredConfirm("nonexistent", "issue44", false, false, Publishing{Body: []byte("abc")})
 	if err != nil {
 		t.Fatalf("PublishWithDeferredConfirm error: %v", err)
 	}


### PR DESCRIPTION
This PR improves the changes proposed in #44 originally made by @shifengbin

Changes:
- Fixed deadlock that occurs with DeferredConfirmations when connection is reset
- Made the fix's code more consistent with the other methods in the file
- Added some documentation for `Wait()` and other internal methods
- Added unit test for `deferredConfirmations.Close()`
- Added integration test to confirm that `.Wait()` will return `ack: false` when connection is closed (as suggested by @DanielePalaia )

The newly added unit & integration tests both passed consistently when I ran them

This problem is also mentioned in #46 