### PR TITLE
Feat: defined a type for exchange kinds

### DIFF
--- a/_examples/pubsub/pubsub.go
+++ b/_examples/pubsub/pubsub.go
@@ -68,7 +68,7 @@ func redial(ctx context.Context, url string) chan chan session {
 				log.Fatalf("cannot create channel: %v", err)
 			}
 
-			if err := ch.ExchangeDeclare(exchange, "fanout", false, true, false, false, nil); err != nil {
+			if err := ch.ExchangeDeclare(exchange, amqp.Fanout, false, true, false, false, nil); err != nil {
 				log.Fatalf("cannot declare fanout exchange: %v", err)
 			}
 

--- a/channel.go
+++ b/channel.go
@@ -1301,7 +1301,7 @@ to respond to any exceptions.
 Optional amqp.Table of arguments that are specific to the server's implementation of
 the exchange can be sent for exchange types that require extra parameters.
 */
-func (ch *Channel) ExchangeDeclare(name, kind string, durable, autoDelete, internal, noWait bool, args Table) error {
+func (ch *Channel) ExchangeDeclare(name string, kind ExchangeType, durable, autoDelete, internal, noWait bool, args Table) error {
 	if err := args.Validate(); err != nil {
 		return err
 	}
@@ -1309,7 +1309,7 @@ func (ch *Channel) ExchangeDeclare(name, kind string, durable, autoDelete, inter
 	return ch.call(
 		&exchangeDeclare{
 			Exchange:   name,
-			Type:       kind,
+			Type:       string(kind),
 			Passive:    false,
 			Durable:    durable,
 			AutoDelete: autoDelete,
@@ -1328,7 +1328,7 @@ exchange is assumed by RabbitMQ to already exist, and attempting to connect to a
 non-existent exchange will cause RabbitMQ to throw an exception. This function
 can be used to detect the existence of an exchange.
 */
-func (ch *Channel) ExchangeDeclarePassive(name, kind string, durable, autoDelete, internal, noWait bool, args Table) error {
+func (ch *Channel) ExchangeDeclarePassive(name string, kind ExchangeType, durable, autoDelete, internal, noWait bool, args Table) error {
 	if err := args.Validate(); err != nil {
 		return err
 	}
@@ -1336,7 +1336,7 @@ func (ch *Channel) ExchangeDeclarePassive(name, kind string, durable, autoDelete
 	return ch.call(
 		&exchangeDeclare{
 			Exchange:   name,
-			Type:       kind,
+			Type:       string(kind),
 			Passive:    true,
 			Durable:    durable,
 			AutoDelete: autoDelete,

--- a/examples_test.go
+++ b/examples_test.go
@@ -130,7 +130,7 @@ func ExampleChannel_Confirm_bridge() {
 		log.Fatalf("channel.open source: %s", err)
 	}
 
-	if err := chs.ExchangeDeclare("log", "topic", true, false, false, false, nil); err != nil {
+	if err := chs.ExchangeDeclare("log", amqp.Topic, true, false, false, false, nil); err != nil {
 		log.Fatalf("exchange.declare destination: %s", err)
 	}
 
@@ -159,7 +159,7 @@ func ExampleChannel_Confirm_bridge() {
 		log.Fatalf("channel.open destination: %s", err)
 	}
 
-	if err := chd.ExchangeDeclare("log", "topic", true, false, false, false, nil); err != nil {
+	if err := chd.ExchangeDeclare("log", amqp.Topic, true, false, false, false, nil); err != nil {
 		log.Fatalf("exchange.declare destination: %s", err)
 	}
 
@@ -239,7 +239,7 @@ func ExampleChannel_Consume() {
 	// are the same.  This is part of AMQP being a programmable messaging model.
 	//
 	// See the Channel.Publish example for the complimentary declare.
-	err = c.ExchangeDeclare("logs", "topic", true, false, false, false, nil)
+	err = c.ExchangeDeclare("logs", amqp.Topic, true, false, false, false, nil)
 	if err != nil {
 		log.Fatalf("exchange.declare: %s", err)
 	}
@@ -365,7 +365,7 @@ func ExampleChannel_PublishWithContext() {
 	// are the same.  This is part of AMQP being a programmable messaging model.
 	//
 	// See the Channel.Consume example for the complimentary declare.
-	err = c.ExchangeDeclare("logs", "topic", true, false, false, false, nil)
+	err = c.ExchangeDeclare("logs", amqp.Topic, true, false, false, false, nil)
 	if err != nil {
 		log.Fatalf("exchange.declare: %v", err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -171,12 +171,12 @@ func TestExchangePassiveOnMissingExchangeShouldError(t *testing.T) {
 
 		if err := ch.ExchangeDeclarePassive(
 			"test-integration-missing-passive-exchange",
-			"direct", // type
-			false,    // duration (note: is durable)
-			true,     // auto-delete
-			false,    // internal
-			false,    // nowait
-			nil,      // args
+			Direct, // type
+			false,  // duration (note: is durable)
+			true,   // auto-delete
+			false,  // internal
+			false,  // nowait
+			nil,    // args
 		); err == nil {
 			t.Fatal("ExchangeDeclarePassive of a missing exchange should return error")
 		}
@@ -199,7 +199,7 @@ func TestIntegrationExchangeDeclarePassiveOnDeclaredShouldNotError(t *testing.T)
 
 		if err := ch.ExchangeDeclare(
 			exchange, // name
-			"direct", // type
+			Direct,   // type
 			false,    // durable
 			true,     // auto-delete
 			false,    // internal
@@ -211,7 +211,7 @@ func TestIntegrationExchangeDeclarePassiveOnDeclaredShouldNotError(t *testing.T)
 
 		if err := ch.ExchangeDeclarePassive(
 			exchange, // name
-			"direct", // type
+			Direct,   // type
 			false,    // durable
 			true,     // auto-delete
 			false,    // internal
@@ -238,7 +238,7 @@ func TestIntegrationExchange(t *testing.T) {
 
 		if err := channel.ExchangeDeclare(
 			exchange, // name
-			"direct", // type
+			Direct,   // type
 			false,    // duration
 			true,     // auto-delete
 			false,    // internal
@@ -396,7 +396,7 @@ func TestIntegrationBasicQueueOperations(t *testing.T) {
 		for _, deleteQueueFirst := range deleteQueueFirstOptions {
 			if err := channel.ExchangeDeclare(
 				exchangeName, // name
-				"direct",     // type
+				Direct,       // type
 				true,         // duration (note: is durable)
 				false,        // auto-delete
 				false,        // internal
@@ -1502,11 +1502,11 @@ func TestDeclareArgsRejectToDeadLetterQueue(t *testing.T) {
 
 		ch, _ := conn.Channel()
 
-		if err := ch.ExchangeDeclare(ex, "fanout", false, true, false, false, nil); err != nil {
+		if err := ch.ExchangeDeclare(ex, Fanout, false, true, false, false, nil); err != nil {
 			t.Fatalf("cannot declare %v: got: %v", ex, err)
 		}
 
-		if err := ch.ExchangeDeclare(dlex, "fanout", false, true, false, false, nil); err != nil {
+		if err := ch.ExchangeDeclare(dlex, Fanout, false, true, false, false, nil); err != nil {
 			t.Fatalf("cannot declare %v: got: %v", dlex, err)
 		}
 
@@ -1722,7 +1722,7 @@ func TestChannelExceptionWithCloseIssue43(t *testing.T) {
 
 		// This ensures that the 2nd channel is unaffected by the channel exception
 		// on channel 1.
-		err = c2.ExchangeDeclare("test-channel-still-exists", "direct", false, true, false, false, nil)
+		err = c2.ExchangeDeclare("test-channel-still-exists", Direct, false, true, false, false, nil)
 		if err != nil {
 			t.Fatalf("failed to declare exchange, got: %v", err)
 		}
@@ -1834,12 +1834,12 @@ func TestExchangeDeclarePrecondition(t *testing.T) {
 
 		err = ch.ExchangeDeclare(
 			exchange,
-			"direct", // exchangeType
-			false,    // durable
-			true,     // auto-delete
-			false,    // internal
-			false,    // noWait
-			nil,      // arguments
+			Direct, // exchangeType
+			false,  // durable
+			true,   // auto-delete
+			false,  // internal
+			false,  // noWait
+			nil,    // arguments
 		)
 		if err != nil {
 			t.Fatalf("Could not initially declare exchange")
@@ -1847,7 +1847,7 @@ func TestExchangeDeclarePrecondition(t *testing.T) {
 
 		err = ch.ExchangeDeclare(
 			exchange,
-			"direct",
+			Direct,
 			true, // different durability
 			true,
 			false,
@@ -2041,7 +2041,7 @@ func TestIntegrationGetNextPublishSeqNo(t *testing.T) {
 		}
 
 		ex := "test-get-next-pub"
-		if err = ch.ExchangeDeclare(ex, "direct", false, false, false, false, nil); err != nil {
+		if err = ch.ExchangeDeclare(ex, Direct, false, false, false, false, nil); err != nil {
 			t.Fatalf("cannot declare %v: got: %v", ex, err)
 		}
 
@@ -2075,7 +2075,7 @@ func TestIntegrationGetNextPublishSeqNoRace(t *testing.T) {
 		}
 
 		ex := "test-get-next-pub"
-		if err = ch.ExchangeDeclare(ex, "direct", false, false, false, false, nil); err != nil {
+		if err = ch.ExchangeDeclare(ex, Direct, false, false, false, false, nil); err != nil {
 			t.Fatalf("cannot declare %v: got: %v", ex, err)
 		}
 

--- a/types.go
+++ b/types.go
@@ -15,12 +15,15 @@ import (
 // name. Applications can route to a queue using the queue name as routing key.
 const DefaultExchange = ""
 
+// Type of Exchanges
+type ExchangeType string
+
 // Constants for standard AMQP 0-9-1 exchange types.
 const (
-	ExchangeDirect  = "direct"
-	ExchangeFanout  = "fanout"
-	ExchangeTopic   = "topic"
-	ExchangeHeaders = "headers"
+	Direct  ExchangeType = "direct"
+	Fanout  ExchangeType = "fanout"
+	Topic   ExchangeType = "topic"
+	Headers ExchangeType = "headers"
 )
 
 var (


### PR DESCRIPTION
The developer must type out the kind of exchange when declaring it, which could lead to typos. Also, the IDE or code editor did not help or suggest a type of exchange.
This way, selecting an exchange is more straightforward and helps maintain the code more easily.