### PR TITLE
refactor: simplify with atomic types

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -38,8 +38,8 @@ type Channel struct {
 
 	id uint16
 
-	// closed is set to 1 when the channel has been closed - see Channel.send()
-	closed int32
+	// closed is set to true when the channel has been closed - see Channel.send()
+	closed atomic.Bool
 	close  chan struct{}
 
 	// true when we will never notify again
@@ -92,7 +92,7 @@ func newChannel(c *Connection, id uint16) *Channel {
 
 // Signal that from now on, Channel.send() should call Channel.sendClosed()
 func (ch *Channel) setClosed() {
-	atomic.StoreInt32(&ch.closed, 1)
+	ch.closed.Store(true)
 }
 
 // shutdown is called by Connection after the channel has been removed from the
@@ -488,7 +488,7 @@ func (ch *Channel) Close() error {
 // IsClosed returns true if the channel is marked as closed, otherwise false
 // is returned.
 func (ch *Channel) IsClosed() bool {
-	return atomic.LoadInt32(&ch.closed) == 1
+	return ch.closed.Load()
 }
 
 /*

--- a/connection.go
+++ b/connection.go
@@ -122,7 +122,7 @@ type Connection struct {
 	Properties Table    // Server properties
 	Locales    []string // Server locales
 
-	closed int32 // Will be 1 if the connection is closed, 0 otherwise. Should only be accessed as atomic
+	closed atomic.Bool // Will be true if the connection is closed, false otherwise.
 }
 
 type readDeadliner interface {
@@ -486,7 +486,7 @@ func (c *Connection) closeWith(err *Error) error {
 // IsClosed returns true if the connection is marked as closed, otherwise false
 // is returned.
 func (c *Connection) IsClosed() bool {
-	return atomic.LoadInt32(&c.closed) == 1
+	return c.closed.Load()
 }
 
 // setDeadline is a wrapper to type assert Connection.conn and set an I/O
@@ -598,7 +598,7 @@ func (c *Connection) flush() (err error) {
 }
 
 func (c *Connection) shutdown(err *Error) {
-	atomic.StoreInt32(&c.closed, 1)
+	c.closed.Store(true)
 
 	c.destructor.Do(func() {
 		c.m.Lock()

--- a/consumers.go
+++ b/consumers.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 )
 
-var consumerSeq uint64
+var consumerSeq atomic.Uint64
 
 const consumerTagLengthMax = 0xFF // see writeShortstr
 
@@ -23,7 +23,7 @@ func uniqueConsumerTag() string {
 func commandNameBasedUniqueConsumerTag(commandName string) string {
 	tagPrefix := "ctag-"
 	tagInfix := commandName
-	tagSuffix := "-" + strconv.FormatUint(atomic.AddUint64(&consumerSeq, 1), 10)
+	tagSuffix := "-" + strconv.FormatUint(consumerSeq.Add(1), 10)
 
 	if len(tagPrefix)+len(tagInfix)+len(tagSuffix) > consumerTagLengthMax {
 		tagInfix = "streadway/amqp"


### PR DESCRIPTION
This PR simplifies atomic state handling by replacing legacy function-based atomics with typed atomic fields and methods.