### PR TITLE
Fix to increase timeout milliseconds since it's too tight

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -846,14 +846,14 @@ func TestIntegrationConsumeCancelWithContext(t *testing.T) {
 		assertConsumeBody(t, messages, []byte("1"))
 
 		cancel()
-		<-time.After(100 * time.Millisecond) // wait to call cancel asynchronously
+		<-time.After(200 * time.Millisecond) // wait to call cancel asynchronously
 
 		if e := ch.Publish("", queue, false, false, Publishing{Body: []byte("2")}); e != nil {
 			t.Fatalf("error publishing: %v", e)
 		}
 
 		select {
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(200 * time.Millisecond):
 			t.Fatalf("Timeout on Close")
 		case _, ok := <-messages:
 			if ok {


### PR DESCRIPTION
I found an integration test of #192 failed on windows-latest (1.20). I guess it's a timing issue?

```
=== RUN   TestIntegrationConsumeCancelWithContext
    integration_test.go:857: Timeout on Close
--- FAIL: TestIntegrationConsumeCancelWithContext (0.27s)
```

https://github.com/rabbitmq/amqp091-go/actions/runs/5322251884/jobs/9638444129