### PR TITLE
Remove warning on RabbitMQ tutorials in go

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ please file an issue.
 ## Documentation
 
  * [Godoc API reference](http://godoc.org/github.com/rabbitmq/amqp091-go)
- * [RabbitMQ tutorials in Go](https://github.com/rabbitmq/rabbitmq-tutorials/tree/master/go) currently use a different client.
-    They will be switched to use this client eventually
+ * [RabbitMQ tutorials in Go](https://github.com/rabbitmq/rabbitmq-tutorials/tree/master/go)
 
 ## Contributing
 


### PR DESCRIPTION
The go tutorial has been updated to use rabbitmq/amqp091-go
https://github.com/rabbitmq/rabbitmq-tutorials/commit/52ca462906a6cd10e387e39074cee468f6bd2b47