### PR TITLE
Fix example client to avoid deadlock in Close

### DIFF
--- a/example_client_test.go
+++ b/example_client_test.go
@@ -290,12 +290,10 @@ func (client *Client) Push(data []byte) error {
 			}
 			continue
 		}
-		select {
-		case confirm := <-client.notifyConfirm:
-			if confirm.Ack {
-				client.logger.Printf("Push confirmed [%d]!", confirm.DeliveryTag)
-				return nil
-			}
+		confirm := <-client.notifyConfirm
+		if confirm.Ack {
+			client.logger.Printf("Push confirmed [%d]!", confirm.DeliveryTag)
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
The example was "giving up" on publish confirmation after the
resendDelay. This is not correct because the library will keep track of
this confirmation, and it will try to deliver the confirmation. By
giving up, we are may leave confirmations un-received in the
confirmation channel, which will cause a deadlock during the shut down
sequence in Channel.Close.

We should not give up on the confirmation and simply wait.

Fixes #122

