### PR TITLE
connection: fix: reader go-routine is leaked on connection close

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,9 @@ jobs:
           - 5672:5672
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go environment
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Tests

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,8 @@ list: ## list Makefile targets
 	@echo "The most used targets: \n"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-
 fmt: ## Run go fmt against code
 	go fmt ./...
-
 
 vet: ## Run go vet against code
 	go vet ./...

--- a/connection_test.go
+++ b/connection_test.go
@@ -213,3 +213,31 @@ func TestChannelIsClosed(t *testing.T) {
 		t.Fatal("channel expected to be marked as closed")
 	}
 }
+
+// TestReaderGoRoutineTerminatesWhenMsgIsProcessedDuringClose tests the issue
+// described in https://github.com/rabbitmq/amqp091-go/issues/69.
+func TestReaderGoRoutineTerminatesWhenMsgIsProcessedDuringClose(t *testing.T) {
+	const routines = 10
+	c := integrationConnection(t, t.Name())
+
+	var wg sync.WaitGroup
+	startSigCh := make(chan interface{})
+
+	for i := 0; i < routines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			<-startSigCh
+
+			err := c.Close()
+			if err != nil {
+				t.Logf("close failed in routine %d: %s", id, err.Error())
+			}
+		}(i)
+	}
+	close(startSigCh)
+
+	t.Log("waiting for go-routines to terminate")
+	wg.Wait()
+}

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -56,11 +56,12 @@ func ExampleConnection_reconnect() {
 		// between reconnects, shares the same topology as the consumer.  If we rather
 		// sent all messages up front, the first consumer would receive every message.
 		// We would rather show how the messages are not lost between reconnects.
-		_, pub, err := setup(url, queue)
+		con, pub, err := setup(url, queue)
 		if err != nil {
 			fmt.Println("err publisher setup:", err)
 			return
 		}
+		defer con.Close()
 
 		// Purge the queue from the publisher side to establish initial state
 		if _, err := pub.QueuePurge(queue, false); err != nil {


### PR DESCRIPTION
When a message was sent and it's response was received while the
connection was closed or an error happened, the reader go-routine could
get stuck and be leaked.

The reader go routine tries to send a received message to the unbuffered
c.rpc channel via the dispatch0() and dispatchN() methods.
The call() method reads from the rpc channel.
If an error happened while the dispatch method sends a message to the
rpc channel, the call() method could terminate because it read an error
from c.errors or because c.errors was closed.

To prevent the scenario:
- the reader go-routine now closes c.rpc when it terminates,
- The call() method, reads from c.rpc until a message was received or it
  is closed. When c.rpc is closed, it reads an error from c.errors or
  wait until c.errors is closed.
  When it reads an error, it returns it. If it is closed it returns
  ErrClosed.

This ensures that the messages is read from c.rpc before call() returns.
It also ensures that when a message was received that it is processed.
Previously it could happen that the message was silently ignored because
c.errors returned an error or was closed.

This fixes #69.
A testcase can be found in PR https://github.com/rabbitmq/amqp091-go/pull/71