### PR TITLE
Expose delivery not initialised error

### DIFF
--- a/delivery.go
+++ b/delivery.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var errDeliveryNotInitialized = errors.New("delivery not initialized")
+var ErrDeliveryNotInitialized = errors.New("delivery not initialized. Channel is probably closed")
 
 // Acknowledger notifies the server of successful or failed consumption of
 // deliveries via identifier found in the Delivery.DeliveryTag field.
@@ -122,7 +122,7 @@ delivery that is not automatically acknowledged.
 */
 func (d Delivery) Ack(multiple bool) error {
 	if d.Acknowledger == nil {
-		return errDeliveryNotInitialized
+		return ErrDeliveryNotInitialized
 	}
 	return d.Acknowledger.Ack(d.DeliveryTag, multiple)
 }
@@ -142,7 +142,7 @@ delivery that is not automatically acknowledged.
 */
 func (d Delivery) Reject(requeue bool) error {
 	if d.Acknowledger == nil {
-		return errDeliveryNotInitialized
+		return ErrDeliveryNotInitialized
 	}
 	return d.Acknowledger.Reject(d.DeliveryTag, requeue)
 }
@@ -167,7 +167,7 @@ delivery that is not automatically acknowledged.
 */
 func (d Delivery) Nack(multiple, requeue bool) error {
 	if d.Acknowledger == nil {
-		return errDeliveryNotInitialized
+		return ErrDeliveryNotInitialized
 	}
 	return d.Acknowledger.Nack(d.DeliveryTag, multiple, requeue)
 }

--- a/delivery_test.go
+++ b/delivery_test.go
@@ -5,7 +5,11 @@
 
 package amqp091
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
 func shouldNotPanic(t *testing.T) {
 	if err := recover(); err != nil {
@@ -14,25 +18,49 @@ func shouldNotPanic(t *testing.T) {
 }
 
 // A closed delivery chan could produce zero value.  Ack/Nack/Reject on these
-// deliveries can produce a nil pointer panic.  Instead return an error when
+// deliveries can produce a nil pointer panic. Instead, return an error when
 // the method can never be successful.
 func TestAckZeroValueAcknowledgerDoesNotPanic(t *testing.T) {
 	defer shouldNotPanic(t)
-	if err := (Delivery{}).Ack(false); err == nil {
-		t.Errorf("expected Delivery{}.Ack to error")
+	err := (Delivery{}).Ack(false)
+	if err == nil {
+		t.Fatalf("expected Delivery{}.Ack to error")
+	}
+	if !errors.Is(err, ErrDeliveryNotInitialized) {
+		t.Fatalf("expected '%v' got '%v'", ErrDeliveryNotInitialized, err)
+	}
+	expectedErrMessage := "delivery not initialized. Channel is probably closed"
+	if !strings.EqualFold(err.Error(), expectedErrMessage) {
+		t.Errorf("expected '%s' got '%s'", expectedErrMessage, err)
 	}
 }
 
 func TestNackZeroValueAcknowledgerDoesNotPanic(t *testing.T) {
 	defer shouldNotPanic(t)
-	if err := (Delivery{}).Nack(false, false); err == nil {
-		t.Errorf("expected Delivery{}.Ack to error")
+	err := (Delivery{}).Nack(false, false)
+	if err == nil {
+		t.Fatalf("expected Delivery{}.Nack to error")
+	}
+	if !errors.Is(err, ErrDeliveryNotInitialized) {
+		t.Fatalf("expected '%v' got '%v'", ErrDeliveryNotInitialized, err)
+	}
+	expectedErrMessage := "delivery not initialized. Channel is probably closed"
+	if !strings.EqualFold(err.Error(), expectedErrMessage) {
+		t.Errorf("expected '%s' got '%s'", expectedErrMessage, err)
 	}
 }
 
 func TestRejectZeroValueAcknowledgerDoesNotPanic(t *testing.T) {
 	defer shouldNotPanic(t)
-	if err := (Delivery{}).Reject(false); err == nil {
-		t.Errorf("expected Delivery{}.Ack to error")
+	err := (Delivery{}).Reject(false)
+	if err == nil {
+		t.Fatalf("expected Delivery{}.Reject to error")
+	}
+	if !errors.Is(err, ErrDeliveryNotInitialized) {
+		t.Fatalf("expected '%v' got '%v'", ErrDeliveryNotInitialized, err)
+	}
+	expectedErrMessage := "delivery not initialized. Channel is probably closed"
+	if !strings.EqualFold(err.Error(), expectedErrMessage) {
+		t.Errorf("expected '%s' got '%s'", expectedErrMessage, err)
 	}
 }


### PR DESCRIPTION
This error can happen when a Delivery (message) is ack/nack/reject after
the AMQP channel is closed, and the consuming function/routine does not
check the status of Go receive operation.

The error is reproducible with a very simple snippet like the following:

```go
conn, _ := amqp.DialConfig(...)
ch, _ := conn.Channel()
ch.Publish(...)
deliveries, _ = ch.Consume(...)
ch.Close()
for i := 0; i < 3; i++ {
  m := <- deliveries
  err := m.Ack(false)
  printf("error: %v\n", err)
}
```

The expected output of above snippet is first `nil`, then followed by two errors.

This can be entirely avoided by checking the receive operation status, using the form
of `m, ok := <-deliveries`, and checking the value of `ok`. 
