### PR TITLE
Add support for uint16/uint32

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: 2
 run:
   build-tags:
     - integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ docs](https://golangci-lint.run/usage/install/) for more information.
 The static checks can be run via:
 
 ```shell
-make checks
+make check
 ```
 
 ## Running Tests

--- a/channel.go
+++ b/channel.go
@@ -143,7 +143,7 @@ func (ch *Channel) shutdown(e *Error) {
 		ch.cancels = nil
 
 		if ch.confirms != nil {
-			ch.confirms.Close()
+			_ = ch.confirms.Close()
 		}
 
 		close(ch.errors)

--- a/client_test.go
+++ b/client_test.go
@@ -230,7 +230,7 @@ func (t *server) channelOpen(id int) {
 
 func TestDefaultClientProperties(t *testing.T) {
 	rwc, srv := newSession(t)
-	t.Cleanup(func() { rwc.Close() })
+	t.Cleanup(func() { _ = rwc.Close() })
 
 	go func() {
 		srv.connectionOpen()
@@ -255,7 +255,7 @@ func TestDefaultClientProperties(t *testing.T) {
 
 func TestCustomClientProperties(t *testing.T) {
 	rwc, srv := newSession(t)
-	t.Cleanup(func() { rwc.Close() })
+	t.Cleanup(func() { _ = rwc.Close() })
 
 	config := defaultConfig()
 	config.Properties = Table{
@@ -282,7 +282,7 @@ func TestCustomClientProperties(t *testing.T) {
 
 func TestOpen(t *testing.T) {
 	rwc, srv := newSession(t)
-	t.Cleanup(func() { rwc.Close() })
+	t.Cleanup(func() { _ = rwc.Close() })
 	go func() {
 		srv.connectionOpen()
 	}()
@@ -329,7 +329,7 @@ func TestOpenClose_ShouldNotPanic(t *testing.T) {
 
 func TestChannelOpen(t *testing.T) {
 	rwc, srv := newSession(t)
-	t.Cleanup(func() { rwc.Close() })
+	t.Cleanup(func() { _ = rwc.Close() })
 
 	go func() {
 		srv.connectionOpen()
@@ -349,7 +349,7 @@ func TestChannelOpen(t *testing.T) {
 
 func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
 	rwc, srv := newSession(t)
-	t.Cleanup(func() { rwc.Close() })
+	t.Cleanup(func() { _ = rwc.Close() })
 
 	go func() {
 		srv.expectAMQP()
@@ -365,7 +365,7 @@ func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
 func TestOpenAMQPlainAuth(t *testing.T) {
 	auth := make(chan Table)
 	rwc, srv := newSession(t)
-	t.Cleanup(func() { rwc.Close() })
+	t.Cleanup(func() { _ = rwc.Close() })
 
 	go func() {
 		srv.expectAMQP()
@@ -400,7 +400,7 @@ func TestOpenFailedCredentials(t *testing.T) {
 		srv.expectAMQP()
 		srv.connectionStart()
 		// Now kill/timeout the connection indicating bad auth
-		rwc.Close()
+		_ = rwc.Close()
 	}()
 
 	c, err := Open(rwc, defaultConfig())
@@ -419,7 +419,7 @@ func TestOpenFailedVhost(t *testing.T) {
 		srv.recv(0, &connectionOpen{})
 
 		// Now kill/timeout the connection on bad Vhost
-		rwc.Close()
+		_ = rwc.Close()
 	}()
 
 	c, err := Open(rwc, defaultConfig())
@@ -430,7 +430,7 @@ func TestOpenFailedVhost(t *testing.T) {
 
 func TestConfirmMultipleOrdersDeliveryTags(t *testing.T) {
 	rwc, srv := newSession(t)
-	defer rwc.Close()
+	defer func() { _ = rwc.Close() }()
 
 	go func() {
 		srv.connectionOpen()
@@ -527,7 +527,7 @@ func TestConfirmMultipleOrdersDeliveryTags(t *testing.T) {
 
 func TestDeferredConfirmations(t *testing.T) {
 	rwc, srv := newSession(t)
-	defer rwc.Close()
+	defer func() { _ = rwc.Close() }()
 
 	go func() {
 		srv.connectionOpen()
@@ -694,7 +694,7 @@ func TestNotifyClosesAllChansAfterConnectionClose(t *testing.T) {
 // Should not panic when sending bodies split at different boundaries
 func TestPublishBodySliceIssue74(t *testing.T) {
 	rwc, srv := newSession(t)
-	defer rwc.Close()
+	defer func() { _ = rwc.Close() }()
 
 	const frameSize = 100
 	const publishings = frameSize * 3
@@ -740,7 +740,7 @@ func TestPublishBodySliceIssue74(t *testing.T) {
 // Should not panic when server and client have frame_size of 0
 func TestPublishZeroFrameSizeIssue161(t *testing.T) {
 	rwc, srv := newSession(t)
-	defer rwc.Close()
+	defer func() { _ = rwc.Close() }()
 
 	const frameSize = 0
 	const publishings = 1
@@ -787,14 +787,14 @@ func TestPublishZeroFrameSizeIssue161(t *testing.T) {
 
 func TestPublishAndShutdownDeadlockIssue84(t *testing.T) {
 	rwc, srv := newSession(t)
-	defer rwc.Close()
+	defer func() { _ = rwc.Close() }()
 
 	go func() {
 		srv.connectionOpen()
 		srv.channelOpen(1)
 		srv.recv(1, &basicPublish{})
 		// Mimic a broken io pipe so that Publish catches the error and goes into shutdown
-		srv.S.Close()
+		_ = srv.S.Close()
 	}()
 
 	c, err := Open(rwc, defaultConfig())
@@ -851,7 +851,7 @@ func TestLeakClosedConsumersIssue264(t *testing.T) {
 	const tag = "consumer-tag"
 
 	rwc, srv := newSession(t)
-	defer rwc.Close()
+	defer func() { _ = rwc.Close() }()
 
 	go func() {
 		srv.connectionOpen()
@@ -871,7 +871,7 @@ func TestLeakClosedConsumersIssue264(t *testing.T) {
 
 		srv.recv(0, &connectionClose{})
 		srv.send(0, &connectionCloseOk{})
-		srv.C.Close()
+		_ = srv.C.Close()
 	}()
 
 	c, err := Open(rwc, defaultConfig())

--- a/connection.go
+++ b/connection.go
@@ -273,7 +273,7 @@ func DialConfig(url string, config Config) (*Connection, error) {
 
 		client := tls.Client(conn, config.TLSClientConfig)
 		if err := client.Handshake(); err != nil {
-			conn.Close()
+			_ = conn.Close()
 			return nil, err
 		}
 
@@ -630,7 +630,7 @@ func (c *Connection) shutdown(err *Error) {
 			ch.shutdown(err)
 		}
 
-		c.conn.Close()
+		_ = c.conn.Close()
 		// reader exit
 		close(c.close)
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -123,7 +123,9 @@ func ExampleChannel_Confirm_bridge() {
 	if err != nil {
 		log.Fatalf("connection.open source: %s", err)
 	}
-	defer source.Close()
+	defer func() {
+		_ = source.Close()
+	}()
 
 	chs, err := source.Channel()
 	if err != nil {
@@ -152,7 +154,9 @@ func ExampleChannel_Confirm_bridge() {
 	if err != nil {
 		log.Fatalf("connection.open destination: %s", err)
 	}
-	defer destination.Close()
+	defer func() {
+		_ = destination.Close()
+	}()
 
 	chd, err := destination.Channel()
 	if err != nil {
@@ -228,7 +232,7 @@ func ExampleChannel_Consume() {
 	if err != nil {
 		log.Fatalf("connection.open: %s", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	c, err := conn.Channel()
 	if err != nil {
@@ -354,7 +358,7 @@ func ExampleChannel_PublishWithContext() {
 	// This waits for a server acknowledgment which means the sockets will have
 	// flushed all outbound publishings prior to returning.  It's important to
 	// block on Close to not lose any publishings.
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	c, err := conn.Channel()
 	if err != nil {
@@ -406,7 +410,7 @@ func ExampleConnection_NotifyBlocked() {
 	if err != nil {
 		log.Fatalf("connection.open: %s", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	blockings := conn.NotifyBlocked(make(chan amqp.Blocking))
 	go func() {
@@ -432,7 +436,7 @@ func ExampleTable_SetClientConnectionName() {
 	if err != nil {
 		log.Fatalf("connection.open: %s", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 }
 
 func ExampleConnection_UpdateSecret() {
@@ -454,7 +458,7 @@ func ExampleConnection_UpdateSecret() {
 	uri := fmt.Sprintf("amqp://%s:%s@localhost:5672", "client_id", token)
 	c, _ := amqp.Dial(uri)
 
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 
 	// It also calls Connection.UpdateSecret()
 	tokenRefresherTask := func(conn *amqp.Connection, token string) {
@@ -467,7 +471,7 @@ func ExampleConnection_UpdateSecret() {
 	go tokenRefresherTask(c, "my-JWT-token")
 
 	ch, _ := c.Channel()
-	defer ch.Close()
+	defer func() { _ = ch.Close() }()
 
 	_, _ = ch.QueueDeclare(
 		"test-amqp",

--- a/integration_test.go
+++ b/integration_test.go
@@ -56,26 +56,30 @@ func TestIntegrationOpenClose(t *testing.T) {
 
 func TestIntegrationOpenCloseChannel(t *testing.T) {
 	if c := integrationConnection(t, "channel"); c != nil {
-		defer c.Close()
+		defer func() {
+			_ = c.Close()
+		}()
 
 		ch, err := c.Channel()
 		if err != nil {
 			t.Fatalf("create channel 1: %s", err)
 		}
-		ch.Close()
+		_ = ch.Close()
 	}
 }
 
 func TestIntegrationHighChannelChurnInTightLoop(t *testing.T) {
 	if c := integrationConnection(t, "channel churn"); c != nil {
-		defer c.Close()
+		defer func() {
+			_ = c.Close()
+		}()
 
 		for i := 0; i < 1000; i++ {
 			ch, err := c.Channel()
 			if err != nil {
 				t.Fatalf("create channel 1: %s", err)
 			}
-			ch.Close()
+			_ = ch.Close()
 		}
 	}
 }
@@ -121,7 +125,9 @@ func TestIntegrationLocalAddr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to dial with config %+v integration server: %s", config, err)
 	}
-	defer c.Close()
+	defer func() {
+		_ = c.Close()
+	}()
 
 	a := c.LocalAddr()
 	_, portString, err := net.SplitHostPort(a.String())
@@ -143,7 +149,7 @@ func TestIntegrationRemoteAddr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to dial with config %+v integration server: %s", config, err)
 	}
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 
 	a := c.RemoteAddr()
 	_, portString, err := net.SplitHostPort(a.String())
@@ -162,13 +168,13 @@ func TestIntegrationRemoteAddr(t *testing.T) {
 func TestExchangePassiveOnMissingExchangeShouldError(t *testing.T) {
 	c := integrationConnection(t, "exch")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, err := c.Channel()
 		if err != nil {
 			t.Fatalf("create channel 1: %s", err)
 		}
-		defer ch.Close()
+		defer func() { _ = ch.Close() }()
 
 		if err := ch.ExchangeDeclarePassive(
 			"test-integration-missing-passive-exchange",
@@ -188,7 +194,7 @@ func TestExchangePassiveOnMissingExchangeShouldError(t *testing.T) {
 func TestIntegrationExchangeDeclarePassiveOnDeclaredShouldNotError(t *testing.T) {
 	c := integrationConnection(t, "exch")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		exchange := "test-integration-declared-passive-exchange"
 
@@ -196,7 +202,7 @@ func TestIntegrationExchangeDeclarePassiveOnDeclaredShouldNotError(t *testing.T)
 		if err != nil {
 			t.Fatalf("create channel: %s", err)
 		}
-		defer ch.Close()
+		defer func() { _ = ch.Close() }()
 
 		if err := ch.ExchangeDeclare(
 			exchange, // name
@@ -227,7 +233,7 @@ func TestIntegrationExchangeDeclarePassiveOnDeclaredShouldNotError(t *testing.T)
 func TestIntegrationExchange(t *testing.T) {
 	c := integrationConnection(t, "exch")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		channel, err := c.Channel()
 		if err != nil {
@@ -266,13 +272,13 @@ func TestIntegrationExchange(t *testing.T) {
 func TestIntegrationQueueDeclarePassiveOnMissingExchangeShouldError(t *testing.T) {
 	c := integrationConnection(t, "queue")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, err := c.Channel()
 		if err != nil {
 			t.Fatalf("create channel1: %s", err)
 		}
-		defer ch.Close()
+		defer func() { _ = ch.Close() }()
 
 		if _, err := ch.QueueDeclarePassive(
 			"test-integration-missing-passive-queue", // name
@@ -294,13 +300,13 @@ func TestIntegrationQueueDeclarePassiveOnMissingExchangeShouldError(t *testing.T
 func TestIntegrationQueueDeclarePassiveOnQueueTypeMismatchShouldError(t *testing.T) {
 	c := integrationConnection(t, t.Name())
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, err := c.Channel()
 		if err != nil {
 			t.Fatalf("create channel1: %s", err)
 		}
-		defer ch.Close()
+		defer func() { _ = ch.Close() }()
 
 		queueName := t.Name()
 
@@ -334,7 +340,7 @@ func TestIntegrationQueueDeclarePassiveOnQueueTypeMismatchShouldError(t *testing
 func TestIntegrationPassiveQueue(t *testing.T) {
 	c := integrationConnection(t, "queue")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		name := "test-integration-declared-passive-queue"
 
@@ -342,7 +348,7 @@ func TestIntegrationPassiveQueue(t *testing.T) {
 		if err != nil {
 			t.Fatalf("create channel1: %s", err)
 		}
-		defer ch.Close()
+		defer func() { _ = ch.Close() }()
 
 		if _, err := ch.QueueDeclare(
 			name,  // name
@@ -382,7 +388,7 @@ func TestIntegrationPassiveQueue(t *testing.T) {
 func TestIntegrationBasicQueueOperations(t *testing.T) {
 	c := integrationConnection(t, "queue")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		channel, err := c.Channel()
 		if err != nil {
@@ -490,7 +496,7 @@ func TestIntegrationConnectionNegotiatesMaxChannels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to dial with config %+v integration server: %s", config, err)
 	}
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 
 	if want, got := defaultChannelMax, c.Config.ChannelMax; want != got {
 		t.Fatalf("expected connection to negotiate uint16 (%d) channels, got: %d", want, got)
@@ -504,7 +510,7 @@ func TestIntegrationConnectionNegotiatesClientMaxChannels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to dial with config %+v integration server: %s", config, err)
 	}
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 
 	if want, got := config.ChannelMax, c.Config.ChannelMax; want != got {
 		t.Fatalf("expected client specified channel limit after handshake %d, got: %d", want, got)
@@ -518,7 +524,7 @@ func TestIntegrationChannelIDsExhausted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected to dial with config %+v integration server: %s", config, err)
 	}
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 
 	for i := uint16(1); i <= c.Config.ChannelMax; i++ {
 		if _, err := c.Channel(); err != nil {
@@ -534,7 +540,7 @@ func TestIntegrationChannelIDsExhausted(t *testing.T) {
 func TestIntegrationChannelClosing(t *testing.T) {
 	c := integrationConnection(t, "closings")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		// open and close
 		channel, err := c.Channel()
@@ -605,7 +611,7 @@ func TestIntegrationChannelClosing(t *testing.T) {
 func TestIntegrationMeaningfulChannelErrors(t *testing.T) {
 	c := integrationConnection(t, "pub")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, err := c.Channel()
 		if err != nil {
@@ -644,7 +650,7 @@ func TestIntegrationMeaningfulChannelErrors(t *testing.T) {
 func TestIntegrationNonBlockingClose(t *testing.T) {
 	c := integrationConnection(t, "#6")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, err := c.Channel()
 		if err != nil {
@@ -699,8 +705,8 @@ func TestIntegrationPublishConsume(t *testing.T) {
 	c2 := integrationConnection(t, "sub")
 
 	if c1 != nil && c2 != nil {
-		defer c1.Close()
-		defer c2.Close()
+		defer func() { _ = c1.Close() }()
+		defer func() { _ = c2.Close() }()
 
 		pub, _ := c1.Channel()
 		sub, _ := c2.Channel()
@@ -740,8 +746,8 @@ func TestIntegrationConsumeFlow(t *testing.T) {
 	c2 := integrationConnection(t, "sub-flow")
 
 	if c1 != nil && c2 != nil {
-		defer c1.Close()
-		defer c2.Close()
+		defer func() { _ = c1.Close() }()
+		defer func() { _ = c2.Close() }()
 
 		pub, _ := c1.Channel()
 		sub, _ := c2.Channel()
@@ -807,7 +813,7 @@ func TestIntegrationRecoverNotImplemented(t *testing.T) {
 
 	if c, ch := integrationQueue(t, queue); c != nil {
 		if product, ok := c.Properties["product"]; ok && product.(string) == "RabbitMQ" {
-			defer c.Close()
+			defer func() { _ = c.Close() }()
 
 			err := ch.Recover(false)
 
@@ -831,7 +837,7 @@ func TestIntegrationConsumeCancel(t *testing.T) {
 	c := integrationConnection(t, "pub")
 
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, _ := c.Channel()
 
@@ -875,7 +881,7 @@ func TestIntegrationConsumeCancelWithContext(t *testing.T) {
 	c := integrationConnection(t, "pub")
 
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, _ := c.Channel()
 
@@ -972,7 +978,7 @@ func (c Publishing) Generate(r *rand.Rand, _ int) reflect.Value {
 
 func TestQuickPublishOnly(t *testing.T) {
 	if c := integrationConnection(t, "quick"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 		pub, err := c.Channel()
 		if err != nil {
 			t.Fatalf("getting channel failed: %s", err)
@@ -998,7 +1004,7 @@ func TestQuickPublishOnly(t *testing.T) {
 func TestPublishEmptyBody(t *testing.T) {
 	c := integrationConnection(t, "empty")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, err := c.Channel()
 		if err != nil {
@@ -1037,7 +1043,7 @@ func TestPublishEmptyBody(t *testing.T) {
 func TestPublishEmptyBodyWithHeadersIssue67(t *testing.T) {
 	c := integrationConnection(t, "issue67")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, err := c.Channel()
 		if err != nil {
@@ -1086,8 +1092,8 @@ func TestQuickPublishConsumeOnly(t *testing.T) {
 	c2 := integrationConnection(t, "quick-sub")
 
 	if c1 != nil && c2 != nil {
-		defer c1.Close()
-		defer c2.Close()
+		defer func() { _ = c1.Close() }()
+		defer func() { _ = c2.Close() }()
 
 		pub, err := c1.Channel()
 		if err != nil {
@@ -1144,8 +1150,8 @@ func TestQuickPublishConsumeBigBody(t *testing.T) {
 	c2 := integrationConnection(t, "big-sub")
 
 	if c1 != nil && c2 != nil {
-		defer c1.Close()
-		defer c2.Close()
+		defer func() { _ = c1.Close() }()
+		defer func() { _ = c2.Close() }()
 
 		pub, err := c1.Channel()
 		if err != nil {
@@ -1193,7 +1199,7 @@ func TestQuickPublishConsumeBigBody(t *testing.T) {
 
 func TestIntegrationGetOk(t *testing.T) {
 	if c := integrationConnection(t, "getok"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		queue := "test.get-ok"
 		ch, _ := c.Channel()
@@ -1223,7 +1229,7 @@ func TestIntegrationGetOk(t *testing.T) {
 
 func TestIntegrationGetEmpty(t *testing.T) {
 	if c := integrationConnection(t, "getok"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		queue := "test.get-ok"
 		ch, _ := c.Channel()
@@ -1245,7 +1251,7 @@ func TestIntegrationGetEmpty(t *testing.T) {
 
 func TestIntegrationTxCommit(t *testing.T) {
 	if c := integrationConnection(t, "txcommit"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		queue := "test.tx.commit"
 		ch, _ := c.Channel()
@@ -1280,7 +1286,7 @@ func TestIntegrationTxCommit(t *testing.T) {
 
 func TestIntegrationTxRollback(t *testing.T) {
 	if c := integrationConnection(t, "txrollback"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		queue := "test.tx.rollback"
 		ch, _ := c.Channel()
@@ -1314,7 +1320,7 @@ func TestIntegrationTxRollback(t *testing.T) {
 
 func TestIntegrationReturn(t *testing.T) {
 	if c, ch := integrationQueue(t, "return"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ret := make(chan Return, 1)
 
@@ -1346,7 +1352,7 @@ func TestIntegrationCancel(t *testing.T) {
 	consumerTag := "test.cancel"
 
 	if c, ch := integrationQueue(t, queue); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		cancels := ch.NotifyCancel(make(chan string, 1))
 		consumeErr := make(chan error, 1)
@@ -1378,7 +1384,7 @@ func TestIntegrationCancel(t *testing.T) {
 
 func TestIntegrationConfirm(t *testing.T) {
 	if c, ch := integrationQueue(t, "confirm"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		confirms := ch.NotifyPublish(make(chan Confirmation, 1))
 
@@ -1404,7 +1410,7 @@ func TestIntegrationConfirm(t *testing.T) {
 // https://github.com/streadway/amqp/issues/61
 func TestRoundTripAllFieldValueTypes61(t *testing.T) {
 	if conn := integrationConnection(t, "issue61"); conn != nil {
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		timestamp := time.Unix(100000000, 0)
 
 		headers := Table{
@@ -1478,7 +1484,7 @@ func TestRoundTripAllFieldValueTypes61(t *testing.T) {
 // Relates to https://github.com/streadway/amqp/issues/60
 func TestDeclareArgsXMessageTTL(t *testing.T) {
 	if conn := integrationConnection(t, "declareTTL"); conn != nil {
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		ch, _ := conn.Channel()
 		args := Table{"x-message-ttl": int32(9000000)}
@@ -1496,7 +1502,7 @@ func TestDeclareArgsXMessageTTL(t *testing.T) {
 // Relates to https://github.com/streadway/amqp/issues/56
 func TestDeclareArgsRejectToDeadLetterQueue(t *testing.T) {
 	if conn := integrationConnection(t, "declareArgs"); conn != nil {
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		ex, q := "declareArgs", "declareArgs-deliveries"
 		dlex, dlq := ex+"-dead-letter", q+"-dead-letter"
@@ -1575,7 +1581,7 @@ func TestDeclareArgsRejectToDeadLetterQueue(t *testing.T) {
 // https://github.com/streadway/amqp/issues/48
 func TestDeadlockConsumerIssue48(t *testing.T) {
 	if conn := integrationConnection(t, "issue48"); conn != nil {
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		deadline := make(chan bool)
 		go func() {
@@ -1645,7 +1651,7 @@ func TestRepeatedChannelExceptionWithPublishAndMaxProcsIssue46(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		conn.Close()
+		_ = conn.Close()
 	})
 
 	for i := 0; i < 100; i++ {
@@ -1679,7 +1685,7 @@ func TestRepeatedChannelExceptionWithPublishAndMaxProcsIssue46(t *testing.T) {
 func TestChannelExceptionWithCloseIssue43(t *testing.T) {
 	conn := integrationConnection(t, "issue43")
 	if conn != nil {
-		t.Cleanup(func() { conn.Close() })
+		t.Cleanup(func() { _ = conn.Close() })
 
 		go func() {
 			for err := range conn.NotifyClose(make(chan *Error)) {
@@ -1719,7 +1725,7 @@ func TestChannelExceptionWithCloseIssue43(t *testing.T) {
 
 		// Receive or send the channel close method, the channel shuts down
 		// but this expects a channel.close-ok to be received.
-		c1.Close()
+		_ = c1.Close()
 
 		// This ensures that the 2nd channel is unaffected by the channel exception
 		// on channel 1.
@@ -1738,8 +1744,8 @@ func TestCorruptedMessageIssue7(t *testing.T) {
 	c2 := integrationConnection(t, "")
 
 	if c1 != nil && c2 != nil {
-		defer c1.Close()
-		defer c2.Close()
+		defer func() { _ = c1.Close() }()
+		defer func() { _ = c2.Close() }()
 
 		pub, err := c1.Channel()
 		if err != nil {
@@ -1789,7 +1795,7 @@ func TestCorruptedMessageIssue7(t *testing.T) {
 // https://github.com/streadway/amqp/issues/136
 func TestChannelCounterShouldNotPanicIssue136(t *testing.T) {
 	if c := integrationConnection(t, "issue136"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 		var wg sync.WaitGroup
 
 		// exceeds 65535 channels
@@ -1823,8 +1829,8 @@ func TestExchangeDeclarePrecondition(t *testing.T) {
 	c1 := integrationConnection(t, "exchange-double-declare")
 	c2 := integrationConnection(t, "exchange-double-declare-cleanup")
 	if c1 != nil && c2 != nil {
-		defer c1.Close()
-		defer c2.Close()
+		defer func() { _ = c1.Close() }()
+		defer func() { _ = c2.Close() }()
 
 		ch, err := c1.Channel()
 		if err != nil {
@@ -1877,7 +1883,7 @@ func TestExchangeDeclarePrecondition(t *testing.T) {
 
 func TestRabbitMQQueueTTLGet(t *testing.T) {
 	if c := integrationRabbitMQ(t, "ttl"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		queue := "test.rabbitmq-message-ttl"
 		channel, err := c.Channel()
@@ -1916,7 +1922,7 @@ func TestRabbitMQQueueTTLGet(t *testing.T) {
 
 func TestRabbitMQQueueNackMultipleRequeue(t *testing.T) {
 	if c := integrationRabbitMQ(t, "nack"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		if c.isCapable("basic.nack") {
 			queue := "test.rabbitmq-basic-nack"
@@ -1966,7 +1972,7 @@ func TestRabbitMQQueueNackMultipleRequeue(t *testing.T) {
 func TestConsumerCancelNotification(t *testing.T) {
 	c := integrationConnection(t, "consumer cancel notification")
 	if c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 		ch, err := c.Channel()
 		if err != nil {
 			t.Fatalf("got error on channel.open: %v", err)
@@ -2015,13 +2021,13 @@ func TestConcurrentChannelAndConnectionClose(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-starter
-			c.Close()
+			_ = c.Close()
 		}()
 
 		go func() {
 			defer wg.Done()
 			<-starter
-			ch.Close()
+			_ = ch.Close()
 		}()
 		close(starter)
 		wg.Wait()
@@ -2030,7 +2036,7 @@ func TestConcurrentChannelAndConnectionClose(t *testing.T) {
 
 func TestIntegrationGetNextPublishSeqNo(t *testing.T) {
 	if c := integrationConnection(t, "GetNextPublishSeqNo"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, err := c.Channel()
 		if err != nil {
@@ -2064,7 +2070,7 @@ func TestIntegrationGetNextPublishSeqNo(t *testing.T) {
 
 func TestIntegrationGetNextPublishSeqNoRace(t *testing.T) {
 	if c := integrationConnection(t, "GetNextPublishSeqNoRace"); c != nil {
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 
 		ch, err := c.Channel()
 		if err != nil {
@@ -2136,8 +2142,8 @@ func TestShouldNotWaitAfterConnectionClosedIssue44(t *testing.T) {
 		t.Fatalf("PublishWithDeferredConfirm error: %v", err)
 	}
 
-	ch.Close()
-	conn.Close()
+	_ = ch.Close()
+	_ = conn.Close()
 
 	ack := confirm.Wait()
 
@@ -2149,7 +2155,7 @@ func TestShouldNotWaitAfterConnectionClosedIssue44(t *testing.T) {
 func TestDeliveryAckShouldReturnSpecificErrorOnClosedChannel(t *testing.T) {
 	// setup
 	c, ch := integrationQueue(t, t.Name())
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	err := ch.Publish(DefaultExchange, t.Name(), false, false, Publishing{
 		Body: []byte("this is a test"),
 	})
@@ -2220,8 +2226,8 @@ func TestShouldNotWaitAfterConnectionClosedNewChannelCreatedIssue11(t *testing.T
 		t.Fatalf("PublishWithDeferredConfirm error: %v", err)
 	}
 
-	ch.Close()
-	conn.Close()
+	_ = ch.Close()
+	_ = conn.Close()
 
 	_, err = conn.Channel()
 	if err == nil {
@@ -2235,8 +2241,8 @@ func TestAckShouldNotCloseChannel_GH296(t *testing.T) {
 	const messageCount = 10
 	queueName := t.Name()
 	c, ch := integrationQueue(t, queueName)
-	defer ch.Close()
-	defer c.Close()
+	defer func() { _ = ch.Close() }()
+	defer func() { _ = c.Close() }()
 
 	notifyConnClosed := make(chan *Error)
 	c.NotifyClose(notifyConnClosed)

--- a/read.go
+++ b/read.go
@@ -155,6 +155,8 @@ func readTimestamp(r io.Reader) (v time.Time, err error) {
 's': int16
 't': bool
 'x': []byte
+'u': uint16 (identical on the wire to int16)
+'i': uint32 (identical on the wire to int32)
 */
 func readField(r io.Reader) (v interface{}, err error) {
 	var typ byte
@@ -214,6 +216,20 @@ func readField(r io.Reader) (v interface{}, err error) {
 
 	case 'd':
 		var value float64
+		if err = binary.Read(r, binary.BigEndian, &value); err != nil {
+			return
+		}
+		return value, nil
+
+	case 'u':
+		var value uint16
+		if err = binary.Read(r, binary.BigEndian, &value); err != nil {
+			return
+		}
+		return value, nil
+
+	case 'i':
+		var value uint32
 		if err = binary.Read(r, binary.BigEndian, &value); err != nil {
 			return
 		}

--- a/read.go
+++ b/read.go
@@ -431,7 +431,7 @@ func (r *reader) parseBodyFrame(channel uint16, size uint32) (frame frame, err e
 	return bf, nil
 }
 
-var errHeartbeatPayload = errors.New("Heartbeats should not have a payload")
+var errHeartbeatPayload = errors.New("heartbeats should not have a payload")
 
 func (r *reader) parseHeartbeatFrame(channel uint16, size uint32) (frame frame, err error) {
 	hf := &heartbeatFrame{

--- a/read_write_test.go
+++ b/read_write_test.go
@@ -1,0 +1,189 @@
+package amqp091
+
+import (
+	"bytes"
+	"encoding/binary"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fieldTypeTest struct {
+	fieldType byte
+	value     interface{}
+	encoded   string
+}
+
+// This function constructs a header frame given a payload string, using some sane defaults.
+// A bit of reimplementing the code under test here, but it's not worth manually computing payload sizes for every
+// test case; we primarily care about testing the encodings themselves.
+func makeHeader(key string, encodedField string) string {
+	payload := string([]byte{byte(len(key))}) + key + encodedField
+	size := 18 + len(payload) // 18 is a magic number derived from the structure of our header frame
+	tableLen := len(payload)
+	sizeBytes := make([]byte, 4)
+	tableLenBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(sizeBytes, uint32(size))
+	binary.BigEndian.PutUint32(tableLenBytes, uint32(tableLen))
+	p := "\x02" + // frame type: header
+		"\x00\x01" + // channel: 1
+		string(sizeBytes) +
+		"\x00\x3C" + // ClassId: 60 (basic)
+		"\x00\x00" + // Weight: 0
+		"\x00\x00\x00\x00\x00\x00\x00\x04" + // Body size: 4 bytes (irrelevant)
+		"\x20\x00" + // Property flags: 8192 (headers present)
+		string(tableLenBytes) +
+		payload +
+		"\xCE"
+	return p
+}
+
+// Happy case tests
+func TestReadWriteAllFieldTypes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("excessive allocation")
+	}
+
+	// Each of these test cases use hex to express their encoded values for explicitness. The sole exception is the
+	// first character which is the field type itself, and cases where the field type is a string, in which case the
+	// string is directly embedded in the encoded form for readability.
+	fieldTests := []fieldTypeTest{
+		// short strings, max 255 bytes
+		{'S', "bar", "S\x00\x00\x00\x03bar"},
+		{'S', "iamalongerstringbutstillunderthe255bytelimit", "S\x00\x00\x00\x2Ciamalongerstringbutstillunderthe255bytelimit"},
+		// int32
+		{'I', int32(-2147483648), "I\x80\x00\x00\x00"},
+		{'I', int32(42), "I\x00\x00\x00\x2A"},
+		{'I', int32(2147483647), "I\x7F\xFF\xFF\xFF"},
+		// timestamp
+		{'T', time.Unix(1234567890, 0), "T\x00\x00\x00\x00I\x96\x02\xd2"},
+		// int8
+		{'b', int8(-5), "b\xfb"},
+		{'b', int8(5), "b\x05"},
+		// byte
+		{'B', byte(0x7f), "B\x7f"},
+		// int16
+		{'s', int16(-1234), "s\xfb\x2e"},
+		{'s', int16(1234), "s\x04\xd2"},
+		// int64
+		{'l', int64(123456789012345), "l\x00\x00\x70\x48\x86\x0D\xDF\x79"},
+		{'l', int64(-123456789012345), "l\xff\xff\x8f\xb7\x79\xf2\x20\x87"},
+		// float32
+		{'f', float32(3.14), "f\x40\x48\xf5\xc3"},
+		// float64
+		{'d', float64(2.71828), "d\x40\x05\xbf\x09\x95\xaa\xf7\x90"},
+		// decimal
+		{'D', Decimal{Scale: 2, Value: 314}, "D\x02\x00\x00\x01\x3A"},
+		// array
+		{'A', []interface{}{"foo", int32(1)}, "A\x00\x00\x00\x0d\x53\x00\x00\x00\x03\x66\x6F\x6F\x49\x00\x00\x00\x01"},
+		// table
+		{'F', Table{"baz": "qux"}, "F\x00\x00\x00\x0c\x03bazS\x00\x00\x00\x03qux"},
+		// byte array
+		{'x', []byte{0x01, 0x02, 0x03}, "x\x00\x00\x00\x03\x01\x02\x03"},
+		// boolean
+		{'t', true, "t\x01"},
+		{'t', false, "t\x00"},
+		// void
+		{'V', nil, "V"},
+		// uint16
+		{'u', uint16(12345), "u\x30\x39"},
+		{'u', uint16(65535), "u\xff\xff"},
+		{'u', uint16(0), "u\x00\x00"},
+		// uint32
+		{'i', uint32(12345), "i\x00\x00\x30\x39"},
+		{'i', uint32(4294967295), "i\xff\xff\xff\xff"},
+		{'i', uint32(0), "i\x00\x00\x00\x00"},
+	}
+
+	// Run through each test case and exercise both read and write pathways, ensuring the string value and the encoded
+	// value always match.
+	for idx, ft := range fieldTests {
+		input := makeHeader("foo", ft.encoded)
+		t.Run(string(ft.fieldType), func(t *testing.T) {
+			// Test reading
+			r := reader{strings.NewReader(input)}
+			frame, err := r.ReadFrame()
+			if err != nil {
+				t.Errorf("scenario %d: unexpected error for field type %q: %v", idx, ft.fieldType, err)
+				return
+			}
+			hf, ok := frame.(*headerFrame)
+			if !ok {
+				t.Errorf("scenario %d: frame is not a headerFrame: %#v", idx, frame)
+				return
+			}
+			got := hf.Properties.Headers["foo"]
+			want := ft.value
+			// Special handling for comparing equality of []byte and time.Time
+			switch v := want.(type) {
+			case []byte:
+				if g, ok := got.([]byte); !ok || !bytes.Equal(g, v) {
+					t.Errorf("scenario %d: unexpected []byte value: got %#v, want %#v", idx, got, v)
+				}
+			case time.Time:
+				if g, ok := got.(time.Time); !ok || !g.Equal(v) {
+					t.Errorf("scenario %d: unexpected time.Time value: got %#v, want %#v", idx, got, v)
+				}
+			default:
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("scenario %d: unexpected value: got %#v, want %#v", idx, got, want)
+				}
+			}
+
+			// Test writing
+			var buf bytes.Buffer
+			hf = &headerFrame{
+				ChannelId: 1,
+				ClassId:   60,
+				weight:    0,
+				Size:      4,
+				Properties: properties{
+					Headers: Table{
+						"foo": ft.value,
+					},
+				},
+			}
+			err = hf.write(&buf)
+			if err != nil {
+				t.Errorf("scenario %d: unexpected error for field type %q: %v", idx, ft.fieldType, err)
+				return
+			}
+			writeGot := buf.Bytes()
+			writeWant := []byte(input)
+			if !bytes.Equal(writeGot, writeWant) {
+				t.Errorf("scenario %d: unexpected encoding for field type %q: got: %x want: %x", idx, ft.fieldType, writeGot, writeWant)
+			}
+		})
+	}
+}
+
+// We should throw if we encounter something on the wire that does not match our field type expectations.
+// Note: No need to test bad writes as Go will enforce that you can't do uint16(65536) for example, it's too big to fit.
+func TestReadWriteAllFieldTypesBadParse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("excessive allocation")
+	}
+
+	fieldTests := []fieldTypeTest{
+		// uint16
+		{'u', uint16(12345), "u\x30\x39\x40"}, // Too many bytes
+		{'u', uint16(12345), "u\x30"},         // Too few bytes
+		// uint32
+		{'i', uint32(12345), "i\x00\x00\x30\x39\x40"}, // Too many bytes
+		{'i', uint32(12345), "i\x00\x00\x30"},         // Too few bytes
+	}
+
+	for idx, ft := range fieldTests {
+		input := makeHeader("foo", ft.encoded)
+		t.Run(string(ft.fieldType), func(t *testing.T) {
+			// Test reading
+			r := reader{strings.NewReader(input)}
+			_, err := r.ReadFrame()
+			if err == nil {
+				t.Errorf("scenario %d: missing expected error for field type %q: %v", idx, ft.fieldType, err)
+				return
+			}
+		})
+	}
+}

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -62,7 +62,7 @@ func ExampleConnection_reconnect() {
 			fmt.Println("err publisher setup:", err)
 			return
 		}
-		defer con.Close()
+		defer func() { _ = con.Close() }()
 
 		// Purge the queue from the publisher side to establish initial state
 		if _, err := pub.QueuePurge(queue, false); err != nil {
@@ -99,7 +99,9 @@ func ExampleConnection_reconnect() {
 
 				// Simulate an error like a server restart, loss of route or operator
 				// intervention that results in the connection terminating
-				go conn.Close()
+				go func() {
+					_ = conn.Close()
+				}()
 			}
 		}
 	} else {

--- a/shared_test.go
+++ b/shared_test.go
@@ -24,8 +24,8 @@ func (p pipe) Write(b []byte) (int, error) {
 }
 
 func (p pipe) Close() error {
-	p.r.Close()
-	p.w.Close()
+	_ = p.r.Close()
+	_ = p.w.Close()
 	return nil
 }
 

--- a/spec091.go
+++ b/spec091.go
@@ -2830,7 +2830,7 @@ func (r *reader) parseMethodFrame(channel uint16, size uint32) (f frame, err err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, fmt.Errorf("bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 		}
 
 	case 20: // channel
@@ -2885,7 +2885,7 @@ func (r *reader) parseMethodFrame(channel uint16, size uint32) (f frame, err err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, fmt.Errorf("bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 		}
 
 	case 40: // exchange
@@ -2956,7 +2956,7 @@ func (r *reader) parseMethodFrame(channel uint16, size uint32) (f frame, err err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, fmt.Errorf("bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 		}
 
 	case 50: // queue
@@ -3043,7 +3043,7 @@ func (r *reader) parseMethodFrame(channel uint16, size uint32) (f frame, err err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, fmt.Errorf("bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 		}
 
 	case 60: // basic
@@ -3194,7 +3194,7 @@ func (r *reader) parseMethodFrame(channel uint16, size uint32) (f frame, err err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, fmt.Errorf("bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 		}
 
 	case 90: // tx
@@ -3249,7 +3249,7 @@ func (r *reader) parseMethodFrame(channel uint16, size uint32) (f frame, err err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, fmt.Errorf("bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 		}
 
 	case 85: // confirm
@@ -3272,11 +3272,11 @@ func (r *reader) parseMethodFrame(channel uint16, size uint32) (f frame, err err
 			mf.Method = method
 
 		default:
-			return nil, fmt.Errorf("Bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
+			return nil, fmt.Errorf("bad method frame, unknown method %d for class %d", mf.MethodId, mf.ClassId)
 		}
 
 	default:
-		return nil, fmt.Errorf("Bad method frame, unknown class %d", mf.ClassId)
+		return nil, fmt.Errorf("bad method frame, unknown class %d", mf.ClassId)
 	}
 
 	return mf, nil

--- a/tls_test.go
+++ b/tls_test.go
@@ -111,7 +111,9 @@ func TestTlsConfigFromUriPushdownServerNameIndication(t *testing.T) {
 // Tests opening a connection of a TLS enabled socket server
 func TestTLSHandshake(t *testing.T) {
 	srv := startTLSServer(t, tlsServerConfig(t))
-	defer srv.Close()
+	defer func() {
+		_ = srv.Close()
+	}()
 
 	success := make(chan bool)
 	errs := make(chan error, 3)
@@ -123,7 +125,7 @@ func TestTLSHandshake(t *testing.T) {
 		case session := <-srv.Sessions:
 			session.connectionOpen()
 			session.connectionClose()
-			session.S.Close()
+			_ = session.S.Close()
 		}
 	}()
 
@@ -133,7 +135,9 @@ func TestTLSHandshake(t *testing.T) {
 			errs <- fmt.Errorf("expected to open a TLS connection, got err: %v", err)
 			return
 		}
-		defer c.Close()
+		defer func() {
+			_ = c.Close()
+		}()
 
 		if st := c.ConnectionState(); !st.HandshakeComplete {
 			errs <- fmt.Errorf("expected to complete a TLS handshake, TLS connection state: %+v", st)

--- a/write.go
+++ b/write.go
@@ -288,6 +288,8 @@ func writeLongstr(w io.Writer, s string) (err error) {
 's': int16
 't': bool
 'x': []byte
+'u': uint16 (identical on the wire to int16)
+'i': uint32 (identical on the wire to int32)
 */
 func writeField(w io.Writer, value interface{}) (err error) {
 	var buf [9]byte
@@ -318,6 +320,11 @@ func writeField(w io.Writer, value interface{}) (err error) {
 		binary.BigEndian.PutUint16(buf[1:3], uint16(v))
 		enc = buf[:3]
 
+	case uint16:
+		buf[0] = 'u'
+		binary.BigEndian.PutUint16(buf[1:3], uint16(v))
+		enc = buf[:3]
+
 	case int:
 		buf[0] = 'I'
 		binary.BigEndian.PutUint32(buf[1:5], uint32(v))
@@ -325,6 +332,11 @@ func writeField(w io.Writer, value interface{}) (err error) {
 
 	case int32:
 		buf[0] = 'I'
+		binary.BigEndian.PutUint32(buf[1:5], uint32(v))
+		enc = buf[:5]
+
+	case uint32:
+		buf[0] = 'i'
 		binary.BigEndian.PutUint32(buf[1:5], uint32(v))
 		enc = buf[:5]
 


### PR DESCRIPTION
u and i are field types in the AMQP-0.9.1 spec that correspond to uint16 and uint32 respectively; currently this library throws when encountering these field types. This change adds full support for reading and writing them and resolves https://github.com/rabbitmq/amqp091-go/issues/302. It also includes a test suite exercising all field types in both the read and write pathways.

This change also includes some housekeeping updates to satisfy the linter, which was no longer passing due to issues like not handling returned errors. However, in the interest of full backwards compatibility, this change does not actually return those errors - instead it swallows them with `_` to preserve existing behavior.

Apart from the new field types, the only potential breaking change is lowercasing a few error messages which started with uppercase letters.