### PR TITLE
Use correct mutex to guard confirms.published

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1826,8 +1826,8 @@ func (ch *Channel) Reject(tag uint64, requeue bool) error {
 // GetNextPublishSeqNo returns the sequence number of the next message to be
 // published, when in confirm mode.
 func (ch *Channel) GetNextPublishSeqNo() uint64 {
-	ch.confirms.m.Lock()
-	defer ch.confirms.m.Unlock()
+	ch.confirms.publishedMut.Lock()
+	defer ch.confirms.publishedMut.Unlock()
 
 	return ch.confirms.published + 1
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -2049,25 +2049,27 @@ func TestIntegrationGetNextPublishSeqNoRace(t *testing.T) {
 		}
 
 		wg := sync.WaitGroup{}
+		fail := false
 
 		wg.Add(2)
 
 		go func() {
 			defer wg.Done()
-			n := ch.GetNextPublishSeqNo()
-			if n <= 0 {
-				t.Fatalf("wrong next publish seqence number, expected: > %d, got: %d", 0, n)
-			}
+			_ = ch.GetNextPublishSeqNo()
 		}()
 
 		go func() {
 			defer wg.Done()
 			if err := ch.PublishWithContext(context.TODO(), "test-get-next-pub-seq", "", false, false, Publishing{}); err != nil {
-				t.Fatalf("publish error: %v", err)
+				t.Logf("publish error: %v", err)
+				fail = true
 			}
 		}()
 
 		wg.Wait()
+		if fail {
+			t.FailNow()
+		}
 
 		n = ch.GetNextPublishSeqNo()
 		if n != 2 {


### PR DESCRIPTION
The `confirms` type uses the `publishedMut` to guard access to the `published` field:

https://github.com/rabbitmq/amqp091-go/blob/a6fa7f7d76ecb00f1f46d42d02adfe0454c5514f/confirms.go#L43-L47

https://github.com/rabbitmq/amqp091-go/blob/a6fa7f7d76ecb00f1f46d42d02adfe0454c5514f/confirms.go#L53-L56

etc.

However, the `Channel` type uses the mutex `m` (on the `confirms` type) instead:

https://github.com/rabbitmq/amqp091-go/blob/a6fa7f7d76ecb00f1f46d42d02adfe0454c5514f/channel.go#L1829-L1832

This can lead to race if the `GetNextPublishSeqNo` function is used while other functions on the `confirms` type is used concurrently.

