### PR TITLE
Do not embed context in DeferredConfirmation

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -642,7 +642,6 @@ func (ch *Channel) NotifyPublish(confirm chan Confirmation) chan Confirmation {
 	}
 
 	return confirm
-
 }
 
 /*
@@ -1458,7 +1457,7 @@ func (ch *Channel) PublishWithDeferredConfirmWithContext(ctx context.Context, ex
 	}
 
 	if ch.confirming {
-		return ch.confirms.Publish(ctx), nil
+		return ch.confirms.Publish(), nil
 	}
 
 	return nil, nil

--- a/confirms.go
+++ b/confirms.go
@@ -173,11 +173,6 @@ func (d *deferredConfirmations) Close() {
 	}
 }
 
-// Confirm does nothing. It exists for backwards compatibility.
-//
-// Deprecated: do not use.
-func (d *DeferredConfirmation) Confirm(_ bool) {}
-
 // setAck sets the acknowledgement status of the confirmation. Note that it is
 // not safe for concurrent use and must not be called more than once.
 func (d *DeferredConfirmation) setAck(ack bool) {

--- a/types.go
+++ b/types.go
@@ -6,10 +6,8 @@
 package amqp091
 
 import (
-	"context"
 	"fmt"
 	"io"
-	"sync"
 	"time"
 )
 
@@ -187,11 +185,10 @@ type Blocking struct {
 // allows users to directly correlate a publishing to a confirmation. These are
 // returned from PublishWithDeferredConfirm on Channels.
 type DeferredConfirmation struct {
-	m            sync.Mutex
-	ctx          context.Context
-	cancel       context.CancelFunc
-	DeliveryTag  uint64
-	confirmation Confirmation
+	DeliveryTag uint64
+
+	done chan struct{}
+	ack  int32 // atomic bool
 }
 
 // Confirmation notifies the acknowledgment or negative acknowledgement of a

--- a/types.go
+++ b/types.go
@@ -188,7 +188,7 @@ type DeferredConfirmation struct {
 	DeliveryTag uint64
 
 	done chan struct{}
-	ack  int32 // atomic bool
+	ack  bool
 }
 
 // Confirmation notifies the acknowledgment or negative acknowledgement of a


### PR DESCRIPTION
This change removes embedded `context.Context` (which is generally an anti-pattern) from `DeferredConfirmation`. Instead, we use a simple channel to wait for ack/nack status. This approach is more flexible since it can be combined with timers, tickers, other contexts and channels in general using `select{}` statements and there is no overhead from context cancellation setup.

Note that #96 introduced a behavior where `Wait` would unblock and return false once the context passed to `Publish` expires. This commit reverts this (arguably breaking) behavior in favor of `WaitContext` function.
