### PR TITLE
Fix inefficient use of buffers that reduces the potential throughput of basicPublish

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -447,14 +447,20 @@ func (c *Connection) send(f frame) error {
 	return err
 }
 
-// The send() method uses writer.WriteFrame(), which will write the Frame then
+// sendUnflushed performs an *Unflushed* write. It is otherwise equivalent to
+// send(), and we provide a separate flush() function to explicitly flush the
+// buffer after all Frames are written.
+//
+// Why is this a thing?
+//
+// send() method uses writer.WriteFrame(), which will write the Frame then
 // flush the buffer. For cases like the sendOpen() method on Channel, which
 // sends multiple Frames (methodFrame, headerFrame, N x bodyFrame), flushing
 // after each Frame is inefficient as it negates much of the benefit of using a
-// buffered writer and results in more syscalls than necessary. Flushing buffers
+// buffered writer, and results in more syscalls than necessary. Flushing buffers
 // after every frame can have a significant performance impact when sending
 // (basicPublish) small messages, so this method performs an *Unflushed* write
-// but is otherwise equivalent to the send() method and we provide a separate
+// but is otherwise equivalent to send() method, and we provide a separate
 // flush method to explicitly flush the buffer after all Frames are written.
 func (c *Connection) sendUnflushed(f frame) error {
 	if c.IsClosed() {
@@ -471,15 +477,7 @@ func (c *Connection) sendUnflushed(f frame) error {
 			Code:   FrameError,
 			Reason: err.Error(),
 		})
-	} /*else { // Moving to flush increases basicPublish throughput even more
-		// Broadcast we sent a frame, reducing heartbeats, only
-		// if there is something that can receive - like a non-reentrant
-		// call or if the heartbeater isn't running
-		select {
-		case c.sends <- time.Now():
-		default:
-		}
-	}*/
+	}
 
 	return err
 }
@@ -490,12 +488,11 @@ func (c *Connection) flush() (err error) {
 	if buf, ok := c.writer.w.(*bufio.Writer); ok {
 		err = buf.Flush()
 
-		// Moving send notifier to flush increases basicPublish throughput even
-		// more for the small message case. As sendUnflushed + flush is used
-		// for the case of sending semantically related Frames (e.g. a Message
-		// like basicPublish) there is no real advantage to sending per Frame
-		// vice per "group of related Frames" and for the case of small messages
-		// time.Now() is (relatively) expensive.
+		// Moving send notifier to flush increases basicPublish for the small message
+		// case. As sendUnflushed + flush is used for the case of sending semantically
+		// related Frames (e.g. a Message like basicPublish) there is no real advantage
+		// to sending per Frame vice per "group of related Frames" and for the case of
+		// small messages time.Now() is (relatively) expensive.
 		if err == nil {
 			// Broadcast we sent a frame, reducing heartbeats, only
 			// if there is something that can receive - like a non-reentrant

--- a/connection.go
+++ b/connection.go
@@ -447,6 +447,69 @@ func (c *Connection) send(f frame) error {
 	return err
 }
 
+// The send() method uses writer.WriteFrame(), which will write the Frame then
+// flush the buffer. For cases like the sendOpen() method on Channel, which
+// sends multiple Frames (methodFrame, headerFrame, N x bodyFrame), flushing
+// after each Frame is inefficient as it negates much of the benefit of using a
+// buffered writer and results in more syscalls than necessary. Flushing buffers
+// after every frame can have a significant performance impact when sending
+// (basicPublish) small messages, so this method performs an *Unflushed* write
+// but is otherwise equivalent to the send() method and we provide a separate
+// flush method to explicitly flush the buffer after all Frames are written.
+func (c *Connection) sendUnflushed(f frame) error {
+	if c.IsClosed() {
+		return ErrClosed
+	}
+
+	c.sendM.Lock()
+	err := f.write(c.writer.w)
+	c.sendM.Unlock()
+
+	if err != nil {
+		// shutdown could be re-entrant from signaling notify chans
+		go c.shutdown(&Error{
+			Code:   FrameError,
+			Reason: err.Error(),
+		})
+	} /*else { // Moving to flush increases basicPublish throughput even more
+		// Broadcast we sent a frame, reducing heartbeats, only
+		// if there is something that can receive - like a non-reentrant
+		// call or if the heartbeater isn't running
+		select {
+		case c.sends <- time.Now():
+		default:
+		}
+	}*/
+
+	return err
+}
+
+// This method is intended to be used with sendUnflushed() to explicitly flush
+// the buffer after all required Frames have been written to the buffer.
+func (c *Connection) flush() (err error) {
+	if buf, ok := c.writer.w.(*bufio.Writer); ok {
+		err = buf.Flush()
+
+		// Moving send notifier to flush increases basicPublish throughput even
+		// more for the small message case. As sendUnflushed + flush is used
+		// for the case of sending semantically related Frames (e.g. a Message
+		// like basicPublish) there is no real advantage to sending per Frame
+		// vice per "group of related Frames" and for the case of small messages
+		// time.Now() is (relatively) expensive.
+		if err == nil {
+			// Broadcast we sent a frame, reducing heartbeats, only
+			// if there is something that can receive - like a non-reentrant
+			// call or if the heartbeater isn't running
+			select {
+			case c.sends <- time.Now():
+			default:
+			}
+		}
+	}
+
+	return
+}
+
 func (c *Connection) shutdown(err *Error) {
 	atomic.StoreInt32(&c.closed, 1)
 


### PR DESCRIPTION
As per issue https://github.com/rabbitmq/amqp091-go/issues/141

Improve the performance of Channel sendOpen method by adding an sendUnflushed method to Connection that allows us to use the write buffer more efficiently by writing all the Frames of the message and *then* flushing the buffer rather than flushing each Frame. This significantly improves the performance of basicPublish for small messages where the bulk of the CPU load tends towards Syscall so with small messages we might have a Syscall per message vice per Frame.