### PR TITLE
Some unit tests in connection were showing a race condition (see #31):

### DIFF
--- a/change_version.sh
+++ b/change_version.sh
@@ -1,0 +1,4 @@
+#/bin/bash
+echo $1 > VERSION
+sed -i -e "s/.*buildVersion           = \"*.*/buildVersion =            \"$1\"/" ./connection.go
+go fmt ./...

--- a/client_test.go
+++ b/client_test.go
@@ -236,7 +236,7 @@ func TestDefaultClientProperties(t *testing.T) {
 	if want, got := defaultLocale, srv.start.Locale; want != got {
 		t.Errorf("expected locale %s got: %s", want, got)
 	}
-	rwc.Close()
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestCustomClientProperties(t *testing.T) {
@@ -265,7 +265,7 @@ func TestCustomClientProperties(t *testing.T) {
 		t.Errorf("expected version %s got: %s", want, got)
 	}
 
-	rwc.Close()
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestOpen(t *testing.T) {
@@ -278,7 +278,7 @@ func TestOpen(t *testing.T) {
 	if c, err := Open(rwc, defaultConfig()); err != nil {
 		t.Fatalf("could not create connection: %v (%s)", c, err)
 	}
-	rwc.Close()
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestChannelOpen(t *testing.T) {
@@ -288,7 +288,6 @@ func TestChannelOpen(t *testing.T) {
 		srv.connectionOpen()
 		srv.channelOpen(1)
 
-		rwc.Close()
 	}()
 
 	c, err := Open(rwc, defaultConfig())
@@ -300,6 +299,8 @@ func TestChannelOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not open channel: %v (%s)", ch, err)
 	}
+
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
@@ -314,6 +315,7 @@ func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
 	if err != ErrSASL {
 		t.Fatalf("expected ErrSASL got: %+v on %+v", err, c)
 	}
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestOpenAMQPlainAuth(t *testing.T) {
@@ -344,7 +346,7 @@ func TestOpenAMQPlainAuth(t *testing.T) {
 	if table["PASSWORD"] != defaultPassword {
 		t.Fatalf("unexpected password: want: %s, got: %s", defaultPassword, table["PASSWORD"])
 	}
-	rwc.Close()
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestOpenFailedCredentials(t *testing.T) {
@@ -361,6 +363,7 @@ func TestOpenFailedCredentials(t *testing.T) {
 	if err != ErrCredentials {
 		t.Fatalf("expected ErrCredentials got: %+v on %+v", err, c)
 	}
+
 }
 
 func TestOpenFailedVhost(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -218,7 +218,7 @@ func TestDefaultClientProperties(t *testing.T) {
 
 	go func() {
 		srv.connectionOpen()
-		rwc.Close()
+
 	}()
 
 	if c, err := Open(rwc, defaultConfig()); err != nil {
@@ -229,13 +229,14 @@ func TestDefaultClientProperties(t *testing.T) {
 		t.Errorf("expected product %s got: %s", want, got)
 	}
 
-	if want, got := defaultVersion, srv.start.ClientProperties["version"]; want != got {
+	if want, got := buildVersion, srv.start.ClientProperties["version"]; want != got {
 		t.Errorf("expected version %s got: %s", want, got)
 	}
 
 	if want, got := defaultLocale, srv.start.Locale; want != got {
 		t.Errorf("expected locale %s got: %s", want, got)
 	}
+	rwc.Close()
 }
 
 func TestCustomClientProperties(t *testing.T) {
@@ -249,7 +250,7 @@ func TestCustomClientProperties(t *testing.T) {
 
 	go func() {
 		srv.connectionOpen()
-		rwc.Close()
+
 	}()
 
 	if c, err := Open(rwc, config); err != nil {
@@ -263,18 +264,21 @@ func TestCustomClientProperties(t *testing.T) {
 	if want, got := config.Properties["version"], srv.start.ClientProperties["version"]; want != got {
 		t.Errorf("expected version %s got: %s", want, got)
 	}
+
+	rwc.Close()
 }
 
 func TestOpen(t *testing.T) {
 	rwc, srv := newSession(t)
 	go func() {
 		srv.connectionOpen()
-		rwc.Close()
+
 	}()
 
 	if c, err := Open(rwc, defaultConfig()); err != nil {
 		t.Fatalf("could not create connection: %v (%s)", c, err)
 	}
+	rwc.Close()
 }
 
 func TestChannelOpen(t *testing.T) {
@@ -326,7 +330,7 @@ func TestOpenAMQPlainAuth(t *testing.T) {
 
 		srv.recv(0, &connectionOpen{})
 		srv.send(0, &connectionOpenOk{})
-		rwc.Close()
+
 		auth <- table
 	}()
 
@@ -340,6 +344,7 @@ func TestOpenAMQPlainAuth(t *testing.T) {
 	if table["PASSWORD"] != defaultPassword {
 		t.Fatalf("unexpected password: want: %s, got: %s", defaultPassword, table["PASSWORD"])
 	}
+	rwc.Close()
 }
 
 func TestOpenFailedCredentials(t *testing.T) {

--- a/connection.go
+++ b/connection.go
@@ -24,7 +24,7 @@ const (
 	defaultHeartbeat         = 10 * time.Second
 	defaultConnectionTimeout = 30 * time.Second
 	defaultProduct           = "Amqp 0.9.1 Client"
-	defaultVersion           = "β"
+	buildVersion             = "1.3.0"
 	platform                 = "golang"
 	// Safer default that makes channel leaks a lot easier to spot
 	// before they create operational headaches. See https://github.com/rabbitmq/rabbitmq-server/issues/1593.
@@ -759,7 +759,7 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 	if len(config.Properties) == 0 {
 		config.Properties = Table{
 			"product":  defaultProduct,
-			"version":  defaultVersion,
+			"version":  buildVersion,
 			"platform": platform,
 		}
 	}


### PR DESCRIPTION
These ones were the ones testing Open scenarios. The issue is that Open and Close, rwc.Open and rwc.Close can at the same time write on:

c.allocator = newAllocator(1, c.Config.ChannelMax)
connection.go line 444 and
connection.go line 849

while shutdown is protected by the structure mutex m, OpenComplete() is not causing the race.

While it's not clear if the library should protect this eventuality, the tests are testing the Open function, so I think the close can be put in the main thread avoiding the race and not affecting the test validity