### PR TITLE
Documenting Publishing.Expiration usage

### DIFF
--- a/types.go
+++ b/types.go
@@ -144,6 +144,19 @@ const (
 	flagReserved1       = 0x0004
 )
 
+// Expiration. These constants should be used to set a messages expiration TTL.
+// They should be viewed as a clarification of the expiration functionality in
+// messages and their usage is not enforced by this pkg.
+//
+// The server requires a string value that is interpreted as milliseconds. If
+// no value is set, which translates to the nil value of string, the message
+// will never expire by itself. This does not influence queue configured TTL
+// configurations.
+const (
+	NeverExpire       string = ""  // empty value means never expire
+	ImmediatelyExpire string = "0" // 0 means immediately expire
+)
+
 // Queue captures the current server state of the queue on the server returned
 // from Channel.QueueDeclare or Channel.QueueInspect.
 type Queue struct {
@@ -162,18 +175,25 @@ type Publishing struct {
 	Headers Table
 
 	// Properties
-	ContentType     string    // MIME content type
-	ContentEncoding string    // MIME content encoding
-	DeliveryMode    uint8     // Transient (0 or 1) or Persistent (2)
-	Priority        uint8     // 0 to 9
-	CorrelationId   string    // correlation identifier
-	ReplyTo         string    // address to to reply to (ex: RPC)
-	Expiration      string    // message expiration spec
-	MessageId       string    // message identifier
-	Timestamp       time.Time // message timestamp
-	Type            string    // message type name
-	UserId          string    // creating user id - ex: "guest"
-	AppId           string    // creating application id
+	ContentType     string // MIME content type
+	ContentEncoding string // MIME content encoding
+	DeliveryMode    uint8  // Transient (0 or 1) or Persistent (2)
+	Priority        uint8  // 0 to 9
+	CorrelationId   string // correlation identifier
+	ReplyTo         string // address to to reply to (ex: RPC)
+	// Expiration represents the message TTL in milliseconds. A value of "0"
+	// indicates that the message will immediately expire if the message arrives
+	// at its destination and the message is not directly handled by a consumer
+	// that currently has the capacatity to do so. If you wish the message to
+	// not expire on its own, set this value to empty string or use the
+	// corresponding constant NeverExpire. This does not influence queue
+	// configured TTL values.
+	Expiration string
+	MessageId  string    // message identifier
+	Timestamp  time.Time // message timestamp
+	Type       string    // message type name
+	UserId     string    // creating user id - ex: "guest"
+	AppId      string    // creating application id
 
 	// The application specific payload of the message
 	Body []byte

--- a/types.go
+++ b/types.go
@@ -144,14 +144,14 @@ const (
 	flagReserved1       = 0x0004
 )
 
-// Expiration. These constants should be used to set a messages expiration TTL.
+// Expiration. These constants can be used to set a messages expiration TTL.
 // They should be viewed as a clarification of the expiration functionality in
 // messages and their usage is not enforced by this pkg.
 //
-// The server requires a string value that is interpreted as milliseconds. If
-// no value is set, which translates to the nil value of string, the message
-// will never expire by itself. This does not influence queue configured TTL
-// configurations.
+// The server requires a string value that is interpreted by the server as
+// milliseconds. If no value is set, which translates to the nil value of
+// string, the message will never expire by itself. This does not influence queue
+// configured TTL configurations.
 const (
 	NeverExpire       string = ""  // empty value means never expire
 	ImmediatelyExpire string = "0" // 0 means immediately expire
@@ -185,9 +185,9 @@ type Publishing struct {
 	// indicates that the message will immediately expire if the message arrives
 	// at its destination and the message is not directly handled by a consumer
 	// that currently has the capacatity to do so. If you wish the message to
-	// not expire on its own, set this value to empty string or use the
-	// corresponding constant NeverExpire. This does not influence queue
-	// configured TTL values.
+	// not expire on its own, set this value to any ttl value, empty string or
+	// use the corresponding constants NeverExpire and ImmediatelyExpire. This
+	// does not influence queue configured TTL values.
 	Expiration string
 	MessageId  string    // message identifier
 	Timestamp  time.Time // message timestamp


### PR DESCRIPTION
So this one got me good on a really nasty bug from my side. I was using the pkg to publish big batches of messages to a queue. When reading the source code it was not clear to me the value was used as milliseconds. I assumed wrongly if the value is `0` the message will not expire. I assumed this because `0` would be the nil value for a go int. This assumption was painfully wrong - which lead to all messages not immediately retrieved by the consumer to get rightfully deleted. I wanted to spare others from the same mistake.

I am perfectly aware the rabbit mq documentation states the usage here: https://www.rabbitmq.com/ttl.html#per-message-ttl-in-publishers

But I think a little more documentation in the code and some clarification can prevent others from making the same mistake. I also provided two constants for the field that further elaborate on the usage and should explain it in its entirety. They are not needed but so are the `DeliveryMode` constants (Transient, Persistent). If this is not wanted please provide feedback and I will refine the PR.

Best regards and thank you all a lot for your work on this client!