### PR TITLE
tests: add testcase to ensure reader routine terminates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/rabbitmq/amqp091-go
 
 go 1.16
+
+require go.uber.org/goleak v1.1.12


### PR DESCRIPTION
Add a testcase for the bug that the reader go-routine tries to send a
message to the buffered rpc channel but call() terminated because it
read an error from the errors chan or the errors chan was closed.
It cause that reader routine gets stuck forever and does not terminate
when the connection is closed.
More information: https://github.com/rabbitmq/amqp091-go/issues/69.

This testcase does not reproduce the issue reliably, but it is triggered
in ~80% of executions.


This PR adds a testcase for the issue https://github.com/rabbitmq/amqp091-go/issues/69 and the fix https://github.com/rabbitmq/amqp091-go/pull/70.

------

If you have an idea how to trigger the bug reliably in a testcase, please let me know.
