### PR TITLE
Check if channel is nil before updating it

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -601,13 +601,17 @@ func (c *Connection) dispatch0(f frame) {
 
 func (c *Connection) dispatchN(f frame) {
 	c.m.Lock()
-	channel := c.channels[f.channel()]
-	updateChannel(f, channel)
+	channel, ok := c.channels[f.channel()]
+	if ok {
+		updateChannel(f, channel)
+	} else {
+		Logger.Printf("[debug] dropping frame, channel %d does not exist", f.channel())
+	}
 	c.m.Unlock()
 
 	// Note: this could result in concurrent dispatch depending on
 	// how channels are managed in an application
-	if channel != nil {
+	if ok {
 		channel.recv(channel, f)
 	} else {
 		c.dispatchClosed(f)


### PR DESCRIPTION
In observed the following panic in the wild:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x54 pc=0x104cf3c]

goroutine 144 [running]:
github.com/rabbitmq/amqp091-go.(*Channel).setClosed(...)
	/home/runner/go/pkg/mod/github.com/rabbitmq/amqp091-go@v1.5.0/channel.go:94
github.com/rabbitmq/amqp091-go.updateChannel(...)
	/home/runner/go/pkg/mod/github.com/rabbitmq/amqp091-go@v1.5.0/types.go:329
github.com/rabbitmq/amqp091-go.(*Connection).dispatchN(0xc000b2ea00, {0x1d5c150, 0xc00096f1b8?})
	/home/runner/go/pkg/mod/github.com/rabbitmq/amqp091-go@v1.5.0/connection.go:539 +0xbc
github.com/rabbitmq/amqp091-go.(*Connection).demux(0xc00039cf28?, {0x1d5c150, 0xc00096f1b8})
	/home/runner/go/pkg/mod/github.com/rabbitmq/amqp091-go@v1.5.0/connection.go:500 +0x5b
github.com/rabbitmq/amqp091-go.(*Connection).reader(0xc000b2ea00, {0x1d57540?, 0xc0004620c8?})
	/home/runner/go/pkg/mod/github.com/rabbitmq/amqp091-go@v1.5.0/connection.go:600 +0x23d
created by github.com/rabbitmq/amqp091-go.Open
	/home/runner/go/pkg/mod/github.com/rabbitmq/amqp091-go@v1.5.0/connection.go:265 +0x34c
```

Trying to understand what happens, it turns out the nil pointer deference here https://github.com/rabbitmq/amqp091-go/blob/v1.5.0/channel.go#L94 actually seems the be caused by the map access here https://github.com/rabbitmq/amqp091-go/blob/v1.5.0/connection.go#L538, which returns `nil` if the key doesn't exist / the map is empty.
Thus, a check whether the channel is nil is missing.