### PR TITLE
Export basicPublish

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -254,7 +254,7 @@ func (ch *Channel) sendOpen(msg message) (err error) {
 		// Flushing after each Frame is inefficient, as it negates much of the
 		// benefit of using a buffered writer and results in more syscalls than
 		// necessary. Flushing buffers after every frame can have a significant
-		// performance impact when sending (e.g. basicPublish) small messages,
+		// performance impact when sending (e.g. BasicPublish) small messages,
 		// so sendUnflushed() performs an *Unflushed* write, but is otherwise
 		// equivalent to the send() method. We later use the separate flush
 		// method to explicitly flush the buffer after all Frames are written.
@@ -1546,7 +1546,7 @@ func (ch *Channel) PublishWithDeferredConfirm(exchange, key string, mandatory, i
 		dc = ch.confirms.publish()
 	}
 
-	if err := ch.send(&basicPublish{
+	if err := ch.send(&BasicPublish{
 		Exchange:   exchange,
 		RoutingKey: key,
 		Mandatory:  mandatory,

--- a/client_test.go
+++ b/client_test.go
@@ -439,10 +439,10 @@ func TestConfirmMultipleOrdersDeliveryTags(t *testing.T) {
 		srv.recv(1, &confirmSelect{})
 		srv.send(1, &confirmSelectOk{})
 
-		srv.recv(1, &basicPublish{})
-		srv.recv(1, &basicPublish{})
-		srv.recv(1, &basicPublish{})
-		srv.recv(1, &basicPublish{})
+		srv.recv(1, &BasicPublish{})
+		srv.recv(1, &BasicPublish{})
+		srv.recv(1, &BasicPublish{})
+		srv.recv(1, &BasicPublish{})
 
 		// Single tag, plus multiple, should produce
 		// 2, 1, 3, 4
@@ -450,10 +450,10 @@ func TestConfirmMultipleOrdersDeliveryTags(t *testing.T) {
 		srv.send(1, &basicAck{DeliveryTag: 1})
 		srv.send(1, &basicAck{DeliveryTag: 4, Multiple: true})
 
-		srv.recv(1, &basicPublish{})
-		srv.recv(1, &basicPublish{})
-		srv.recv(1, &basicPublish{})
-		srv.recv(1, &basicPublish{})
+		srv.recv(1, &BasicPublish{})
+		srv.recv(1, &BasicPublish{})
+		srv.recv(1, &BasicPublish{})
+		srv.recv(1, &BasicPublish{})
 
 		// And some more, but in reverse order, multiple then one
 		// 5, 6, 7, 8
@@ -536,10 +536,10 @@ func TestDeferredConfirmations(t *testing.T) {
 		srv.recv(1, &confirmSelect{})
 		srv.send(1, &confirmSelectOk{})
 
-		srv.recv(1, &basicPublish{})
-		srv.recv(1, &basicPublish{})
-		srv.recv(1, &basicPublish{})
-		srv.recv(1, &basicPublish{})
+		srv.recv(1, &BasicPublish{})
+		srv.recv(1, &BasicPublish{})
+		srv.recv(1, &BasicPublish{})
+		srv.recv(1, &BasicPublish{})
 	}()
 
 	c, err := Open(rwc, defaultConfig())
@@ -707,7 +707,7 @@ func TestPublishBodySliceIssue74(t *testing.T) {
 		srv.channelOpen(1)
 
 		for i := 0; i < publishings; i++ {
-			srv.recv(1, &basicPublish{})
+			srv.recv(1, &BasicPublish{})
 		}
 
 		done <- true
@@ -751,7 +751,7 @@ func TestPublishZeroFrameSizeIssue161(t *testing.T) {
 		srv.channelOpen(1)
 
 		for i := 0; i < publishings; i++ {
-			srv.recv(1, &basicPublish{})
+			srv.recv(1, &BasicPublish{})
 		}
 
 		done <- true
@@ -792,7 +792,7 @@ func TestPublishAndShutdownDeadlockIssue84(t *testing.T) {
 	go func() {
 		srv.connectionOpen()
 		srv.channelOpen(1)
-		srv.recv(1, &basicPublish{})
+		srv.recv(1, &BasicPublish{})
 		// Mimic a broken io pipe so that Publish catches the error and goes into shutdown
 		srv.S.Close()
 	}()

--- a/connection.go
+++ b/connection.go
@@ -549,7 +549,7 @@ func (c *Connection) endSendUnflushed() error {
 // after each Frame is inefficient as it negates much of the benefit of using a
 // buffered writer, and results in more syscalls than necessary. Flushing buffers
 // after every frame can have a significant performance impact when sending
-// (basicPublish) small messages, so this method performs an *Unflushed* write
+// (BasicPublish) small messages, so this method performs an *Unflushed* write
 // but is otherwise equivalent to send() method, and we provide a separate
 // flush method to explicitly flush the buffer after all Frames are written.
 func (c *Connection) sendUnflushed(f frame) error {
@@ -578,9 +578,9 @@ func (c *Connection) flush() (err error) {
 	if buf, ok := c.writer.w.(*bufio.Writer); ok {
 		err = buf.Flush()
 
-		// Moving send notifier to flush increases basicPublish for the small message
+		// Moving send notifier to flush increases BasicPublish for the small message
 		// case. As sendUnflushed + flush is used for the case of sending semantically
-		// related Frames (e.g. a Message like basicPublish) there is no real advantage
+		// related Frames (e.g. a Message like BasicPublish) there is no real advantage
 		// to sending per Frame vice per "group of related Frames" and for the case of
 		// small messages time.Now() is (relatively) expensive.
 		if err == nil {

--- a/spec091.go
+++ b/spec091.go
@@ -1916,7 +1916,7 @@ func (msg *basicCancelOk) read(r io.Reader) (err error) {
 	return
 }
 
-type basicPublish struct {
+type BasicPublish struct {
 	reserved1  uint16
 	Exchange   string
 	RoutingKey string
@@ -1926,23 +1926,23 @@ type basicPublish struct {
 	Body       []byte
 }
 
-func (msg *basicPublish) id() (uint16, uint16) {
+func (msg *BasicPublish) id() (uint16, uint16) {
 	return 60, 40
 }
 
-func (msg *basicPublish) wait() bool {
+func (msg *BasicPublish) wait() bool {
 	return false
 }
 
-func (msg *basicPublish) getContent() (properties, []byte) {
+func (msg *BasicPublish) getContent() (properties, []byte) {
 	return msg.Properties, msg.Body
 }
 
-func (msg *basicPublish) setContent(props properties, body []byte) {
+func (msg *BasicPublish) setContent(props properties, body []byte) {
 	msg.Properties, msg.Body = props, body
 }
 
-func (msg *basicPublish) write(w io.Writer) (err error) {
+func (msg *BasicPublish) write(w io.Writer) (err error) {
 	var bits byte
 
 	if err = binary.Write(w, binary.BigEndian, msg.reserved1); err != nil {
@@ -1971,7 +1971,7 @@ func (msg *basicPublish) write(w io.Writer) (err error) {
 	return
 }
 
-func (msg *basicPublish) read(r io.Reader) (err error) {
+func (msg *BasicPublish) read(r io.Reader) (err error) {
 	var bits byte
 
 	if err = binary.Read(r, binary.BigEndian, &msg.reserved1); err != nil {
@@ -3099,7 +3099,7 @@ func (r *reader) parseMethodFrame(channel uint16, size uint32) (f frame, err err
 
 		case 40: // basic publish
 			// fmt.Println("NextMethod: class:60 method:40")
-			method := &basicPublish{}
+			method := &BasicPublish{}
 			if err = method.read(r.r); err != nil {
 				return
 			}


### PR DESCRIPTION
Recently, I have been working on non-intrusive monitoring of the amqp091 module in OTEL. When handling the publish process, I need to insert the tracing context into the message headers. Initially, I monitored the PublishWithDeferredConfirm method, but since msg is a non-pointer, modifying the passed variable after instrumentation was not feasible. I then attempted to monitor the Channel.send method, but basicPublish is unexported. After comparing the options, I found that making basicPublish an exported method would have a smaller impact. This way, I can use assertions in Channel.send to obtain and process tracing information.