### PR TITLE
Fixing simple errors

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -428,7 +428,7 @@ func ExampleTable_SetClientConnectionName() {
 	// name will be visible in RabbitMQ Management UI.
 	config := amqp.Config{Properties: amqp.NewConnectionProperties()}
 	config.Properties.SetClientConnectionName("my-client-app")
-	conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
+	conn, err := amqp.DialConfig("amqp://guest:guest@localhost:5672/", config)
 	if err != nil {
 		log.Fatalf("connection.open: %s", err)
 	}

--- a/uri.go
+++ b/uri.go
@@ -166,7 +166,7 @@ func ParseURI(uri string) (URI, error) {
 	if params.Has("channel_max") {
 		value, err := strconv.ParseUint(params.Get("channel_max"), 10, 16)
 		if err != nil {
-			return builder, fmt.Errorf("connection_timeout is not an integer: %v", err)
+			return builder, fmt.Errorf("channel_max is not an uint16: %v", err)
 		}
 		builder.ChannelMax = uint16(value)
 	}


### PR DESCRIPTION
- Fixed channel max error message
- Fixed example "set client connection name"