### PR TITLE
fix: modernize lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,18 @@ run:
     - integration
 linters:
   default: standard
+  enable:
+    - modernize
   disable:
     - testpackage
     - testableexamples
     - godox
     - gochecknoinits
+  settings:
+    modernize:
+      disable:
+        # enable when
+        - minmax
   exclusions:
     generated: lax
     presets:

--- a/connection_test.go
+++ b/connection_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package amqp091
 
@@ -255,7 +254,7 @@ func TestReaderGoRoutineTerminatesWhenMsgIsProcessedDuringClose(t *testing.T) {
 	c := integrationConnection(t, t.Name())
 
 	var wg sync.WaitGroup
-	startSigCh := make(chan interface{})
+	startSigCh := make(chan any)
 
 	for i := 0; i < routines; i++ {
 		wg.Add(1)

--- a/integration_test.go
+++ b/integration_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build integration
-// +build integration
 
 package amqp091
 
@@ -1408,8 +1407,8 @@ func TestRoundTripAllFieldValueTypes61(t *testing.T) {
 		timestamp := time.Unix(100000000, 0)
 
 		headers := Table{
-			"A": []interface{}{
-				[]interface{}{"nested array", int32(3)},
+			"A": []any{
+				[]any{"nested array", int32(3)},
 				Decimal{2, 1},
 				Table{"S": "nested table in array"},
 				int32(2 << 20),
@@ -1561,7 +1560,7 @@ func TestDeclareArgsRejectToDeadLetterQueue(t *testing.T) {
 			} else {
 				// pass if we've parsed an array
 				if v, ok := d.Headers["x-death"]; ok {
-					if _, ok := v.([]interface{}); ok {
+					if _, ok := v.([]any); ok {
 						return
 					}
 				}

--- a/log.go
+++ b/log.go
@@ -5,7 +5,7 @@
 package amqp091
 
 type Logging interface {
-	Printf(format string, v ...interface{})
+	Printf(format string, v ...any)
 }
 
 var Logger Logging = NullLogger{}
@@ -18,5 +18,5 @@ func SetLogger(logger Logging) {
 
 type NullLogger struct{}
 
-func (l NullLogger) Printf(format string, v ...interface{}) {
+func (l NullLogger) Printf(format string, v ...any) {
 }

--- a/read.go
+++ b/read.go
@@ -140,7 +140,7 @@ func readTimestamp(r io.Reader) (v time.Time, err error) {
 }
 
 /*
-'A': []interface{}
+'A': any
 'D': Decimal
 'F': Table
 'I': int32
@@ -156,7 +156,7 @@ func readTimestamp(r io.Reader) (v time.Time, err error) {
 't': bool
 'x': []byte
 */
-func readField(r io.Reader) (v interface{}, err error) {
+func readField(r io.Reader) (v any, err error) {
 	var typ byte
 	if err = binary.Read(r, binary.BigEndian, &typ); err != nil {
 		return
@@ -275,7 +275,7 @@ func readTable(r io.Reader) (table Table, err error) {
 
 	for nested.Len() > 0 {
 		var key string
-		var value interface{}
+		var value any
 
 		if key, err = readShortstr(&nested); err != nil {
 			return
@@ -291,7 +291,7 @@ func readTable(r io.Reader) (table Table, err error) {
 	return
 }
 
-func readArray(r io.Reader) (arr []interface{}, err error) {
+func readArray(r io.Reader) (arr []any, err error) {
 	var size uint32
 
 	if err = binary.Read(r, binary.BigEndian, &size); err != nil {
@@ -300,7 +300,7 @@ func readArray(r io.Reader) (arr []interface{}, err error) {
 
 	var (
 		lim   = &io.LimitedReader{R: r, N: int64(size)}
-		field interface{}
+		field any
 	)
 
 	for {

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -83,7 +83,7 @@ func ExampleConnection_reconnect() {
 			// Simulate a producer on a different connection showing that consumers
 			// continue where they were left off after each reconnect.
 			if err := pub.PublishWithContext(context.TODO(), "", queue, false, false, amqp.Publishing{
-				Body: []byte(fmt.Sprintf("%d", i)),
+				Body: fmt.Appendf(nil, "%d", i),
 			}); err != nil {
 				fmt.Println("err publish:", err)
 				return

--- a/types.go
+++ b/types.go
@@ -393,7 +393,7 @@ const (
 //	amqp.Decimal
 //	amqp.Table
 //	[]byte
-//	[]interface{} - containing above types
+//	[]any - containing above types
 //
 // Functions taking a table will immediately fail when the table contains a
 // value of an unsupported type.
@@ -404,14 +404,14 @@ const (
 // Use a type assertion when reading values from a table for type conversion.
 //
 // RabbitMQ expects int32 for integer values.
-type Table map[string]interface{}
+type Table map[string]any
 
-func validateField(f interface{}) error {
+func validateField(f any) error {
 	switch fv := f.(type) {
 	case nil, bool, byte, int8, int, int16, int32, int64, float32, float64, string, []byte, Decimal, time.Time:
 		return nil
 
-	case []interface{}:
+	case []any:
 		for _, v := range fv {
 			if err := validateField(v); err != nil {
 				return fmt.Errorf("in array %s", err)

--- a/types_test.go
+++ b/types_test.go
@@ -64,7 +64,7 @@ func TestErrorMessage(t *testing.T) {
 
 func TestValidateField(t *testing.T) {
 	// Test case for simple types
-	simpleTypes := []interface{}{
+	simpleTypes := []any{
 		nil, true, byte(1), int8(1), 10, int16(10), int32(10), int64(10),
 		float32(1.0), float64(1.0), "string", []byte("byte slice"),
 		Decimal{Scale: 2, Value: 12345},
@@ -76,19 +76,19 @@ func TestValidateField(t *testing.T) {
 		}
 	}
 
-	// Test case for []interface{}
-	sliceTypes := []interface{}{
+	// Test case for []any
+	sliceTypes := []any{
 		"string", 10, float64(1.0), Decimal{Scale: 2, Value: 12345},
 	}
 	if err := validateField(sliceTypes); err != nil {
-		t.Errorf("validateField failed for []interface{}: %s", err)
+		t.Errorf("validateField failed for []any: %s", err)
 	}
 
 	// Test case for Table
 	tableType := Table{
 		"key1": "value1",
 		"key2": 10,
-		"key3": []interface{}{"nested string", 20},
+		"key3": []any{"nested string", 20},
 	}
 	if err := validateField(tableType); err != nil {
 		t.Errorf("validateField failed for Table: %s", err)

--- a/write.go
+++ b/write.go
@@ -273,7 +273,7 @@ func writeLongstr(w io.Writer, s string) (err error) {
 }
 
 /*
-'A': []interface{}
+'A': []any
 'D': Decimal
 'F': Table
 'I': int32
@@ -289,7 +289,7 @@ func writeLongstr(w io.Writer, s string) (err error) {
 't': bool
 'x': []byte
 */
-func writeField(w io.Writer, value interface{}) (err error) {
+func writeField(w io.Writer, value any) (err error) {
 	var buf [9]byte
 	var enc []byte
 
@@ -354,7 +354,7 @@ func writeField(w io.Writer, value interface{}) (err error) {
 		binary.BigEndian.PutUint32(buf[1:5], uint32(len(v)))
 		enc = append(buf[:5], []byte(v)...)
 
-	case []interface{}: // field-array
+	case []any: // field-array
 		buf[0] = 'A'
 
 		sec := new(bytes.Buffer)


### PR DESCRIPTION
This PR enables `modernize` linter and fixes lint issues.

`minmax` is disabled because it produces wrong code on Go 1.20. See https://github.com/golang/go/issues/78250