### PR TITLE
feat: add MIME types constants for  content types

### DIFF
--- a/types.go
+++ b/types.go
@@ -23,6 +23,21 @@ const (
 	ExchangeHeaders = "headers"
 )
 
+// MIME types constants
+const (
+	MimeTextPlain                  = "text/plain"
+	MimeApplicationJSON            = "application/json"
+	MimeApplicationOctetStream     = "application/octet-stream"
+	MimeApplicationXML             = "application/xml"
+	MimeTextXML                    = "text/xml"
+	MimeApplicationProtobuf        = "application/protobuf"
+	MimeApplicationXProtobuf       = "application/x-protobuf"
+	MimeApplicationMsgPack         = "application/msgpack"
+	MimeApplicationAvro            = "application/avro"
+	MimeApplicationCloudEventsJSON = "application/cloudevents+json"
+	MimeApplicationFormURLEncoded  = "application/x-www-form-urlencoded"
+)
+
 var (
 	// ErrClosed is returned when the channel or connection is not open
 	ErrClosed = &Error{Code: ChannelError, Reason: "channel/connection is not open"}


### PR DESCRIPTION
Add MIME type constants for content type

This PR introduces a set of well-known MIME type constants to be used when publishing messages to RabbitMQ.

The goal is to avoid hard-coded strings when setting content_type, improving type safety, readability, and consistency across producers and consumers.

Although RabbitMQ does not enforce MIME types, content type is a commonly used AMQP property and is often relied upon by consumers for deserialization and routing logic. Providing constants helps prevent typos and encourages reuse of standardized values.

This change is fully backward-compatible, as the underlying API still accepts raw strings. The constants are purely additive and optional.

If you need to add more MIME types or remove any that don't make sense, please let me know.

### Example 
```go

type res struct {
	Msg string `json:"msg"`
}

body := res{
		Msg: "hello world",
	}

	b, _ := json.Marshal(body)

ch.PublishWithContext(ctx, "", queue.Name, false, false, amqp.Publishing{
		ContentType: amqp.MimeApplicationJSON, // application/json
		Body:        b,
	})
```