### PR TITLE
Change the error type for ErrDeliveryNotInitialized

### DIFF
--- a/delivery.go
+++ b/delivery.go
@@ -6,11 +6,8 @@
 package amqp091
 
 import (
-	"errors"
 	"time"
 )
-
-var ErrDeliveryNotInitialized = errors.New("delivery not initialized. Channel is probably closed")
 
 // Acknowledger notifies the server of successful or failed consumption of
 // deliveries via identifier found in the Delivery.DeliveryTag field.

--- a/delivery_test.go
+++ b/delivery_test.go
@@ -7,7 +7,6 @@ package amqp091
 
 import (
 	"errors"
-	"strings"
 	"testing"
 )
 
@@ -29,10 +28,6 @@ func TestAckZeroValueAcknowledgerDoesNotPanic(t *testing.T) {
 	if !errors.Is(err, ErrDeliveryNotInitialized) {
 		t.Fatalf("expected '%v' got '%v'", ErrDeliveryNotInitialized, err)
 	}
-	expectedErrMessage := "delivery not initialized. Channel is probably closed"
-	if !strings.EqualFold(err.Error(), expectedErrMessage) {
-		t.Errorf("expected '%s' got '%s'", expectedErrMessage, err)
-	}
 }
 
 func TestNackZeroValueAcknowledgerDoesNotPanic(t *testing.T) {
@@ -44,10 +39,6 @@ func TestNackZeroValueAcknowledgerDoesNotPanic(t *testing.T) {
 	if !errors.Is(err, ErrDeliveryNotInitialized) {
 		t.Fatalf("expected '%v' got '%v'", ErrDeliveryNotInitialized, err)
 	}
-	expectedErrMessage := "delivery not initialized. Channel is probably closed"
-	if !strings.EqualFold(err.Error(), expectedErrMessage) {
-		t.Errorf("expected '%s' got '%s'", expectedErrMessage, err)
-	}
 }
 
 func TestRejectZeroValueAcknowledgerDoesNotPanic(t *testing.T) {
@@ -58,9 +49,5 @@ func TestRejectZeroValueAcknowledgerDoesNotPanic(t *testing.T) {
 	}
 	if !errors.Is(err, ErrDeliveryNotInitialized) {
 		t.Fatalf("expected '%v' got '%v'", ErrDeliveryNotInitialized, err)
-	}
-	expectedErrMessage := "delivery not initialized. Channel is probably closed"
-	if !strings.EqualFold(err.Error(), expectedErrMessage) {
-		t.Errorf("expected '%s' got '%s'", expectedErrMessage, err)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -27,6 +27,9 @@ var (
 	// ErrClosed is returned when the channel or connection is not open
 	ErrClosed = &Error{Code: ChannelError, Reason: "channel/connection is not open"}
 
+	// ErrDeliveryNotInitialized Is returned when the delivery's Acknowledger is not initialized, likely the channel is closed.
+	ErrDeliveryNotInitialized = &Error{Code: ChannelError, Reason: "delivery not initialized. Channel is probably closed"}
+
 	// ErrChannelMax is returned when Connection.Channel has been called enough
 	// times that all channel IDs have been exhausted in the client or the
 	// server.


### PR DESCRIPTION
We should catch the error that Channel/Connection is closed and reconnect. Better to catch the error by the same code: ChannelError.
