### PR TITLE
adding go 1.20 to tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go-version: ['1.18', '1.19', '1.20']
+        go-version: ['1.19', '1.20']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.18', '1.19', '1.20']
+        go-version: ['1.19', '1.20']
     services:
       rabbitmq:
         image: rabbitmq

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go-version: ['1.18', '1.19']
+        go-version: ['1.18', '1.19', '1.20']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.18', '1.19']
+        go-version: ['1.18', '1.19', '1.20']
     services:
       rabbitmq:
         image: rabbitmq


### PR DESCRIPTION
I added go version 1.20 to testing workflow.