### PR TITLE
Add a CloseDeadline function to Connection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,4 +49,6 @@ jobs:
           go-version: ${{ matrix.go-version }}
           check-latest: true
       - name: Tests
+        env:
+          RABBITMQ_RABBITMQCTL_PATH: DOCKER:${{ job.services.rabbitmq.id }}
         run: make check-fmt tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,12 @@ Here is the recommended workflow:
 1. Run Static Checks
 1. Run integration tests (see below)
 1. **Implement tests**
-1. Implement fixs
-1. Commit your changes (`git commit -am 'Add some feature'`)
+1. Implement fixes
+1. Commit your changes. Use a [good, descriptive, commit message][good-commit].
 1. Push to a branch (`git push -u origin my-new-feature`)
 1. Submit a pull request
+
+[good-commit]: https://cbea.ms/git-commit/
 
 ## Running Static Checks
 
@@ -42,6 +44,18 @@ The integration tests can be run via:
 ```shell
 make tests
 ```
+
+Some tests require access to `rabbitmqctl` CLI. Use the environment variable
+`RABBITMQ_RABBITMQCTL_PATH=/some/path/to/rabbitmqctl` to run those tests. 
+
+If you have Docker available in your machine, you can run:
+
+```shell
+make tests-docker
+```
+
+This target will start a RabbitMQ container, run the test suite with the environment
+variable setup, and stop RabbitMQ container after a successful run.
 
 All integration tests should use the `integrationConnection(...)` test
 helpers defined in `integration_test.go` to setup the integration environment

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ fmt: ## Run go fmt against code
 tests: ## Run all tests and requires a running rabbitmq-server. Use GO_TEST_FLAGS to add extra flags to go test
 	go test -race -v -tags integration $(GO_TEST_FLAGS)
 
+.PHONY: tests-docker
+tests-docker: rabbitmq-server
+	RABBITMQ_RABBITMQCTL_PATH="DOCKER:$(CONTAINER_NAME)" go test -race -v -tags integration $(GO_TEST_FLAGS)
+	$(MAKE) stop-rabbitmq-server
+
 .PHONY: check
 check:
 	golangci-lint run ./...

--- a/connection.go
+++ b/connection.go
@@ -472,30 +472,6 @@ func (c *Connection) setDeadline(t time.Time) error {
 	return con.SetDeadline(t)
 }
 
-// setReadDeadline is a wrapper to type assert Connection.conn and set an I/O
-// deadline in the underlying TCP connection socket, by calling
-// net.Conn.SetReadDeadline(). It returns an error, in case the type assertion
-// fails, although this should never happen.
-func (c *Connection) setReadDeadline(t time.Time) error {
-	con, ok := c.conn.(net.Conn)
-	if !ok {
-		return errInvalidTypeAssertion
-	}
-	return con.SetReadDeadline(t)
-}
-
-// setWriteDeadline is a wrapper to type assert Connection.conn and set an I/O
-// deadline in the underlying TCP connection socket, by calling
-// net.Conn.WriteSetDeadline(). It returns an error, in case the type assertion
-// fails, although this should never happen.
-func (c *Connection) setWriteDeadline(t time.Time) error {
-	con, ok := c.conn.(net.Conn)
-	if !ok {
-		return errInvalidTypeAssertion
-	}
-	return con.SetWriteDeadline(t)
-}
-
 func (c *Connection) send(f frame) error {
 	if c.IsClosed() {
 		return ErrClosed

--- a/connection.go
+++ b/connection.go
@@ -399,6 +399,46 @@ func (c *Connection) Close() error {
 	)
 }
 
+// CloseDeadline requests and waits for the response to close this AMQP connection.
+//
+// Accepts a deadline for waiting the server response. The deadline is passed
+// to the low-level connection i.e. network socket.
+//
+// Regardless of the error returned, the connection is considered closed, and it
+// should not be used after calling this function.
+//
+// In the event of an I/O timeout, connection-closed listeners are NOT informed.
+//
+// After returning from this call, all resources associated with this connection,
+// including the underlying io, Channels, Notify listeners and Channel consumers
+// will also be closed.
+func (c *Connection) CloseDeadline(deadline time.Time) error {
+	if c.IsClosed() {
+		return ErrClosed
+	}
+
+	err := c.setDeadline(deadline)
+	if err != nil {
+		return err
+	}
+
+	err = c.call(
+		&connectionClose{
+			ReplyCode: replySuccess,
+			ReplyText: "kthxbai",
+		},
+		&connectionCloseOk{},
+	)
+
+	if err != nil {
+		c.shutdown(nil)
+		return err
+	}
+
+	c.shutdown(nil)
+	return nil
+}
+
 func (c *Connection) closeWith(err *Error) error {
 	if c.IsClosed() {
 		return ErrClosed
@@ -418,6 +458,42 @@ func (c *Connection) closeWith(err *Error) error {
 // is returned.
 func (c *Connection) IsClosed() bool {
 	return atomic.LoadInt32(&c.closed) == 1
+}
+
+// setDeadline is a wrapper to type assert Connection.conn and set an I/O
+// deadline in the underlying TCP connection socket, by calling
+// net.Conn.SetDeadline(). It returns an error, in case the type assertion fails,
+// although this should never happen.
+func (c *Connection) setDeadline(t time.Time) error {
+	con, ok := c.conn.(net.Conn)
+	if !ok {
+		return errInvalidTypeAssertion
+	}
+	return con.SetDeadline(t)
+}
+
+// setReadDeadline is a wrapper to type assert Connection.conn and set an I/O
+// deadline in the underlying TCP connection socket, by calling
+// net.Conn.SetReadDeadline(). It returns an error, in case the type assertion
+// fails, although this should never happen.
+func (c *Connection) setReadDeadline(t time.Time) error {
+	con, ok := c.conn.(net.Conn)
+	if !ok {
+		return errInvalidTypeAssertion
+	}
+	return con.SetReadDeadline(t)
+}
+
+// setWriteDeadline is a wrapper to type assert Connection.conn and set an I/O
+// deadline in the underlying TCP connection socket, by calling
+// net.Conn.WriteSetDeadline(). It returns an error, in case the type assertion
+// fails, although this should never happen.
+func (c *Connection) setWriteDeadline(t time.Time) error {
+	con, ok := c.conn.(net.Conn)
+	if !ok {
+		return errInvalidTypeAssertion
+	}
+	return con.SetWriteDeadline(t)
 }
 
 func (c *Connection) send(f frame) error {

--- a/connection.go
+++ b/connection.go
@@ -417,26 +417,20 @@ func (c *Connection) CloseDeadline(deadline time.Time) error {
 		return ErrClosed
 	}
 
+	defer c.shutdown(nil)
+
 	err := c.setDeadline(deadline)
 	if err != nil {
 		return err
 	}
 
-	err = c.call(
+	return c.call(
 		&connectionClose{
 			ReplyCode: replySuccess,
 			ReplyText: "kthxbai",
 		},
 		&connectionCloseOk{},
 	)
-
-	if err != nil {
-		c.shutdown(nil)
-		return err
-	}
-
-	c.shutdown(nil)
-	return nil
 }
 
 func (c *Connection) closeWith(err *Error) error {
@@ -445,6 +439,7 @@ func (c *Connection) closeWith(err *Error) error {
 	}
 
 	defer c.shutdown(err)
+
 	return c.call(
 		&connectionClose{
 			ReplyCode: uint16(err.Code),

--- a/integration_test.go
+++ b/integration_test.go
@@ -2008,13 +2008,6 @@ func TestShouldNotWaitAfterConnectionClosedIssue44(t *testing.T) {
  * Support for integration tests
  */
 
-func loggedConnection(t *testing.T, conn *Connection, name string) *Connection {
-	if name != "" {
-		conn.conn = &logIO{t, name, conn.conn}
-	}
-	return conn
-}
-
 // Returns a connection to the AMQP if the AMQP_URL environment
 // variable is set and a connection can be established.
 func integrationConnection(t *testing.T, name string) *Connection {

--- a/integration_test.go
+++ b/integration_test.go
@@ -2023,7 +2023,7 @@ func integrationConnection(t *testing.T, name string) *Connection {
 		t.Fatalf("cannot dial integration server. Is the rabbitmq-server service running? %s", err)
 		return nil
 	}
-	return loggedConnection(t, conn, name)
+	return conn
 }
 
 // Returns a connection, channel and declares a queue when the AMQP_URL is in the environment

--- a/types.go
+++ b/types.go
@@ -63,6 +63,11 @@ var (
 	ErrFieldType = &Error{Code: SyntaxError, Reason: "unsupported table field type"}
 )
 
+// internal errors used inside the library
+var (
+	errInvalidTypeAssertion = &Error{Code: InternalError, Reason: "type assertion unsuccessful", Server: false, Recover: true}
+)
+
 // Error captures the code and reason a channel or connection has been closed
 // by the server.
 type Error struct {


### PR DESCRIPTION

## Summary

- Add CloseDeadline function to Connection
- Remove unused function in integration tests
- Updated contribution guidelines

Fixes #178

## Background information

During a [memory alarm][rmq-memory-alarm], RabbitMQ will block publisher connections. This means that RabbitMQ will stop reading from the connection socket. In this case, any further attempts from the client using this connection will be blocked on I/O. For example, a connection close request, will block in I/O, and the client application will be blocked.

Other clients, like Java or C#, use a timeout when closing a connection, and return an exception if the connection is not closed within the timeout. Those clients also do connection recovery, but that's outside of the scope of this client (See README anti-goals).

This client now also provides a `Connection.CloseDeadline` function to specify an I/O timeout for the connection close request to complete.

[rmq-memory-alarm]: https://www.rabbitmq.com/memory.html

