### PR TITLE
These ones were the ones testing Open scenarios. The issue is that Op…

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -218,7 +218,7 @@ func TestDefaultClientProperties(t *testing.T) {
 
 	go func() {
 		srv.connectionOpen()
-		rwc.Close()
+
 	}()
 
 	if c, err := Open(rwc, defaultConfig()); err != nil {
@@ -236,6 +236,7 @@ func TestDefaultClientProperties(t *testing.T) {
 	if want, got := defaultLocale, srv.start.Locale; want != got {
 		t.Errorf("expected locale %s got: %s", want, got)
 	}
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestCustomClientProperties(t *testing.T) {
@@ -249,7 +250,7 @@ func TestCustomClientProperties(t *testing.T) {
 
 	go func() {
 		srv.connectionOpen()
-		rwc.Close()
+
 	}()
 
 	if c, err := Open(rwc, config); err != nil {
@@ -263,18 +264,21 @@ func TestCustomClientProperties(t *testing.T) {
 	if want, got := config.Properties["version"], srv.start.ClientProperties["version"]; want != got {
 		t.Errorf("expected version %s got: %s", want, got)
 	}
+
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestOpen(t *testing.T) {
 	rwc, srv := newSession(t)
 	go func() {
 		srv.connectionOpen()
-		rwc.Close()
+
 	}()
 
 	if c, err := Open(rwc, defaultConfig()); err != nil {
 		t.Fatalf("could not create connection: %v (%s)", c, err)
 	}
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestChannelOpen(t *testing.T) {
@@ -284,7 +288,6 @@ func TestChannelOpen(t *testing.T) {
 		srv.connectionOpen()
 		srv.channelOpen(1)
 
-		rwc.Close()
 	}()
 
 	c, err := Open(rwc, defaultConfig())
@@ -296,6 +299,8 @@ func TestChannelOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not open channel: %v (%s)", ch, err)
 	}
+
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
@@ -310,6 +315,7 @@ func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
 	if err != ErrSASL {
 		t.Fatalf("expected ErrSASL got: %+v on %+v", err, c)
 	}
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestOpenAMQPlainAuth(t *testing.T) {
@@ -326,7 +332,7 @@ func TestOpenAMQPlainAuth(t *testing.T) {
 
 		srv.recv(0, &connectionOpen{})
 		srv.send(0, &connectionOpenOk{})
-		rwc.Close()
+
 		auth <- table
 	}()
 
@@ -340,6 +346,7 @@ func TestOpenAMQPlainAuth(t *testing.T) {
 	if table["PASSWORD"] != defaultPassword {
 		t.Fatalf("unexpected password: want: %s, got: %s", defaultPassword, table["PASSWORD"])
 	}
+	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestOpenFailedCredentials(t *testing.T) {
@@ -356,6 +363,7 @@ func TestOpenFailedCredentials(t *testing.T) {
 	if err != ErrCredentials {
 		t.Fatalf("expected ErrCredentials got: %+v on %+v", err, c)
 	}
+
 }
 
 func TestOpenFailedVhost(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -215,6 +215,7 @@ func (t *server) channelOpen(id int) {
 
 func TestDefaultClientProperties(t *testing.T) {
 	rwc, srv := newSession(t)
+	t.Cleanup(func() { rwc.Close() })
 
 	go func() {
 		srv.connectionOpen()
@@ -236,11 +237,12 @@ func TestDefaultClientProperties(t *testing.T) {
 	if want, got := defaultLocale, srv.start.Locale; want != got {
 		t.Errorf("expected locale %s got: %s", want, got)
 	}
-	t.Cleanup(func() { rwc.Close() })
+
 }
 
 func TestCustomClientProperties(t *testing.T) {
 	rwc, srv := newSession(t)
+	t.Cleanup(func() { rwc.Close() })
 
 	config := defaultConfig()
 	config.Properties = Table{
@@ -265,11 +267,11 @@ func TestCustomClientProperties(t *testing.T) {
 		t.Errorf("expected version %s got: %s", want, got)
 	}
 
-	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestOpen(t *testing.T) {
 	rwc, srv := newSession(t)
+	t.Cleanup(func() { rwc.Close() })
 	go func() {
 		srv.connectionOpen()
 
@@ -278,11 +280,12 @@ func TestOpen(t *testing.T) {
 	if c, err := Open(rwc, defaultConfig()); err != nil {
 		t.Fatalf("could not create connection: %v (%s)", c, err)
 	}
-	t.Cleanup(func() { rwc.Close() })
+
 }
 
 func TestChannelOpen(t *testing.T) {
 	rwc, srv := newSession(t)
+	t.Cleanup(func() { rwc.Close() })
 
 	go func() {
 		srv.connectionOpen()
@@ -300,11 +303,11 @@ func TestChannelOpen(t *testing.T) {
 		t.Fatalf("could not open channel: %v (%s)", ch, err)
 	}
 
-	t.Cleanup(func() { rwc.Close() })
 }
 
 func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
 	rwc, srv := newSession(t)
+	t.Cleanup(func() { rwc.Close() })
 
 	go func() {
 		srv.expectAMQP()
@@ -315,12 +318,13 @@ func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
 	if err != ErrSASL {
 		t.Fatalf("expected ErrSASL got: %+v on %+v", err, c)
 	}
-	t.Cleanup(func() { rwc.Close() })
+
 }
 
 func TestOpenAMQPlainAuth(t *testing.T) {
 	auth := make(chan Table)
 	rwc, srv := newSession(t)
+	t.Cleanup(func() { rwc.Close() })
 
 	go func() {
 		srv.expectAMQP()
@@ -346,7 +350,7 @@ func TestOpenAMQPlainAuth(t *testing.T) {
 	if table["PASSWORD"] != defaultPassword {
 		t.Fatalf("unexpected password: want: %s, got: %s", defaultPassword, table["PASSWORD"])
 	}
-	t.Cleanup(func() { rwc.Close() })
+
 }
 
 func TestOpenFailedCredentials(t *testing.T) {


### PR DESCRIPTION
…en and Close, rwc.Open and rwc.Close can at the same time write on:

c.allocator = newAllocator(1, c.Config.ChannelMax)
connection.go line 444 and
connection.go line 849

while shutdown is protected by the structure mutex m, OpenComplete() is not causing the race.

While it's not clear if the library should protect this eventuality, the tests are testing the Open function, so I think the close can be put in the main thread avoiding the race and not affecting the test validity