### PR TITLE
Update AMQP Spec

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1634,6 +1634,11 @@ If the deliveries cannot be recovered, an error will be returned and the channel
 will be closed.
 
 Note: this method is not implemented on RabbitMQ, use Delivery.Nack instead
+
+Deprecated: This method is deprecated in RabbitMQ. RabbitMQ used Recover(true)
+as a mechanism for consumers to tell the broker that they were ready for more
+deliveries, back in 2008-2009. Support for this will be removed from RabbitMQ in
+a future release. Use Nack() with requeue=true instead.
 */
 func (ch *Channel) Recover(requeue bool) error {
 	return ch.call(

--- a/spec/amqp0-9-1.stripped.extended.xml
+++ b/spec/amqp0-9-1.stripped.extended.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <!--
      WARNING: Modified from the official 0-9-1 specification XML by
@@ -50,13 +50,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <constant name="frame-end" value="206"/>
   <constant name="reply-success" value="200"/>
   <constant name="content-too-large" value="311" class="soft-error"/>
-  <constant name="no-route" value="312" class = "soft-error">
-    <doc>
-      Errata: Section 1.2 ought to define an exception 312 "No route", which used to
-      exist in 0-9 and is what RabbitMQ sends back with 'basic.return' when a
-      'mandatory' message cannot be delivered to any queue.
-    </doc>
-  </constant>
+  <constant name="no-route" value="312" class="soft-error"/>
   <constant name="no-consumers" value="313" class="soft-error"/>
   <constant name="connection-forced" value="320" class="hard-error"/>
   <constant name="invalid-path" value="402" class="hard-error"/>
@@ -191,11 +185,22 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <chassis name="server" implement="MUST"/>
     </method>
     <method name="blocked" index="60">
-      <chassis name="server" implement="MAY"/>
-      <field name="reason" type="shortstr"/>
+      <chassis name="server" implement="MUST"/>
+      <chassis name="client" implement="MUST"/>
+      <field name="reason" domain="shortstr"/>
     </method>
     <method name="unblocked" index="61">
-      <chassis name="server" implement="MAY"/>
+      <chassis name="server" implement="MUST"/>
+      <chassis name="client" implement="MUST"/>
+    </method>
+    <method name="update-secret" synchronous="1" index="70">
+      <chassis name="client" implement="MUST"/>
+      <response name="update-secret-ok"/>
+      <field name="new-secret" domain="longstr"/>
+      <field name="reason" domain="shortstr"/>
+    </method>
+    <method name="update-secret-ok" synchronous="1" index="71">
+      <chassis name="server" implement="MUST"/>
     </method>
   </class>
   <class name="channel" handler="channel" index="20">

--- a/spec/gen.go
+++ b/spec/gen.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/spec091.go
+++ b/spec091.go
@@ -552,6 +552,66 @@ func (msg *connectionUnblocked) read(r io.Reader) (err error) {
 	return
 }
 
+type connectionUpdateSecret struct {
+	NewSecret string
+	Reason    string
+}
+
+func (msg *connectionUpdateSecret) id() (uint16, uint16) {
+	return 10, 70
+}
+
+func (msg *connectionUpdateSecret) wait() bool {
+	return true
+}
+
+func (msg *connectionUpdateSecret) write(w io.Writer) (err error) {
+
+	if err = writeLongstr(w, msg.NewSecret); err != nil {
+		return
+	}
+
+	if err = writeShortstr(w, msg.Reason); err != nil {
+		return
+	}
+
+	return
+}
+
+func (msg *connectionUpdateSecret) read(r io.Reader) (err error) {
+
+	if msg.NewSecret, err = readLongstr(r); err != nil {
+		return
+	}
+
+	if msg.Reason, err = readShortstr(r); err != nil {
+		return
+	}
+
+	return
+}
+
+type connectionUpdateSecretOk struct {
+}
+
+func (msg *connectionUpdateSecretOk) id() (uint16, uint16) {
+	return 10, 71
+}
+
+func (msg *connectionUpdateSecretOk) wait() bool {
+	return true
+}
+
+func (msg *connectionUpdateSecretOk) write(w io.Writer) (err error) {
+
+	return
+}
+
+func (msg *connectionUpdateSecretOk) read(r io.Reader) (err error) {
+
+	return
+}
+
 type channelOpen struct {
 	reserved1 string
 }
@@ -1174,7 +1234,7 @@ func (msg *queueDeclare) id() (uint16, uint16) {
 }
 
 func (msg *queueDeclare) wait() bool {
-	return !msg.NoWait
+	return true && !msg.NoWait
 }
 
 func (msg *queueDeclare) write(w io.Writer) (err error) {
@@ -2847,6 +2907,22 @@ func (r *reader) parseMethodFrame(channel uint16, size uint32) (f frame, err err
 		case 61: // connection unblocked
 			//fmt.Println("NextMethod: class:10 method:61")
 			method := &connectionUnblocked{}
+			if err = method.read(r.r); err != nil {
+				return
+			}
+			mf.Method = method
+
+		case 70: // connection update-secret
+			//fmt.Println("NextMethod: class:10 method:70")
+			method := &connectionUpdateSecret{}
+			if err = method.read(r.r); err != nil {
+				return
+			}
+			mf.Method = method
+
+		case 71: // connection update-secret-ok
+			//fmt.Println("NextMethod: class:10 method:71")
+			method := &connectionUpdateSecretOk{}
 			if err = method.read(r.r); err != nil {
 				return
 			}


### PR DESCRIPTION
Adding missing constant 302 for no-route error.

The spec says that `basic.recover` should be async, but this breaks our
test `TestIntegrationRecoverNotImplemented()`. RabbitMQ has deprecated
this method and it will be removed in a future release. This commit also
adds a deprecation notice to `channel.Recover()`.

