### PR TITLE
ci: run golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,5 +22,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45
-
           only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.45
+
+          only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+run:
+  build-tags:
+    - integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 ## Prerequisites
 
 1. Go: [https://golang.org/dl/](https://golang.org/dl/)
-1. Golint `go get -u -v github.com/golang/lint/golint`
+1. `golint`: `go get -u -v github.com/golang/lint/golint`
+1. `golangci-lint` (Optional for `make check`): [installation docs](https://golangci-lint.run/usage/install/)
 
 ## Contributing
 

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ list: ## list Makefile targets
 fmt: ## Run go fmt against code
 	go fmt ./...
 
-.PHONY: vet
-vet: ## Run go vet against code
-	go vet ./...
-
 .PHONY: tests
 tests: ## Run all tests and requires a running rabbitmq-server
 	env AMQP_URL=amqp://guest:guest@127.0.0.1:5672/ go test -cpu 1,2 -race -v -tags integration
+
+.PHONY: check
+check:
+	golangci-lint run ./...


### PR DESCRIPTION
Add a github action workflow to run golangci-lint.
golangci-lint is configured to only show new issues from PRs.

When all existing issues in the main branch are fixed (or excluded),
only-new-issues could be set to false.