### PR TITLE
Eliminate race condition in Connection.Close() and related methods

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"io"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
@@ -905,5 +906,52 @@ func TestLeakClosedConsumersIssue264(t *testing.T) {
 
 	if _, open := <-consumer; open {
 		t.Fatalf("expected deliveries channel to be closed immediately when the connection is closed so not to leak the bufferDeliveries goroutine")
+	}
+}
+
+func TestConcurrentClose_OnlyOneCloseFrameSent(t *testing.T) {
+	const goroutines = 10
+
+	rwc, srv := newSession(t)
+	t.Cleanup(func() { rwc.Close() })
+
+	go func() {
+		srv.connectionOpen()
+		srv.connectionClose()
+	}()
+
+	c, err := Open(rwc, defaultConfig())
+	if err != nil {
+		t.Fatalf("could not create connection: %v (%s)", c, err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	start := make(chan struct{})
+	errs := make([]error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errs[i] = c.Close()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	var nilCount int
+	for _, err := range errs {
+		switch err {
+		case nil:
+			nilCount++
+		case ErrClosed:
+			// expected for goroutines that did not win the closeOnce race
+		default:
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	if nilCount != 1 {
+		t.Errorf("expected exactly 1 successful close, got %d", nilCount)
 	}
 }

--- a/connection.go
+++ b/connection.go
@@ -93,8 +93,8 @@ func NewConnectionProperties() Table {
 // multiplexed on this channel.  There must always be active receivers for
 // every asynchronous message on this connection.
 type Connection struct {
-	destructor sync.Once  // shutdown once
-	closeOnce  sync.Once  // close handshake once
+	destructor sync.Once // teardown: notify listeners, close channels and the socket
+	closeOnce  sync.Once // handshake: send one `connection.close` frame
 	sendM      sync.Mutex // conn writer mutex
 	m          sync.Mutex // struct field mutex
 

--- a/connection.go
+++ b/connection.go
@@ -93,8 +93,8 @@ func NewConnectionProperties() Table {
 // multiplexed on this channel.  There must always be active receivers for
 // every asynchronous message on this connection.
 type Connection struct {
-	destructor sync.Once // teardown: notify listeners, close channels and the socket
-	closeOnce  sync.Once // handshake: send one `connection.close` frame
+	destructor sync.Once  // teardown: notify listeners, close channels and the socket
+	closeOnce  sync.Once  // handshake: send one `connection.close` frame
 	sendM      sync.Mutex // conn writer mutex
 	m          sync.Mutex // struct field mutex
 

--- a/connection.go
+++ b/connection.go
@@ -94,6 +94,7 @@ func NewConnectionProperties() Table {
 // every asynchronous message on this connection.
 type Connection struct {
 	destructor sync.Once  // shutdown once
+	closeOnce  sync.Once  // close handshake once
 	sendM      sync.Mutex // conn writer mutex
 	m          sync.Mutex // struct field mutex
 
@@ -423,14 +424,23 @@ func (c *Connection) Close() error {
 		return ErrClosed
 	}
 
-	defer c.shutdown(nil)
-	return c.call(
-		&connectionClose{
-			ReplyCode: replySuccess,
-			ReplyText: "kthxbai",
-		},
-		&connectionCloseOk{},
-	)
+	var handshakeErr error
+	var initiated bool
+	c.closeOnce.Do(func() {
+		initiated = true
+		defer c.shutdown(nil)
+		handshakeErr = c.call(
+			&connectionClose{
+				ReplyCode: replySuccess,
+				ReplyText: "kthxbai",
+			},
+			&connectionCloseOk{},
+		)
+	})
+	if !initiated {
+		return ErrClosed
+	}
+	return handshakeErr
 }
 
 // CloseDeadline requests and waits for the response to close this AMQP connection.
@@ -451,20 +461,27 @@ func (c *Connection) CloseDeadline(deadline time.Time) error {
 		return ErrClosed
 	}
 
-	defer c.shutdown(nil)
-
-	err := c.setDeadline(deadline)
-	if err != nil {
-		return err
+	var handshakeErr error
+	var initiated bool
+	c.closeOnce.Do(func() {
+		initiated = true
+		defer c.shutdown(nil)
+		if err := c.setDeadline(deadline); err != nil {
+			handshakeErr = err
+			return
+		}
+		handshakeErr = c.call(
+			&connectionClose{
+				ReplyCode: replySuccess,
+				ReplyText: "kthxbai",
+			},
+			&connectionCloseOk{},
+		)
+	})
+	if !initiated {
+		return ErrClosed
 	}
-
-	return c.call(
-		&connectionClose{
-			ReplyCode: replySuccess,
-			ReplyText: "kthxbai",
-		},
-		&connectionCloseOk{},
-	)
+	return handshakeErr
 }
 
 func (c *Connection) closeWith(err *Error) error {
@@ -472,15 +489,23 @@ func (c *Connection) closeWith(err *Error) error {
 		return ErrClosed
 	}
 
-	defer c.shutdown(err)
-
-	return c.call(
-		&connectionClose{
-			ReplyCode: uint16(err.Code),
-			ReplyText: err.Reason,
-		},
-		&connectionCloseOk{},
-	)
+	var handshakeErr error
+	var initiated bool
+	c.closeOnce.Do(func() {
+		initiated = true
+		defer c.shutdown(err)
+		handshakeErr = c.call(
+			&connectionClose{
+				ReplyCode: uint16(err.Code),
+				ReplyText: err.Reason,
+			},
+			&connectionCloseOk{},
+		)
+	})
+	if !initiated {
+		return ErrClosed
+	}
+	return handshakeErr
 }
 
 // IsClosed returns true if the connection is marked as closed, otherwise false


### PR DESCRIPTION
PR #318 exposed a race condition in `Connection.Close()`. The previous implementation was doing a check-then-act, by checking `IsClosed()`, then moving onto `shutdown()`. The problem was that `closed=true` was set during `shutdown()`; therefore `IsClosed()` could allow multiple goroutines to pass, and then multiple go-routines would send `close` frames to the server.

The initial `CompareAndSwap()` (CAS) fix wasn't effective, because it was setting the connection as "closed", before actually sending a `close` frame to the server, therefore, the call to `send()` was refusing to send the `close` frame. In a few words, the CAS fix caused `close` frame to never be sent.

The correct fix is to use a destructor `sync.Once` to set the connection as "closed", because this destructor blocks all competing goroutines. Therefore, `close` frame is only sent once, and other goroutines return `ErrClosed`, as desired.

Fixes #327