### PR TITLE
Added function to get the remote peer's IP address (conn.RemoteAddr())

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -265,6 +265,18 @@ func (c *Connection) LocalAddr() net.Addr {
 	return &net.TCPAddr{}
 }
 
+/*
+RemoteAddr returns the remote TCP peer address, if known.
+*/
+func (c *Connection) RemoteAddr() net.Addr {
+	if conn, ok := c.conn.(interface {
+		RemoteAddr() net.Addr
+	}); ok {
+		return conn.RemoteAddr()
+	}
+	return &net.TCPAddr{}
+}
+
 // ConnectionState returns basic TLS details of the underlying transport.
 // Returns a zero value when the underlying connection does not implement
 // ConnectionState() tls.ConnectionState.

--- a/integration_test.go
+++ b/integration_test.go
@@ -134,6 +134,28 @@ func TestIntegrationLocalAddr(t *testing.T) {
 	t.Logf("Connected to port %d\n", port)
 }
 
+func TestIntegrationRemoteAddr(t *testing.T) {
+	config := Config{}
+
+	c, err := DialConfig(amqpURL, config)
+	if err != nil {
+		t.Fatalf("expected to dial with config %+v integration server: %s", config, err)
+	}
+	defer c.Close()
+
+	a := c.RemoteAddr()
+	_, portString, err := net.SplitHostPort(a.String())
+	if err != nil {
+		t.Fatalf("expected to get a remote network address with config %+v integration server: %s", config, a.String())
+	}
+
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("expected to get a TCP port number with config %+v integration server: %s", config, err)
+	}
+	t.Logf("Connected to port %d\n", port)
+}
+
 // https://github.com/streadway/amqp/issues/94
 func TestExchangePassiveOnMissingExchangeShouldError(t *testing.T) {
 	c := integrationConnection(t, "exch")


### PR DESCRIPTION
Hi, 

In the clustered RabbitMQ installation it is often necessary to get the remote node's IP address to be able to determine to which node exactly you are connected to.

Having that in mind, I've added `conn.RemoteAddr()` method which behaves similar to `conn.LocalAddr()` but returns remote peer IP address:port instead of local one.

Thank you and have a good day!