### PR TITLE
Remove outdated information from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ This client uses the same 2-clause BSD license as the original project.
 
 This project is based on a mature Go client that's been around for over a decade.
 
-We expect this client to undergo moderate breaking public API changes in 2021.
-Major and minor versions will be updated accordingly.
-
 
 ## Supported Go Versions
 


### PR DESCRIPTION
Removes outdated information in README as requested and according to https://github.com/rabbitmq/amqp091-go/issues/154.