### PR TITLE
add method Temporary to amqp.Error

### DIFF
--- a/types.go
+++ b/types.go
@@ -92,6 +92,18 @@ func (e Error) Error() string {
 	return fmt.Sprintf("Exception (%d) Reason: %q", e.Code, e.Reason)
 }
 
+// Temporary returns true if the error can be recovered by retrying later or with different parameters.
+// Returns the value of the Recover field.
+func (e *Error) Temporary() bool {
+	return e.Recover
+}
+
+// GoString returns a longer description of the error than .Error() including all fields.
+func (e *Error) GoString() string {
+	return fmt.Sprintf("Exception (%d) Reason: %q Recoverable: %v Server: %v",
+		e.Code, e.Reason, e.Recover, e.Server)
+}
+
 // Used by header frames to capture routing and header information
 type properties struct {
 	ContentType     string    // MIME content type


### PR DESCRIPTION
Today if I need to check if the error from amqp library is retriable or not, I need to try convert to `*amqp.Error` and check the field `Recover` via `errors.As` function.

However, I may have other kinds of error such context deadline, etc,

A better way is to follow some common interface like `Timeout() bool` or `Temporary() bool`

I choose the second one for amqp.Error -- I hope you will like it

Regards