### PR TITLE
Update Makefile targets related to RabbitMQ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,14 @@ tests: ## Run all tests and requires a running rabbitmq-server
 check:
 	golangci-lint run ./...
 
+CONTAINER_NAME ?= amqp091-go-rabbitmq
+
 .PHONY: rabbitmq-server
-rabbitmq-server:
-	docker run --detach --rm --name amqp091-go-rabbitmq \
+rabbitmq-server: ## Start a RabbitMQ server using Docker. Container name can be customised with CONTAINER_NAME=some-rabbit
+	docker run --detach --rm --name $(CONTAINER_NAME) \
 		--publish 5672:5672 --publish 15672:15672 \
 		--pull always rabbitmq:3-management
 
 .PHONY: stop-rabbitmq-server
-stop-rabbitmq-server:
-	docker stop $$(docker inspect --format='{{.Id}}' amqp091-go-rabbitmq)
+stop-rabbitmq-server: ## Stop a RabbitMQ server using Docker. Container name can be customised with CONTAINER_NAME=some-rabbit
+	docker stop $(CONTAINER_NAME)


### PR DESCRIPTION
## Summary

Simplified version of 'stop-rabbitmq-server'. There is no need to figure
out the container ID, because `docker stop` supports container names.

Container name can now be customised.

Edit: did not assign a milestone because this change is for developers of the library
