### PR TITLE
Fix racing in Open

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ fmt: ## Run go fmt against code
 	go fmt ./...
 
 .PHONY: tests
-tests: ## Run all tests and requires a running rabbitmq-server
-	go test -cpu 1,2 -race -v -tags integration
+tests: ## Run all tests and requires a running rabbitmq-server. Use GO_TEST_FLAGS to add extra flags to go test
+	go test -race -v -tags integration $(GO_TEST_FLAGS)
 
 .PHONY: check
 check:

--- a/connection.go
+++ b/connection.go
@@ -974,7 +974,9 @@ func (c *Connection) openComplete() error {
 		_ = deadliner.SetDeadline(time.Time{})
 	}
 
+	c.m.Lock()
 	c.allocator = newAllocator(1, c.Config.ChannelMax)
+	c.m.Unlock()
 	return nil
 }
 

--- a/connection.go
+++ b/connection.go
@@ -912,6 +912,9 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 		return ErrCredentials
 	}
 
+	// Edge case that may race with c.shutdown()
+	// https://github.com/rabbitmq/amqp091-go/issues/170
+	c.m.Lock()
 	// When the server and client both use default 0, then the max channel is
 	// only limited by uint16.
 	c.Config.ChannelMax = pick(config.ChannelMax, int(tune.ChannelMax))
@@ -919,6 +922,7 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 		c.Config.ChannelMax = defaultChannelMax
 	}
 	c.Config.ChannelMax = min(c.Config.ChannelMax, maxChannelMax)
+	c.m.Unlock()
 
 	// Frame size includes headers and end byte (len(payload)+8), even if
 	// this is less than FrameMinSize, use what the server sends because the


### PR DESCRIPTION
### Summary

- Lock allocator assignment in openComplete
- Add a critical section in openTune

### Description

In #170, it was reported a data race in `Connection.Open`. The situation
described is an edge case, where the connection reader (responsible for reading
data sent from the server/wire) initiates the shutdown sequence in
`Connection.shutdown` before `Connection.Open` completes. This creates a data
race for `Connection.allocator` and `Connection.Config.ChannelMax` fields.

The shutdown function is already protected by the `Connection` struct mutex. The
access from `Open` stack calls is not protected. This PR adds two new, as small
as possible, critical sections protected by the struct mutex during `Open`.

It is quite challenging to add a reliable test for this edge case, even with a
server fake, since we have to inject a failure just before the frame reader
reads, but right after the Tune frame is sent. Original reporter validated the
fix.

Closes #170

