### PR TITLE
Fix linter warnings

### DIFF
--- a/change_version.sh
+++ b/change_version.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 echo $1 > VERSION
 sed -i -e "s/.*buildVersion             = \"*.*/buildVersion =              \"$1\"/" ./connection.go
 go fmt ./...

--- a/connection.go
+++ b/connection.go
@@ -413,7 +413,7 @@ func (c *Connection) closeWith(err *Error) error {
 // IsClosed returns true if the connection is marked as closed, otherwise false
 // is returned.
 func (c *Connection) IsClosed() bool {
-	return (atomic.LoadInt32(&c.closed) == 1)
+	return atomic.LoadInt32(&c.closed) == 1
 }
 
 func (c *Connection) send(f frame) error {

--- a/read.go
+++ b/read.go
@@ -168,7 +168,7 @@ func readField(r io.Reader) (v interface{}, err error) {
 		if err = binary.Read(r, binary.BigEndian, &value); err != nil {
 			return
 		}
-		return (value != 0), nil
+		return value != 0, nil
 
 	case 'B':
 		var value [1]byte


### PR DESCRIPTION
This PR fixes linter warnings, reported in the Goland IDE. The warnings in
question:

- Unreachable code
- Variable names using snake_case instead of CamelCase
- Unused parameters
- Redundant parenthesis
- Shell-bang was not set correctly

Any code after `t.Fatalf` is not executed, because this function stops
execution.

