### PR TITLE
 fix: respect context cancellation on publishing with context operations

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1492,8 +1492,10 @@ func (ch *Channel) Publish(exchange, key string, mandatory, immediate bool, msg 
 /*
 PublishWithContext sends a Publishing from the client to an exchange on the server.
 
-NOTE: If the context is cancelled, the publish operation may still complete in the background because the context is not propagated to the underlying Publish call.
-In this case, PublishWithContext will return the context error immediately rather than waiting for Publish to finish.
+If the context is already cancelled when PublishWithContext is called, it
+returns the context error immediately without attempting to publish.  Context
+cancellation after the call has started does not interrupt an in-flight
+Publish, as the underlying I/O is not context-aware.
 
 When you want a single message to be delivered to a single queue, you can
 publish to the default exchange with the routingKey of the queue name.  This is
@@ -1525,20 +1527,11 @@ When Publish does not return an error and the channel is in confirm mode, the
 internal counter for DeliveryTags with the first confirmation starts at 1.
 */
 func (ch *Channel) PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg Publishing) error {
-	// check if context already cancelled then return early.
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- ch.Publish(exchange, key, mandatory, immediate, msg)
-	}()
 	select {
-	case err := <-errChan:
-		return err
 	case <-ctx.Done():
 		return ctx.Err()
+	default:
+		return ch.Publish(exchange, key, mandatory, immediate, msg)
 	}
 }
 
@@ -1598,27 +1591,17 @@ DeferredConfirmation, allowing the caller to wait on the publisher confirmation
 for this message. If the channel has not been put into confirm mode,
 the DeferredConfirmation will be nil.
 
-NOTE: If the context is cancelled, the publish operation may still complete in the background because the context is not propagated to the underlying PublishWithDeferredConfirm call.
-In this case, PublishWithDeferredConfirmWithContext will return the context error immediately rather than waiting for PublishWithDeferredConfirm to finish.
+If the context is already cancelled when PublishWithDeferredConfirmWithContext is called, it
+returns the context error immediately without attempting to publish.  Context
+cancellation after the call has started does not interrupt an in-flight
+PublishWithDeferredConfirm, as the underlying I/O is not context-aware.
 */
 func (ch *Channel) PublishWithDeferredConfirmWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg Publishing) (*DeferredConfirmation, error) {
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-	type result struct {
-		deferredConfirmation *DeferredConfirmation
-		err                  error
-	}
-	resultChan := make(chan result, 1)
-	go func() {
-		res, err := ch.PublishWithDeferredConfirm(exchange, key, mandatory, immediate, msg)
-		resultChan <- result{deferredConfirmation: res, err: err}
-	}()
 	select {
-	case res := <-resultChan:
-		return res.deferredConfirmation, res.err
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	default:
+		return ch.PublishWithDeferredConfirm(exchange, key, mandatory, immediate, msg)
 	}
 }
 

--- a/channel.go
+++ b/channel.go
@@ -1598,11 +1598,28 @@ DeferredConfirmation, allowing the caller to wait on the publisher confirmation
 for this message. If the channel has not been put into confirm mode,
 the DeferredConfirmation will be nil.
 
-NOTE: PublishWithDeferredConfirmWithContext is equivalent to its non-context variant. The context passed
-to this function is not honoured.
+NOTE: If the context is cancelled, the publish operation may still complete in the background because the context is not propagated to the underlying PublishWithDeferredConfirm call.
+In this case, PublishWithDeferredConfirmWithContext will return the context error immediately rather than waiting for PublishWithDeferredConfirm to finish.
 */
-func (ch *Channel) PublishWithDeferredConfirmWithContext(_ context.Context, exchange, key string, mandatory, immediate bool, msg Publishing) (*DeferredConfirmation, error) {
-	return ch.PublishWithDeferredConfirm(exchange, key, mandatory, immediate, msg)
+func (ch *Channel) PublishWithDeferredConfirmWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg Publishing) (*DeferredConfirmation, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	type result struct {
+		deferredConfirmation *DeferredConfirmation
+		err                  error
+	}
+	resultChan := make(chan result, 1)
+	go func() {
+		res, err := ch.PublishWithDeferredConfirm(exchange, key, mandatory, immediate, msg)
+		resultChan <- result{deferredConfirmation: res, err: err}
+	}()
+	select {
+	case res := <-resultChan:
+		return res.deferredConfirmation, res.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 /*

--- a/channel.go
+++ b/channel.go
@@ -1492,7 +1492,8 @@ func (ch *Channel) Publish(exchange, key string, mandatory, immediate bool, msg 
 /*
 PublishWithContext sends a Publishing from the client to an exchange on the server.
 
-NOTE: this function is equivalent to [Channel.Publish]. Context is not honoured.
+NOTE: If the context is cancelled, the publish operation may still complete in the background because the context is not propagated to the underlying Publish call.
+In this case, PublishWithContext will return the context error immediately rather than waiting for Publish to finish.
 
 When you want a single message to be delivered to a single queue, you can
 publish to the default exchange with the routingKey of the queue name.  This is
@@ -1523,8 +1524,22 @@ confirmations start at 1.  Exit when all publishings are confirmed.
 When Publish does not return an error and the channel is in confirm mode, the
 internal counter for DeliveryTags with the first confirmation starts at 1.
 */
-func (ch *Channel) PublishWithContext(_ context.Context, exchange, key string, mandatory, immediate bool, msg Publishing) error {
-	return ch.Publish(exchange, key, mandatory, immediate, msg)
+func (ch *Channel) PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg Publishing) error {
+	// check if context already cancelled then return early.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- ch.Publish(exchange, key, mandatory, immediate, msg)
+	}()
+	select {
+	case err := <-errChan:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 /*

--- a/client_test.go
+++ b/client_test.go
@@ -8,6 +8,7 @@ package amqp091
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"reflect"
 	"sync"
@@ -954,4 +955,63 @@ func TestConcurrentClose_OnlyOneCloseFrameSent(t *testing.T) {
 	if nilCount != 1 {
 		t.Errorf("expected exactly 1 successful close, got %d", nilCount)
 	}
+}
+
+func TestPublishWithContext_ContextCancelled(t *testing.T) {
+	rwc, srv := newSession(t)
+	defer rwc.Close()
+
+	go func() {
+		srv.connectionOpen()
+		srv.channelOpen(1)
+	}()
+
+	c, err := Open(rwc, defaultConfig())
+	if err != nil {
+		t.Fatalf("could not create connection: %v (%s)", c, err)
+	}
+
+	ch, err := c.Channel()
+	if err != nil {
+		t.Fatalf("could not open channel: %v (%s)", ch, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel context immediately
+
+	err = ch.PublishWithContext(ctx, "", "q", false, false, Publishing{Body: []byte("test")})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+
+}
+
+func TestPublishWithContext_ContextDeadlineExceeded(t *testing.T) {
+	rwc, srv := newSession(t)
+	defer rwc.Close()
+
+	go func() {
+		srv.connectionOpen()
+		srv.channelOpen(1)
+	}()
+
+	c, err := Open(rwc, defaultConfig())
+	if err != nil {
+		t.Fatalf("could not create connection: %v (%s)", c, err)
+	}
+
+	ch, err := c.Channel()
+	if err != nil {
+		t.Fatalf("could not open channel: %v (%s)", ch, err)
+	}
+
+	// setting short deadline to simulate context deadline exceeded.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Millisecond))
+	defer cancel()
+
+	err = ch.PublishWithContext(ctx, "", "q", false, false, Publishing{Body: []byte("test")})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+
 }

--- a/client_test.go
+++ b/client_test.go
@@ -986,69 +986,6 @@ func TestPublishWithContext_ContextCancelled(t *testing.T) {
 
 }
 
-func TestPublishWithContext_ContextDeadlineExceeded(t *testing.T) {
-	rwc, srv := newSession(t)
-	defer rwc.Close()
-
-	go func() {
-		srv.connectionOpen()
-		srv.channelOpen(1)
-	}()
-
-	c, err := Open(rwc, defaultConfig())
-	if err != nil {
-		t.Fatalf("could not create connection: %v (%s)", c, err)
-	}
-
-	ch, err := c.Channel()
-	if err != nil {
-		t.Fatalf("could not open channel: %v (%s)", ch, err)
-	}
-
-	// setting short deadline to simulate context deadline exceeded.
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Millisecond))
-	defer cancel()
-
-	err = ch.PublishWithContext(ctx, "", "q", false, false, Publishing{Body: []byte("test")})
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
-	}
-
-}
-
-func TestPublishWithDeferredConfirmWithContext_ContextDeadlineExceeded(t *testing.T) {
-	rwc, srv := newSession(t)
-	defer rwc.Close()
-
-	go func() {
-		srv.connectionOpen()
-		srv.channelOpen(1)
-	}()
-
-	c, err := Open(rwc, defaultConfig())
-	if err != nil {
-		t.Fatalf("could not create connection: %v (%s)", c, err)
-	}
-
-	ch, err := c.Channel()
-	if err != nil {
-		t.Fatalf("could not open channel: %v (%s)", ch, err)
-	}
-
-	// setting short deadline to simulate context deadline exceeded.
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Millisecond))
-	defer cancel()
-
-	res, err := ch.PublishWithDeferredConfirmWithContext(ctx, "", "q", false, false, Publishing{Body: []byte("test")})
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
-	}
-	if res != nil {
-		t.Fatalf("expected nil, got %v", res)
-	}
-
-}
-
 func TestPublishWithDeferredConfirmWithContext_ContextCancelled(t *testing.T) {
 	rwc, srv := newSession(t)
 	defer rwc.Close()

--- a/client_test.go
+++ b/client_test.go
@@ -1015,3 +1015,68 @@ func TestPublishWithContext_ContextDeadlineExceeded(t *testing.T) {
 	}
 
 }
+
+func TestPublishWithDeferredConfirmWithContext_ContextDeadlineExceeded(t *testing.T) {
+	rwc, srv := newSession(t)
+	defer rwc.Close()
+
+	go func() {
+		srv.connectionOpen()
+		srv.channelOpen(1)
+	}()
+
+	c, err := Open(rwc, defaultConfig())
+	if err != nil {
+		t.Fatalf("could not create connection: %v (%s)", c, err)
+	}
+
+	ch, err := c.Channel()
+	if err != nil {
+		t.Fatalf("could not open channel: %v (%s)", ch, err)
+	}
+
+	// setting short deadline to simulate context deadline exceeded.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Millisecond))
+	defer cancel()
+
+	res, err := ch.PublishWithDeferredConfirmWithContext(ctx, "", "q", false, false, Publishing{Body: []byte("test")})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("expected nil, got %v", res)
+	}
+
+}
+
+func TestPublishWithDeferredConfirmWithContext_ContextCancelled(t *testing.T) {
+	rwc, srv := newSession(t)
+	defer rwc.Close()
+
+	go func() {
+		srv.connectionOpen()
+		srv.channelOpen(1)
+	}()
+
+	c, err := Open(rwc, defaultConfig())
+	if err != nil {
+		t.Fatalf("could not create connection: %v (%s)", c, err)
+	}
+
+	ch, err := c.Channel()
+	if err != nil {
+		t.Fatalf("could not open channel: %v (%s)", ch, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel context immediately
+
+	res, err := ch.PublishWithDeferredConfirmWithContext(ctx, "", "q", false, false, Publishing{Body: []byte("test")})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("expected nil, got %v", res)
+	}
+
+}


### PR DESCRIPTION
 # PR Description:                                                                                                                                                                                                                                                                                                                                                                                                                                                         
  This PR addresses an issue with the publishing interface where:                                                                                                                                                                        
  - PublishWithContext                                                                                                                                                                                                                   
  - PublishWithDeferredConfirmWithContext                                                                                                                                                                                                                                                                                                                                                                                                                                
  
They aren't honoring context when passed.                                                                                                                                                                                                                                                                                                                                                                                                                                       
## Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  - Run the underlying publish call in a goroutine and use select to race it against ctx.Done(), allowing the caller to return early on context cancellation or timeout                                                                  
  - Updated doc comments to clarify that on context cancellation, the publish may still complete in the background since context is not propagated to the underlying Publish call                                                        
  - Added unit tests for pre-cancelled context and deadline exceeded scenarios   


This PR was opened to address #329                    