### PR TITLE
Add support for connection.update-secret

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -266,6 +266,12 @@ func Open(conn io.ReadWriteCloser, config Config) (*Connection, error) {
 	return c, c.open(config)
 }
 
+/*
+UpdateSecret updates the secret used to authenticate this connection. It is used when
+secrets have an expiration date and need to be renewed, like OAuth 2 tokens.
+
+It returns an error if the operation is not successful, or if the connection is closed.
+*/
 func (c *Connection) UpdateSecret(newSecret, reason string) error {
 	if c.IsClosed() {
 		return ErrClosed

--- a/connection.go
+++ b/connection.go
@@ -266,6 +266,16 @@ func Open(conn io.ReadWriteCloser, config Config) (*Connection, error) {
 	return c, c.open(config)
 }
 
+func (c *Connection) UpdateSecret(newSecret, reason string) error {
+	if c.IsClosed() {
+		return ErrClosed
+	}
+	return c.call(&connectionUpdateSecret{
+		NewSecret: newSecret,
+		Reason:    reason,
+	}, &connectionUpdateSecretOk{})
+}
+
 /*
 LocalAddr returns the local TCP peer address, or ":0" (the zero value of net.TCPAddr)
 as a fallback default value if the underlying transport does not support LocalAddr().


### PR DESCRIPTION
This method is in the AMQP 0.9.1 spec and it is supported by RabbitMQ.
This is useful when the secret used in the connection has an expiry, as
it allows the applications to renew the secret without the hassle of
closing-reconnecting consumers/producers.

