### PR TITLE
Return existing error instead of creating new for the same purpose

### DIFF
--- a/_examples/client/client.go
+++ b/_examples/client/client.go
@@ -301,7 +301,7 @@ func (client *Client) Push(data []byte) error {
 	client.m.Lock()
 	if !client.isReady {
 		client.m.Unlock()
-		return errors.New("failed to push: not connected")
+		return errNotConnected
 	}
 	client.m.Unlock()
 	for {


### PR DESCRIPTION
Methods UnsafePush and Consume returns errNotConnected in the same conditions