### PR TITLE
Update Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/rabbitmq/amqp091-go
 
-go 1.15
+go 1.16


### PR DESCRIPTION
We only run tests against 1.16, 1.17 and 1.18. Most of the ecosystem
should be in one of those versions, given Golang lifecycle policy. The
library should just work with Go 1.15, but we do not guarantee it.

Signed-off-by: Aitor Perez Cedres <acedres@vmware.com>
