### PR TITLE
Draft: Use context for Publish methods

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ package amqp091
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"reflect"
 	"testing"
@@ -450,16 +451,16 @@ func TestConfirmMultipleOrdersDeliveryTags(t *testing.T) {
 
 	go func() {
 		var e error
-		if e = ch.Publish("", "q", false, false, Publishing{Body: []byte("pub 1")}); e != nil {
+		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 1")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish("", "q", false, false, Publishing{Body: []byte("pub 2")}); e != nil {
+		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 2")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish("", "q", false, false, Publishing{Body: []byte("pub 3")}); e != nil {
+		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 3")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish("", "q", false, false, Publishing{Body: []byte("pub 4")}); e != nil {
+		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 4")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
 	}()
@@ -473,16 +474,16 @@ func TestConfirmMultipleOrdersDeliveryTags(t *testing.T) {
 
 	go func() {
 		var e error
-		if e = ch.Publish("", "q", false, false, Publishing{Body: []byte("pub 5")}); e != nil {
+		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 5")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish("", "q", false, false, Publishing{Body: []byte("pub 6")}); e != nil {
+		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 6")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish("", "q", false, false, Publishing{Body: []byte("pub 7")}); e != nil {
+		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 7")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish("", "q", false, false, Publishing{Body: []byte("pub 8")}); e != nil {
+		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 8")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
 	}()
@@ -529,7 +530,7 @@ func TestDeferredConfirmations(t *testing.T) {
 
 	var results []*DeferredConfirmation
 	for i := 1; i < 5; i++ {
-		dc, err := ch.PublishWithDeferredConfirm("", "q", false, false, Publishing{Body: []byte("pub")})
+		dc, err := ch.PublishWithDeferredConfirm(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub")})
 		if err != nil {
 			t.Fatalf("failed to PublishWithDeferredConfirm: %v", err)
 		}
@@ -698,7 +699,7 @@ func TestPublishBodySliceIssue74(t *testing.T) {
 
 	for i := 0; i < publishings; i++ {
 		go func(ii int) {
-			if err := ch.Publish("", "q", false, false, Publishing{Body: base[0:ii]}); err != nil {
+			if err := ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: base[0:ii]}); err != nil {
 				t.Errorf("publish error: %v", err)
 			}
 		}(i)
@@ -746,7 +747,7 @@ func TestPublishZeroFrameSizeIssue161(t *testing.T) {
 
 	for i := 0; i < publishings; i++ {
 		go func() {
-			if err := ch.Publish("", "q", false, false, Publishing{Body: []byte("anything")}); err != nil {
+			if err := ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("anything")}); err != nil {
 				t.Errorf("publish error: %v", err)
 			}
 		}()
@@ -779,7 +780,7 @@ func TestPublishAndShutdownDeadlockIssue84(t *testing.T) {
 
 	defer time.AfterFunc(500*time.Millisecond, func() { t.Fatalf("Publish deadlock") }).Stop()
 	for {
-		if err := ch.Publish("exchange", "q", false, false, Publishing{Body: []byte("test")}); err != nil {
+		if err := ch.Publish(context.TODO(), "exchange", "q", false, false, Publishing{Body: []byte("test")}); err != nil {
 			t.Log("successfully caught disconnect error", err)
 			return
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -399,6 +399,10 @@ func TestOpenFailedVhost(t *testing.T) {
 }
 
 func TestConfirmMultipleOrdersDeliveryTags(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	rwc, srv := newSession(t)
 	defer rwc.Close()
 
@@ -451,16 +455,16 @@ func TestConfirmMultipleOrdersDeliveryTags(t *testing.T) {
 
 	go func() {
 		var e error
-		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 1")}); e != nil {
+		if e = ch.Publish(ctx, "", "q", false, false, Publishing{Body: []byte("pub 1")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 2")}); e != nil {
+		if e = ch.Publish(ctx, "", "q", false, false, Publishing{Body: []byte("pub 2")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 3")}); e != nil {
+		if e = ch.Publish(ctx, "", "q", false, false, Publishing{Body: []byte("pub 3")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 4")}); e != nil {
+		if e = ch.Publish(ctx, "", "q", false, false, Publishing{Body: []byte("pub 4")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
 	}()
@@ -474,16 +478,16 @@ func TestConfirmMultipleOrdersDeliveryTags(t *testing.T) {
 
 	go func() {
 		var e error
-		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 5")}); e != nil {
+		if e = ch.Publish(ctx, "", "q", false, false, Publishing{Body: []byte("pub 5")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 6")}); e != nil {
+		if e = ch.Publish(ctx, "", "q", false, false, Publishing{Body: []byte("pub 6")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 7")}); e != nil {
+		if e = ch.Publish(ctx, "", "q", false, false, Publishing{Body: []byte("pub 7")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
-		if e = ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub 8")}); e != nil {
+		if e = ch.Publish(ctx, "", "q", false, false, Publishing{Body: []byte("pub 8")}); e != nil {
 			t.Errorf("publish error: %v", err)
 		}
 	}()
@@ -497,6 +501,10 @@ func TestConfirmMultipleOrdersDeliveryTags(t *testing.T) {
 }
 
 func TestDeferredConfirmations(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	rwc, srv := newSession(t)
 	defer rwc.Close()
 
@@ -530,7 +538,7 @@ func TestDeferredConfirmations(t *testing.T) {
 
 	var results []*DeferredConfirmation
 	for i := 1; i < 5; i++ {
-		dc, err := ch.PublishWithDeferredConfirm(context.TODO(), "", "q", false, false, Publishing{Body: []byte("pub")})
+		dc, err := ch.PublishWithDeferredConfirm(ctx, "", "q", false, false, Publishing{Body: []byte("pub")})
 		if err != nil {
 			t.Fatalf("failed to PublishWithDeferredConfirm: %v", err)
 		}
@@ -664,6 +672,10 @@ func TestNotifyClosesAllChansAfterConnectionClose(t *testing.T) {
 
 // Should not panic when sending bodies split at different boundaries
 func TestPublishBodySliceIssue74(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	rwc, srv := newSession(t)
 	defer rwc.Close()
 
@@ -699,7 +711,7 @@ func TestPublishBodySliceIssue74(t *testing.T) {
 
 	for i := 0; i < publishings; i++ {
 		go func(ii int) {
-			if err := ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: base[0:ii]}); err != nil {
+			if err := ch.Publish(ctx, "", "q", false, false, Publishing{Body: base[0:ii]}); err != nil {
 				t.Errorf("publish error: %v", err)
 			}
 		}(i)
@@ -710,6 +722,10 @@ func TestPublishBodySliceIssue74(t *testing.T) {
 
 // Should not panic when server and client have frame_size of 0
 func TestPublishZeroFrameSizeIssue161(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	rwc, srv := newSession(t)
 	defer rwc.Close()
 
@@ -747,7 +763,7 @@ func TestPublishZeroFrameSizeIssue161(t *testing.T) {
 
 	for i := 0; i < publishings; i++ {
 		go func() {
-			if err := ch.Publish(context.TODO(), "", "q", false, false, Publishing{Body: []byte("anything")}); err != nil {
+			if err := ch.Publish(ctx, "", "q", false, false, Publishing{Body: []byte("anything")}); err != nil {
 				t.Errorf("publish error: %v", err)
 			}
 		}()
@@ -757,6 +773,10 @@ func TestPublishZeroFrameSizeIssue161(t *testing.T) {
 }
 
 func TestPublishAndShutdownDeadlockIssue84(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	rwc, srv := newSession(t)
 	defer rwc.Close()
 
@@ -780,7 +800,7 @@ func TestPublishAndShutdownDeadlockIssue84(t *testing.T) {
 
 	defer time.AfterFunc(500*time.Millisecond, func() { t.Fatalf("Publish deadlock") }).Stop()
 	for {
-		if err := ch.Publish(context.TODO(), "exchange", "q", false, false, Publishing{Body: []byte("test")}); err != nil {
+		if err := ch.Publish(ctx, "exchange", "q", false, false, Publishing{Body: []byte("test")}); err != nil {
 			t.Log("successfully caught disconnect error", err)
 			return
 		}

--- a/confirms_test.go
+++ b/confirms_test.go
@@ -6,6 +6,7 @@
 package amqp091
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -25,7 +26,7 @@ func TestConfirmOneResequences(t *testing.T) {
 	c.Listen(l)
 
 	for i := range fixtures {
-		if want, got := uint64(i+1), c.Publish(); want != got.DeliveryTag {
+		if want, got := uint64(i+1), c.Publish(context.TODO()); want != got.DeliveryTag {
 			t.Fatalf("expected publish to return the 1 based delivery tag published, want: %d, got: %d", want, got.DeliveryTag)
 		}
 	}
@@ -63,7 +64,7 @@ func TestConfirmAndPublishDoNotDeadlock(t *testing.T) {
 	}()
 
 	for i := 0; i < iterations; i++ {
-		c.Publish()
+		c.Publish(context.TODO())
 		<-l
 	}
 }
@@ -81,7 +82,7 @@ func TestConfirmMixedResequences(t *testing.T) {
 	c.Listen(l)
 
 	for range fixtures {
-		c.Publish()
+		c.Publish(context.TODO())
 	}
 
 	c.One(fixtures[0])
@@ -116,7 +117,7 @@ func TestConfirmMultipleResequences(t *testing.T) {
 	c.Listen(l)
 
 	for range fixtures {
-		c.Publish()
+		c.Publish(context.TODO())
 	}
 
 	c.Multiple(fixtures[len(fixtures)-1])
@@ -140,7 +141,7 @@ func BenchmarkSequentialBufferedConfirms(t *testing.B) {
 		if i > cap(l)-1 {
 			<-l
 		}
-		c.One(Confirmation{c.Publish().DeliveryTag, true})
+		c.One(Confirmation{c.Publish(context.TODO()).DeliveryTag, true})
 	}
 }
 
@@ -158,7 +159,7 @@ func TestConfirmsIsThreadSafe(t *testing.T) {
 	c.Listen(l)
 
 	for i := 0; i < count; i++ {
-		go func() { pub <- Confirmation{c.Publish().DeliveryTag, true} }()
+		go func() { pub <- Confirmation{c.Publish(context.TODO()).DeliveryTag, true} }()
 	}
 
 	for i := 0; i < count; i++ {

--- a/example_client_test.go
+++ b/example_client_test.go
@@ -6,6 +6,7 @@
 package amqp091_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -243,6 +244,7 @@ func (client *Client) UnsafePush(data []byte) error {
 		return errNotConnected
 	}
 	return client.channel.Publish(
+		context.TODO(),
 		"",               // Exchange
 		client.queueName, // Routing key
 		false,            // Mandatory

--- a/example_client_test.go
+++ b/example_client_test.go
@@ -243,8 +243,12 @@ func (client *Client) UnsafePush(data []byte) error {
 	if !client.isReady {
 		return errNotConnected
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	return client.channel.Publish(
-		context.TODO(),
+		ctx,
 		"",               // Exchange
 		client.queueName, // Routing key
 		false,            // Mandatory

--- a/examples_test.go
+++ b/examples_test.go
@@ -6,6 +6,7 @@
 package amqp091_test
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
@@ -176,7 +177,7 @@ func ExampleChannel_Confirm_bridge() {
 			log.Fatalf("source channel closed, see the reconnect example for handling this")
 		}
 
-		err = chd.Publish("logs", msg.RoutingKey, false, false, amqp.Publishing{
+		err = chd.Publish(context.TODO(), "logs", msg.RoutingKey, false, false, amqp.Publishing{
 			// Copy all the properties
 			ContentType:     msg.ContentType,
 			ContentEncoding: msg.ContentEncoding,
@@ -377,7 +378,7 @@ func ExampleChannel_Publish() {
 
 	// This is not a mandatory delivery, so it will be dropped if there are no
 	// queues bound to the logs exchange.
-	err = c.Publish("logs", "info", false, false, msg)
+	err = c.Publish(context.TODO(), "logs", "info", false, false, msg)
 	if err != nil {
 		// Since publish is asynchronous this can happen if the network connection
 		// is reset or if the server has run out of resources.

--- a/examples_test.go
+++ b/examples_test.go
@@ -177,7 +177,10 @@ func ExampleChannel_Confirm_bridge() {
 			log.Fatalf("source channel closed, see the reconnect example for handling this")
 		}
 
-		err = chd.Publish(context.TODO(), "logs", msg.RoutingKey, false, false, amqp.Publishing{
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		err = chd.Publish(ctx, "logs", msg.RoutingKey, false, false, amqp.Publishing{
 			// Copy all the properties
 			ContentType:     msg.ContentType,
 			ContentEncoding: msg.ContentEncoding,
@@ -376,9 +379,12 @@ func ExampleChannel_Publish() {
 		Body:         []byte("Go Go AMQP!"),
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	// This is not a mandatory delivery, so it will be dropped if there are no
 	// queues bound to the logs exchange.
-	err = c.Publish(context.TODO(), "logs", "info", false, false, msg)
+	err = c.Publish(ctx, "logs", "info", false, false, msg)
 	if err != nil {
 		// Since publish is asynchronous this can happen if the network connection
 		// is reset or if the server has run out of resources.

--- a/integration_test.go
+++ b/integration_test.go
@@ -668,13 +668,13 @@ func TestIntegrationPublishConsume(t *testing.T) {
 
 		messages, _ := sub.Consume(queue, "", false, false, false, false, nil)
 
-		if e := pub.Publish("", queue, false, false, Publishing{Body: []byte("pub 1")}); e != nil {
+		if e := pub.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("pub 1")}); e != nil {
 			t.Fatalf("publish error: %v", e)
 		}
-		if e := pub.Publish("", queue, false, false, Publishing{Body: []byte("pub 2")}); e != nil {
+		if e := pub.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("pub 2")}); e != nil {
 			t.Fatalf("publish error: %v", e)
 		}
-		if e := pub.Publish("", queue, false, false, Publishing{Body: []byte("pub 3")}); e != nil {
+		if e := pub.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("pub 3")}); e != nil {
 			t.Fatalf("publish error: %v", e)
 		}
 
@@ -717,10 +717,10 @@ func TestIntegrationConsumeFlow(t *testing.T) {
 			t.Fatalf("error consuming: %v", err)
 		}
 
-		if e := pub.Publish("", queue, false, false, Publishing{Body: []byte("pub 1")}); e != nil {
+		if e := pub.Publish(context.TODO(), "ontext.TODO(), "", queue, false, false, Publishing{Body: []byte("pub 1")}); e != nil {
 			t.Fatalf("error publishing: %v", e)
 		}
-		if e := pub.Publish("", queue, false, false, Publishing{Body: []byte("pub 2")}); e != nil {
+		if e := pub.Publish(context.TODO(), "ontext.TODO(), "ontext.TODO(), "", queue, false, false, Publishing{Body: []byte("pub 2")}); e != nil {
 			t.Fatalf("error publishing: %v", e)
 		}
 
@@ -793,7 +793,7 @@ func TestIntegrationConsumeCancel(t *testing.T) {
 
 		messages, _ := ch.Consume(queue, "integration-tag", false, false, false, false, nil)
 
-		if e := ch.Publish("", queue, false, false, Publishing{Body: []byte("1")}); e != nil {
+		if e := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("1")}); e != nil {
 			t.Fatalf("error publishing: %v", e)
 		}
 
@@ -804,7 +804,7 @@ func TestIntegrationConsumeCancel(t *testing.T) {
 			t.Fatalf("error cancelling the consumer: %v", err)
 		}
 
-		if e := ch.Publish("", queue, false, false, Publishing{Body: []byte("2")}); e != nil {
+		if e := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("2")}); e != nil {
 			t.Fatalf("error publishing: %v", e)
 		}
 
@@ -894,7 +894,7 @@ func TestQuickPublishOnly(t *testing.T) {
 		defer integrationQueueDelete(t, pub, queue)
 
 		chk := func(msg Publishing) bool {
-			return pub.Publish("", queue, false, false, msg) == nil
+			return pub.Publish(context.TODO(), "", queue, false, false, msg) == nil
 		}
 		if err := quick.Check(chk, nil); err != nil {
 			t.Fatalf("check error: %v", err)
@@ -925,7 +925,7 @@ func TestPublishEmptyBody(t *testing.T) {
 			t.Fatalf("Could not consume")
 		}
 
-		err = ch.Publish("", queue, false, false, Publishing{})
+		err = ch.Publish(context.TODO(), "", queue, false, false, Publishing{})
 		if err != nil {
 			t.Fatalf("Could not publish")
 		}
@@ -969,7 +969,7 @@ func TestPublishEmptyBodyWithHeadersIssue67(t *testing.T) {
 			"ham": "spam",
 		}
 
-		err = ch.Publish("", queue, false, false, Publishing{Headers: headers})
+		err = ch.Publish(context.TODO(), "", queue, false, false, Publishing{Headers: headers})
 		if err != nil {
 			t.Fatalf("Could not publish")
 		}
@@ -1028,7 +1028,7 @@ func TestQuickPublishConsumeOnly(t *testing.T) {
 		if chkerr := quick.CheckEqual(
 			func(msg Publishing) []byte {
 				empty := Publishing{Body: msg.Body}
-				if pub.Publish("", queue, false, false, empty) != nil {
+				if pub.Publish(context.TODO(), "", queue, false, false, empty) != nil {
 					return []byte{'X'}
 				}
 				return msg.Body
@@ -1082,7 +1082,7 @@ func TestQuickPublishConsumeBigBody(t *testing.T) {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
-		err = pub.Publish("", queue, false, false, fixture)
+		err = pub.Publish(context.TODO(), "", queue, false, false, fixture)
 		if err != nil {
 			t.Fatalf("Could not publish big body")
 		}
@@ -1109,7 +1109,7 @@ func TestIntegrationGetOk(t *testing.T) {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
-		if err := ch.Publish("", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
+		if err := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
 			t.Fatalf("Failed to publish: %s", err)
 		}
 
@@ -1167,7 +1167,7 @@ func TestIntegrationTxCommit(t *testing.T) {
 			t.Fatalf("tx.select failed")
 		}
 
-		if err := ch.Publish("", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
+		if err := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
 			t.Fatalf("Failed to publish: %s", err)
 		}
 
@@ -1202,7 +1202,7 @@ func TestIntegrationTxRollback(t *testing.T) {
 			t.Fatalf("tx.select failed")
 		}
 
-		if err := ch.Publish("", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
+		if err := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
 			t.Fatalf("Failed to publish: %s", err)
 		}
 
@@ -1231,7 +1231,7 @@ func TestIntegrationReturn(t *testing.T) {
 		ch.NotifyReturn(ret)
 
 		// mandatory publish to an exchange without a binding should be returned
-		if err := ch.Publish("", "return-without-binding", true, false, Publishing{Body: []byte("mandatory")}); err != nil {
+		if err := ch.Publish(context.TODO(), "", "return-without-binding", true, false, Publishing{Body: []byte("mandatory")}); err != nil {
 			t.Fatalf("Failed to publish: %s", err)
 		}
 
@@ -1296,7 +1296,7 @@ func TestIntegrationConfirm(t *testing.T) {
 			t.Fatalf("could not confirm")
 		}
 
-		if err := ch.Publish("", "confirm", false, false, Publishing{Body: []byte("confirm")}); err != nil {
+		if err := ch.Publish(context.TODO(), "", "confirm", false, false, Publishing{Body: []byte("confirm")}); err != nil {
 			t.Fatalf("Failed to publish: %s", err)
 		}
 
@@ -1363,7 +1363,7 @@ func TestRoundTripAllFieldValueTypes61(t *testing.T) {
 			t.Fatalf("Could not consume")
 		}
 
-		err = ch.Publish("", queue, false, false, Publishing{Body: []byte("ignored"), Headers: headers})
+		err = ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("ignored"), Headers: headers})
 		if err != nil {
 			t.Fatalf("Could not publish: %v", err)
 		}
@@ -1528,7 +1528,7 @@ func TestDeadlockConsumerIssue48(t *testing.T) {
 
 		for i := 0; i < cap(confirms); i++ {
 			// Fill the queue with some new or remaining publishings
-			if err := ch.Publish("", queue, false, false, Publishing{Body: []byte("")}); err != nil {
+			if err := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("")}); err != nil {
 				t.Fatalf("error publishing: %v", err)
 			}
 		}
@@ -1587,7 +1587,7 @@ func TestRepeatedChannelExceptionWithPublishAndMaxProcsIssue46(t *testing.T) {
 				}
 				break
 			}
-			err := ch.Publish("not-existing-exchange", "some-key", false, false, Publishing{Body: []byte("some-data")})
+			err := ch.Publish(context.TODO(), "not-existing-exchange", "some-key", false, false, Publishing{Body: []byte("some-data")})
 			if err != nil {
 				if publishError, ok := err.(*Error); !ok || publishError.Code != 504 {
 					t.Fatalf("expected channel only exception i: %d j: %d error: %+v", i, j, publishError)
@@ -1634,7 +1634,7 @@ func TestChannelExceptionWithCloseIssue43(t *testing.T) {
 		// Cause an asynchronous channel exception causing the server
 		// to send a "channel.close" method either before or after the next
 		// asynchronous method.
-		err = c1.Publish("nonexisting-exchange", "", false, false, Publishing{})
+		err = c1.Publish(context.TODO(), "nonexisting-exchange", "", false, false, Publishing{})
 		if err != nil {
 			t.Fatalf("failed to publish, got: %v", err)
 		}
@@ -1689,7 +1689,7 @@ func TestCorruptedMessageIssue7(t *testing.T) {
 		}
 
 		for i := 0; i < messageCount; i++ {
-			err := pub.Publish("", queue, false, false, Publishing{
+			err := pub.Publish(context.TODO(), "", queue, false, false, Publishing{
 				Body: generateCrc32Random(t, 7*i),
 			})
 
@@ -1819,7 +1819,7 @@ func TestRabbitMQQueueTTLGet(t *testing.T) {
 			t.Fatalf("queue declare: %s", err)
 		}
 
-		if err := channel.Publish("", queue, false, false, Publishing{Body: []byte("ttl")}); err != nil {
+		if err := channel.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("ttl")}); err != nil {
 			t.Fatalf("error publishing: %v", err)
 		}
 
@@ -1852,10 +1852,10 @@ func TestRabbitMQQueueNackMultipleRequeue(t *testing.T) {
 				t.Fatalf("queue declare: %s", err)
 			}
 
-			if err := channel.Publish("", queue, false, false, Publishing{Body: []byte("1")}); err != nil {
+			if err := channel.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("1")}); err != nil {
 				t.Fatalf("error publishing: %v", err)
 			}
-			if err := channel.Publish("", queue, false, false, Publishing{Body: []byte("2")}); err != nil {
+			if err := channel.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("2")}); err != nil {
 				t.Fatalf("error publishing: %v", err)
 			}
 
@@ -1975,7 +1975,7 @@ func TestIntegrationGetNextPublishSeqNo(t *testing.T) {
 			t.Fatalf("wrong next publish seqence number before any publish, expected: %d, got: %d", 1, n)
 		}
 
-		if err := ch.Publish("test-get-next-pub-seq", "", false, false, Publishing{}); err != nil {
+		if err := ch.Publish(context.TODO(), "test-get-next-pub-seq", "", false, false, Publishing{}); err != nil {
 			t.Fatalf("publish error: %v", err)
 		}
 
@@ -2002,7 +2002,7 @@ func TestShouldNotWaitAfterConnectionClosedIssue44(t *testing.T) {
 		<-closed
 	}()
 
-	confirm, err := ch.PublishWithDeferredConfirm("test-issue44", "issue44", false, false, Publishing{Body: []byte("abc")})
+	confirm, err := ch.PublishWithDeferredConfirm(context.TODO(), "test-issue44", "issue44", false, false, Publishing{Body: []byte("abc")})
 	if err != nil {
 		t.Fatalf("PublishWithDeferredConfirm error: %v", err)
 	}
@@ -2093,7 +2093,7 @@ func TestShouldNotWaitAfterConnectionClosedNewChannelCreatedIssue11(t *testing.T
 
 	conn.NotifyClose(make(chan *Error, 1))
 
-	_, err = ch.PublishWithDeferredConfirm("issue11", "issue11", false, false, Publishing{Body: []byte("abc")})
+	_, err = ch.PublishWithDeferredConfirm(context.TODO(), "issue11", "issue11", false, false, Publishing{Body: []byte("abc")})
 	if err != nil {
 		t.Fatalf("PublishWithDeferredConfirm error: %v", err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -644,6 +644,10 @@ func TestIntegrationNonBlockingClose(t *testing.T) {
 }
 
 func TestIntegrationPublishConsume(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	queue := "test.integration.publish.consume"
 
 	c1 := integrationConnection(t, "pub")
@@ -668,13 +672,13 @@ func TestIntegrationPublishConsume(t *testing.T) {
 
 		messages, _ := sub.Consume(queue, "", false, false, false, false, nil)
 
-		if e := pub.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("pub 1")}); e != nil {
+		if e := pub.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("pub 1")}); e != nil {
 			t.Fatalf("publish error: %v", e)
 		}
-		if e := pub.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("pub 2")}); e != nil {
+		if e := pub.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("pub 2")}); e != nil {
 			t.Fatalf("publish error: %v", e)
 		}
-		if e := pub.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("pub 3")}); e != nil {
+		if e := pub.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("pub 3")}); e != nil {
 			t.Fatalf("publish error: %v", e)
 		}
 
@@ -685,6 +689,10 @@ func TestIntegrationPublishConsume(t *testing.T) {
 }
 
 func TestIntegrationConsumeFlow(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	queue := "test.integration.consumer-flow"
 
 	c1 := integrationConnection(t, "pub-flow")
@@ -717,10 +725,10 @@ func TestIntegrationConsumeFlow(t *testing.T) {
 			t.Fatalf("error consuming: %v", err)
 		}
 
-		if e := pub.Publish(context.TODO(), "ontext.TODO(), "", queue, false, false, Publishing{Body: []byte("pub 1")}); e != nil {
+		if e := pub.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("pub 1")}); e != nil {
 			t.Fatalf("error publishing: %v", e)
 		}
-		if e := pub.Publish(context.TODO(), "ontext.TODO(), "ontext.TODO(), "", queue, false, false, Publishing{Body: []byte("pub 2")}); e != nil {
+		if e := pub.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("pub 2")}); e != nil {
 			t.Fatalf("error publishing: %v", e)
 		}
 
@@ -776,6 +784,10 @@ func TestIntegrationPublishFlow(t *testing.T) {
 }
 
 func TestIntegrationConsumeCancel(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	queue := "test.integration.consume-cancel"
 
 	c := integrationConnection(t, "pub")
@@ -793,7 +805,7 @@ func TestIntegrationConsumeCancel(t *testing.T) {
 
 		messages, _ := ch.Consume(queue, "integration-tag", false, false, false, false, nil)
 
-		if e := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("1")}); e != nil {
+		if e := ch.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("1")}); e != nil {
 			t.Fatalf("error publishing: %v", e)
 		}
 
@@ -804,7 +816,7 @@ func TestIntegrationConsumeCancel(t *testing.T) {
 			t.Fatalf("error cancelling the consumer: %v", err)
 		}
 
-		if e := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("2")}); e != nil {
+		if e := ch.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("2")}); e != nil {
 			t.Fatalf("error publishing: %v", e)
 		}
 
@@ -878,6 +890,10 @@ func (c Publishing) Generate(r *rand.Rand, _ int) reflect.Value {
 }
 
 func TestQuickPublishOnly(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	if c := integrationConnection(t, "quick"); c != nil {
 		defer c.Close()
 		pub, err := c.Channel()
@@ -894,7 +910,7 @@ func TestQuickPublishOnly(t *testing.T) {
 		defer integrationQueueDelete(t, pub, queue)
 
 		chk := func(msg Publishing) bool {
-			return pub.Publish(context.TODO(), "", queue, false, false, msg) == nil
+			return pub.Publish(ctx, "", queue, false, false, msg) == nil
 		}
 		if err := quick.Check(chk, nil); err != nil {
 			t.Fatalf("check error: %v", err)
@@ -903,6 +919,10 @@ func TestQuickPublishOnly(t *testing.T) {
 }
 
 func TestPublishEmptyBody(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	c := integrationConnection(t, "empty")
 	if c != nil {
 		defer c.Close()
@@ -925,7 +945,7 @@ func TestPublishEmptyBody(t *testing.T) {
 			t.Fatalf("Could not consume")
 		}
 
-		err = ch.Publish(context.TODO(), "", queue, false, false, Publishing{})
+		err = ch.Publish(ctx, "", queue, false, false, Publishing{})
 		if err != nil {
 			t.Fatalf("Could not publish")
 		}
@@ -942,6 +962,10 @@ func TestPublishEmptyBody(t *testing.T) {
 }
 
 func TestPublishEmptyBodyWithHeadersIssue67(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	c := integrationConnection(t, "issue67")
 	if c != nil {
 		defer c.Close()
@@ -969,7 +993,7 @@ func TestPublishEmptyBodyWithHeadersIssue67(t *testing.T) {
 			"ham": "spam",
 		}
 
-		err = ch.Publish(context.TODO(), "", queue, false, false, Publishing{Headers: headers})
+		err = ch.Publish(ctx, "", queue, false, false, Publishing{Headers: headers})
 		if err != nil {
 			t.Fatalf("Could not publish")
 		}
@@ -989,6 +1013,10 @@ func TestPublishEmptyBodyWithHeadersIssue67(t *testing.T) {
 }
 
 func TestQuickPublishConsumeOnly(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	c1 := integrationConnection(t, "quick-pub")
 	c2 := integrationConnection(t, "quick-sub")
 
@@ -1028,7 +1056,7 @@ func TestQuickPublishConsumeOnly(t *testing.T) {
 		if chkerr := quick.CheckEqual(
 			func(msg Publishing) []byte {
 				empty := Publishing{Body: msg.Body}
-				if pub.Publish(context.TODO(), "", queue, false, false, empty) != nil {
+				if pub.Publish(ctx, "", queue, false, false, empty) != nil {
 					return []byte{'X'}
 				}
 				return msg.Body
@@ -1047,6 +1075,10 @@ func TestQuickPublishConsumeOnly(t *testing.T) {
 }
 
 func TestQuickPublishConsumeBigBody(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	c1 := integrationConnection(t, "big-pub")
 	c2 := integrationConnection(t, "big-sub")
 
@@ -1082,7 +1114,7 @@ func TestQuickPublishConsumeBigBody(t *testing.T) {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
-		err = pub.Publish(context.TODO(), "", queue, false, false, fixture)
+		err = pub.Publish(ctx, "", queue, false, false, fixture)
 		if err != nil {
 			t.Fatalf("Could not publish big body")
 		}
@@ -1099,6 +1131,10 @@ func TestQuickPublishConsumeBigBody(t *testing.T) {
 }
 
 func TestIntegrationGetOk(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	if c := integrationConnection(t, "getok"); c != nil {
 		defer c.Close()
 
@@ -1109,7 +1145,7 @@ func TestIntegrationGetOk(t *testing.T) {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
-		if err := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
+		if err := ch.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
 			t.Fatalf("Failed to publish: %s", err)
 		}
 
@@ -1153,6 +1189,10 @@ func TestIntegrationGetEmpty(t *testing.T) {
 }
 
 func TestIntegrationTxCommit(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	if c := integrationConnection(t, "txcommit"); c != nil {
 		defer c.Close()
 
@@ -1167,7 +1207,7 @@ func TestIntegrationTxCommit(t *testing.T) {
 			t.Fatalf("tx.select failed")
 		}
 
-		if err := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
+		if err := ch.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
 			t.Fatalf("Failed to publish: %s", err)
 		}
 
@@ -1188,6 +1228,10 @@ func TestIntegrationTxCommit(t *testing.T) {
 }
 
 func TestIntegrationTxRollback(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	if c := integrationConnection(t, "txrollback"); c != nil {
 		defer c.Close()
 
@@ -1202,7 +1246,7 @@ func TestIntegrationTxRollback(t *testing.T) {
 			t.Fatalf("tx.select failed")
 		}
 
-		if err := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
+		if err := ch.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("ok")}); err != nil {
 			t.Fatalf("Failed to publish: %s", err)
 		}
 
@@ -1223,6 +1267,10 @@ func TestIntegrationTxRollback(t *testing.T) {
 }
 
 func TestIntegrationReturn(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	if c, ch := integrationQueue(t, "return"); c != nil {
 		defer c.Close()
 
@@ -1231,7 +1279,7 @@ func TestIntegrationReturn(t *testing.T) {
 		ch.NotifyReturn(ret)
 
 		// mandatory publish to an exchange without a binding should be returned
-		if err := ch.Publish(context.TODO(), "", "return-without-binding", true, false, Publishing{Body: []byte("mandatory")}); err != nil {
+		if err := ch.Publish(ctx, "", "return-without-binding", true, false, Publishing{Body: []byte("mandatory")}); err != nil {
 			t.Fatalf("Failed to publish: %s", err)
 		}
 
@@ -1296,7 +1344,7 @@ func TestIntegrationConfirm(t *testing.T) {
 			t.Fatalf("could not confirm")
 		}
 
-		if err := ch.Publish(context.TODO(), "", "confirm", false, false, Publishing{Body: []byte("confirm")}); err != nil {
+		if err := ch.Publish(ctx, "", "confirm", false, false, Publishing{Body: []byte("confirm")}); err != nil {
 			t.Fatalf("Failed to publish: %s", err)
 		}
 
@@ -1313,6 +1361,10 @@ func TestIntegrationConfirm(t *testing.T) {
 
 // https://github.com/streadway/amqp/issues/61
 func TestRoundTripAllFieldValueTypes61(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	if conn := integrationConnection(t, "issue61"); conn != nil {
 		defer conn.Close()
 		timestamp := time.Unix(100000000, 0)
@@ -1363,7 +1415,7 @@ func TestRoundTripAllFieldValueTypes61(t *testing.T) {
 			t.Fatalf("Could not consume")
 		}
 
-		err = ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("ignored"), Headers: headers})
+		err = ch.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("ignored"), Headers: headers})
 		if err != nil {
 			t.Fatalf("Could not publish: %v", err)
 		}
@@ -1496,6 +1548,10 @@ func TestDeclareArgsRejectToDeadLetterQueue(t *testing.T) {
 
 // https://github.com/streadway/amqp/issues/48
 func TestDeadlockConsumerIssue48(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	if conn := integrationConnection(t, "issue48"); conn != nil {
 		defer conn.Close()
 
@@ -1528,7 +1584,7 @@ func TestDeadlockConsumerIssue48(t *testing.T) {
 
 		for i := 0; i < cap(confirms); i++ {
 			// Fill the queue with some new or remaining publishings
-			if err := ch.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("")}); err != nil {
+			if err := ch.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("")}); err != nil {
 				t.Fatalf("error publishing: %v", err)
 			}
 		}
@@ -1561,6 +1617,10 @@ func TestDeadlockConsumerIssue48(t *testing.T) {
 
 // https://github.com/streadway/amqp/issues/46
 func TestRepeatedChannelExceptionWithPublishAndMaxProcsIssue46(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	conn := integrationConnection(t, "issue46")
 	if conn == nil {
 		t.Fatal("conn is nil")
@@ -1587,7 +1647,7 @@ func TestRepeatedChannelExceptionWithPublishAndMaxProcsIssue46(t *testing.T) {
 				}
 				break
 			}
-			err := ch.Publish(context.TODO(), "not-existing-exchange", "some-key", false, false, Publishing{Body: []byte("some-data")})
+			err := ch.Publish(ctx, "not-existing-exchange", "some-key", false, false, Publishing{Body: []byte("some-data")})
 			if err != nil {
 				if publishError, ok := err.(*Error); !ok || publishError.Code != 504 {
 					t.Fatalf("expected channel only exception i: %d j: %d error: %+v", i, j, publishError)
@@ -1599,6 +1659,10 @@ func TestRepeatedChannelExceptionWithPublishAndMaxProcsIssue46(t *testing.T) {
 
 // https://github.com/streadway/amqp/issues/43
 func TestChannelExceptionWithCloseIssue43(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	conn := integrationConnection(t, "issue43")
 	if conn != nil {
 		t.Cleanup(func() { conn.Close() })
@@ -1634,7 +1698,7 @@ func TestChannelExceptionWithCloseIssue43(t *testing.T) {
 		// Cause an asynchronous channel exception causing the server
 		// to send a "channel.close" method either before or after the next
 		// asynchronous method.
-		err = c1.Publish(context.TODO(), "nonexisting-exchange", "", false, false, Publishing{})
+		err = c1.Publish(ctx, "nonexisting-exchange", "", false, false, Publishing{})
 		if err != nil {
 			t.Fatalf("failed to publish, got: %v", err)
 		}
@@ -1654,6 +1718,10 @@ func TestChannelExceptionWithCloseIssue43(t *testing.T) {
 
 // https://github.com/streadway/amqp/issues/7
 func TestCorruptedMessageIssue7(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	messageCount := 1024
 
 	c1 := integrationConnection(t, "")
@@ -1689,7 +1757,7 @@ func TestCorruptedMessageIssue7(t *testing.T) {
 		}
 
 		for i := 0; i < messageCount; i++ {
-			err := pub.Publish(context.TODO(), "", queue, false, false, Publishing{
+			err := pub.Publish(ctx, "", queue, false, false, Publishing{
 				Body: generateCrc32Random(t, 7*i),
 			})
 
@@ -1799,6 +1867,10 @@ func TestExchangeDeclarePrecondition(t *testing.T) {
 }
 
 func TestRabbitMQQueueTTLGet(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	if c := integrationRabbitMQ(t, "ttl"); c != nil {
 		defer c.Close()
 
@@ -1819,7 +1891,7 @@ func TestRabbitMQQueueTTLGet(t *testing.T) {
 			t.Fatalf("queue declare: %s", err)
 		}
 
-		if err := channel.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("ttl")}); err != nil {
+		if err := channel.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("ttl")}); err != nil {
 			t.Fatalf("error publishing: %v", err)
 		}
 
@@ -1838,6 +1910,10 @@ func TestRabbitMQQueueTTLGet(t *testing.T) {
 }
 
 func TestRabbitMQQueueNackMultipleRequeue(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	if c := integrationRabbitMQ(t, "nack"); c != nil {
 		defer c.Close()
 
@@ -1852,10 +1928,10 @@ func TestRabbitMQQueueNackMultipleRequeue(t *testing.T) {
 				t.Fatalf("queue declare: %s", err)
 			}
 
-			if err := channel.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("1")}); err != nil {
+			if err := channel.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("1")}); err != nil {
 				t.Fatalf("error publishing: %v", err)
 			}
-			if err := channel.Publish(context.TODO(), "", queue, false, false, Publishing{Body: []byte("2")}); err != nil {
+			if err := channel.Publish(ctx, "", queue, false, false, Publishing{Body: []byte("2")}); err != nil {
 				t.Fatalf("error publishing: %v", err)
 			}
 
@@ -1953,6 +2029,10 @@ func TestConcurrentChannelAndConnectionClose(t *testing.T) {
 }
 
 func TestIntegrationGetNextPublishSeqNo(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	if c := integrationConnection(t, "GetNextPublishSeqNo"); c != nil {
 		defer c.Close()
 
@@ -1975,7 +2055,7 @@ func TestIntegrationGetNextPublishSeqNo(t *testing.T) {
 			t.Fatalf("wrong next publish seqence number before any publish, expected: %d, got: %d", 1, n)
 		}
 
-		if err := ch.Publish(context.TODO(), "test-get-next-pub-seq", "", false, false, Publishing{}); err != nil {
+		if err := ch.Publish(ctx, "test-get-next-pub-seq", "", false, false, Publishing{}); err != nil {
 			t.Fatalf("publish error: %v", err)
 		}
 
@@ -1988,6 +2068,10 @@ func TestIntegrationGetNextPublishSeqNo(t *testing.T) {
 
 // https://github.com/rabbitmq/amqp091-go/pull/44
 func TestShouldNotWaitAfterConnectionClosedIssue44(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	conn := integrationConnection(t, "TestShouldNotWaitAfterConnectionClosedIssue44")
 	ch, err := conn.Channel()
 	if err != nil {
@@ -2002,7 +2086,7 @@ func TestShouldNotWaitAfterConnectionClosedIssue44(t *testing.T) {
 		<-closed
 	}()
 
-	confirm, err := ch.PublishWithDeferredConfirm(context.TODO(), "test-issue44", "issue44", false, false, Publishing{Body: []byte("abc")})
+	confirm, err := ch.PublishWithDeferredConfirm(ctx, "test-issue44", "issue44", false, false, Publishing{Body: []byte("abc")})
 	if err != nil {
 		t.Fatalf("PublishWithDeferredConfirm error: %v", err)
 	}
@@ -2085,6 +2169,10 @@ func assertConsumeBody(t *testing.T, messages <-chan Delivery, want []byte) (msg
 
 // https://github.com/rabbitmq/amqp091-go/issues/11
 func TestShouldNotWaitAfterConnectionClosedNewChannelCreatedIssue11(t *testing.T) {
+	deadLine, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadLine)
+	defer cancel()
+
 	conn := integrationConnection(t, "TestShouldNotWaitAfterConnectionClosedNewChannelCreatedIssue11")
 	ch, err := conn.Channel()
 	if err != nil {
@@ -2093,7 +2181,7 @@ func TestShouldNotWaitAfterConnectionClosedNewChannelCreatedIssue11(t *testing.T
 
 	conn.NotifyClose(make(chan *Error, 1))
 
-	_, err = ch.PublishWithDeferredConfirm(context.TODO(), "issue11", "issue11", false, false, Publishing{Body: []byte("abc")})
+	_, err = ch.PublishWithDeferredConfirm(ctx, "issue11", "issue11", false, false, Publishing{Body: []byte("abc")})
 	if err != nil {
 		t.Fatalf("PublishWithDeferredConfirm error: %v", err)
 	}

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -6,6 +6,7 @@
 package amqp091_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -81,7 +82,7 @@ func ExampleConnection_reconnect() {
 
 			// Simulate a producer on a different connection showing that consumers
 			// continue where they were left off after each reconnect.
-			if err := pub.Publish("", queue, false, false, amqp.Publishing{
+			if err := pub.Publish(context.TODO(), "", queue, false, false, amqp.Publishing{
 				Body: []byte(fmt.Sprintf("%d", i)),
 			}); err != nil {
 				fmt.Println("err publish:", err)

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -50,6 +51,9 @@ func consume(url, queue string) (*amqp.Connection, <-chan amqp.Delivery, error) 
 }
 
 func ExampleConnection_reconnect() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	if url := os.Getenv("AMQP_URL"); url != "" {
 		queue := "example.reconnect"
 
@@ -82,7 +86,7 @@ func ExampleConnection_reconnect() {
 
 			// Simulate a producer on a different connection showing that consumers
 			// continue where they were left off after each reconnect.
-			if err := pub.Publish(context.TODO(), "", queue, false, false, amqp.Publishing{
+			if err := pub.Publish(ctx, "", queue, false, false, amqp.Publishing{
 				Body: []byte(fmt.Sprintf("%d", i)),
 			}); err != nil {
 				fmt.Println("err publish:", err)

--- a/types.go
+++ b/types.go
@@ -6,6 +6,7 @@
 package amqp091
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -184,6 +185,7 @@ type Blocking struct {
 // allows users to directly correlate a publishing to a confirmation. These are
 // returned from PublishWithDeferredConfirm on Channels.
 type DeferredConfirmation struct {
+	ctx          context.Context
 	wg           sync.WaitGroup
 	DeliveryTag  uint64
 	confirmation Confirmation

--- a/types.go
+++ b/types.go
@@ -6,7 +6,6 @@
 package amqp091
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -185,7 +184,6 @@ type Blocking struct {
 // allows users to directly correlate a publishing to a confirmation. These are
 // returned from PublishWithDeferredConfirm on Channels.
 type DeferredConfirmation struct {
-	ctx          context.Context
 	wg           sync.WaitGroup
 	DeliveryTag  uint64
 	confirmation Confirmation


### PR DESCRIPTION
Implement #92

This currently require context to be always cancelled (like net/http query) to not have stuck goroutine.

I am considering switching from waitgroup to the context of query for the sync pattern of DeferredConfirmation. This could lead to no leaking goroutine.