### PR TITLE
fix race condition with context close and confirm at the same time on DeferredConfirmation.

### DIFF
--- a/types.go
+++ b/types.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 )
 
@@ -184,6 +185,7 @@ type Blocking struct {
 // allows users to directly correlate a publishing to a confirmation. These are
 // returned from PublishWithDeferredConfirm on Channels.
 type DeferredConfirmation struct {
+	m            sync.Mutex
 	ctx          context.Context
 	cancel       context.CancelFunc
 	DeliveryTag  uint64


### PR DESCRIPTION
When doing more testing, I found one race condition is now possible with the PR #96.

This add test to detect the race condition and add basic solution to prevent to happen.

Sorry for this little possible bug.

One better way would be to use atomic with a uint32 as a bool but that imply potentially a lot of code change