### PR TITLE
Add build TLS config from URI

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -32,12 +32,16 @@ var defaultURI = URI{
 
 // URI represents a parsed AMQP URI string.
 type URI struct {
-	Scheme   string
-	Host     string
-	Port     int
-	Username string
-	Password string
-	Vhost    string
+	Scheme     string
+	Host       string
+	Port       int
+	Username   string
+	Password   string
+	Vhost      string
+	CertFile   string // client TLS auth - path to certificate (PEM)
+	CACertFile string // client TLS auth - path to CA certificate (PEM)
+	KeyFile    string // client TLS auth - path to private key (PEM)
+	ServerName string // client TLS auth - server name
 }
 
 // ParseURI attempts to parse the given AMQP URI according to the spec.
@@ -52,6 +56,17 @@ type URI struct {
 //   Password: guest
 //   Vhost: /
 //
+// Supports TLS query parameters. See https://www.rabbitmq.com/uri-query-parameters.html
+//
+//   certfile: <path/to/client_cert.pem>
+//   keyfile: <path/to/client_key.pem>
+//   cacertfile: <path/to/ca.pem>
+//   server_name_indication: <server name>
+//
+// If cacertfile is not provided, system CA certificates will be used.
+// Mutual TLS (client auth) will be enabled only in case keyfile AND certfile provided.
+//
+// If Config.TLSClientConfig is set, TLS parameters from URI will be ignored.
 func ParseURI(uri string) (URI, error) {
 	builder := defaultURI
 
@@ -112,6 +127,13 @@ func ParseURI(uri string) (URI, error) {
 			builder.Vhost = u.Path
 		}
 	}
+
+	// see https://www.rabbitmq.com/uri-query-parameters.html
+	params := u.Query()
+	builder.CertFile = params.Get("certfile")
+	builder.KeyFile = params.Get("keyfile")
+	builder.CACertFile = params.Get("cacertfile")
+	builder.ServerName = params.Get("server_name_indication")
 
 	return builder, nil
 }

--- a/uri_test.go
+++ b/uri_test.go
@@ -370,18 +370,18 @@ func TestURIDefaultPortAmqps(t *testing.T) {
 }
 
 func TestURITLSConfig(t *testing.T) {
-	url := "amqps://foo.bar/?certfile=/foo/bar/cert.pem&keyfile=/foo/bar/key.pem&cacertfile=/foo/bar/ca.pem&server_name_indication=example.com"
+	url := "amqps://foo.bar/?certfile=/foo/%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82/cert.pem&keyfile=/foo/%E4%BD%A0%E5%A5%BD/key.pem&cacertfile=C:%5Ccerts%5Cca.pem&server_name_indication=example.com"
 	uri, err := ParseURI(url)
 	if err != nil {
 		t.Fatal("Could not parse")
 	}
-	if uri.CertFile != "/foo/bar/cert.pem" {
+	if uri.CertFile != "/foo/привет/cert.pem" {
 		t.Fatal("Certfile not set")
 	}
-	if uri.CACertFile != "/foo/bar/ca.pem" {
+	if uri.CACertFile != "C:\\certs\\ca.pem" {
 		t.Fatal("CA not set")
 	}
-	if uri.KeyFile != "/foo/bar/key.pem" {
+	if uri.KeyFile != "/foo/你好/key.pem" {
 		t.Fatal("Key not set")
 	}
 	if uri.ServerName != "example.com" {

--- a/uri_test.go
+++ b/uri_test.go
@@ -368,3 +368,23 @@ func TestURIDefaultPortAmqps(t *testing.T) {
 		t.Fatal("Default port not correct for amqps, got:", uri.Port)
 	}
 }
+
+func TestURITLSConfig(t *testing.T) {
+	url := "amqps://foo.bar/?certfile=cert.pem&keyfile=key.pem&cacertfile=ca.pem&server_name_indication=example.com"
+	uri, err := ParseURI(url)
+	if err != nil {
+		t.Fatal("Could not parse")
+	}
+	if uri.CertFile != "cert.pem" {
+		t.Fatal("Certfile not set")
+	}
+	if uri.CACertFile != "ca.pem" {
+		t.Fatal("CA not set")
+	}
+	if uri.KeyFile != "key.pem" {
+		t.Fatal("Key not set")
+	}
+	if uri.ServerName != "example.com" {
+		t.Fatal("Server name not set")
+	}
+}

--- a/uri_test.go
+++ b/uri_test.go
@@ -370,18 +370,18 @@ func TestURIDefaultPortAmqps(t *testing.T) {
 }
 
 func TestURITLSConfig(t *testing.T) {
-	url := "amqps://foo.bar/?certfile=cert.pem&keyfile=key.pem&cacertfile=ca.pem&server_name_indication=example.com"
+	url := "amqps://foo.bar/?certfile=/foo/bar/cert.pem&keyfile=/foo/bar/key.pem&cacertfile=/foo/bar/ca.pem&server_name_indication=example.com"
 	uri, err := ParseURI(url)
 	if err != nil {
 		t.Fatal("Could not parse")
 	}
-	if uri.CertFile != "cert.pem" {
+	if uri.CertFile != "/foo/bar/cert.pem" {
 		t.Fatal("Certfile not set")
 	}
-	if uri.CACertFile != "ca.pem" {
+	if uri.CACertFile != "/foo/bar/ca.pem" {
 		t.Fatal("CA not set")
 	}
-	if uri.KeyFile != "key.pem" {
+	if uri.KeyFile != "/foo/bar/key.pem" {
 		t.Fatal("Key not set")
 	}
 	if uri.ServerName != "example.com" {


### PR DESCRIPTION
Add support for `cacertfile`, `certfile`, `keyfile`, `server_name_indication` from https://www.rabbitmq.com/uri-query-parameters.html

* If `cacertfile` is not provided, system CA certificates will be used.
* Mutual TLS (client auth) will be enabled only in case `keyfile` AND `certfile` provided.
* If `Config.TLSClientConfig` is set, TLS parameters from URI will be ignored.