### PR TITLE
channel: return nothing instead of always a nil-error in receive methods

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -334,9 +334,8 @@ func (ch *Channel) dispatch(msg message) {
 	}
 }
 
-func (ch *Channel) transition(f func(*Channel, frame)) error {
+func (ch *Channel) transition(f func(*Channel, frame)) {
 	ch.recv = f
-	return nil
 }
 
 func (ch *Channel) recvMethod(f frame) {

--- a/channel.go
+++ b/channel.go
@@ -358,9 +358,9 @@ func (ch *Channel) recvMethod(f frame) error {
 	case *bodyFrame:
 		// drop
 		return ch.transition((*Channel).recvMethod)
+	default:
+		panic("unexpected frame type")
 	}
-
-	panic("unexpected frame type")
 }
 
 func (ch *Channel) recvHeader(f frame) error {
@@ -383,9 +383,10 @@ func (ch *Channel) recvHeader(f frame) error {
 	case *bodyFrame:
 		// drop and reset
 		return ch.transition((*Channel).recvMethod)
-	}
 
-	panic("unexpected frame type")
+	default:
+		panic("unexpected frame type")
+	}
 }
 
 // state after method + header and before the length
@@ -413,9 +414,10 @@ func (ch *Channel) recvContent(f frame) error {
 		}
 
 		return ch.transition((*Channel).recvContent)
-	}
 
-	panic("unexpected frame type")
+	default:
+		panic("unexpected frame type")
+	}
 }
 
 /*


### PR DESCRIPTION
The channel recv*() methods and transition() were always returning a nil error.
These methods are changed to return nothing instead of always nil.

golangci-lint was complaining that the code ignored the returned error by channel.recv().
This change gets rid of the warning and simplifies the code. 

