### PR TITLE
Add constant for default exchange

### DIFF
--- a/types.go
+++ b/types.go
@@ -13,6 +13,8 @@ import (
 	"time"
 )
 
+const DefaultExchange = ""
+
 // Constants for standard AMQP 0-9-1 exchange types.
 const (
 	ExchangeDirect  = "direct"


### PR DESCRIPTION
Defining a constant for the default exchange is clearer than using an empty string `""`.