### PR TITLE
Fix integration tests for RabbitMQ 4.3

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -277,7 +277,7 @@ func TestIntegrationQueueDeclarePassiveOnMissingExchangeShouldError(t *testing.T
 			"test-integration-missing-passive-queue", // name
 			false,                                    // duration (note: not durable)
 			true,                                     // auto-delete
-			false,                                    // exclusive
+			true,                                     // exclusive
 			false,                                    // noWait
 			nil,                                      // arguments
 		); err == nil {
@@ -307,7 +307,7 @@ func TestIntegrationQueueDeclarePassiveOnQueueTypeMismatchShouldError(t *testing
 			queueName, // name
 			false,     // durable
 			true,      // auto-delete
-			false,     // exclusive
+			true,      // exclusive
 			false,     // noWait
 			nil,       // arguments
 		); err != nil {
@@ -320,7 +320,7 @@ func TestIntegrationQueueDeclarePassiveOnQueueTypeMismatchShouldError(t *testing
 			queueName, // name
 			false,     // duration (note: not durable)
 			true,      // auto-delete
-			false,     // exclusive
+			true,      // exclusive
 			false,     // noWait
 			args,      // arguments
 		); err != nil {
@@ -347,7 +347,7 @@ func TestIntegrationPassiveQueue(t *testing.T) {
 			name,  // name
 			false, // durable
 			true,  // auto-delete
-			false, // exclusive
+			true,  // exclusive
 			false, // noWait
 			nil,   // arguments
 		); err != nil {
@@ -358,7 +358,7 @@ func TestIntegrationPassiveQueue(t *testing.T) {
 			name,  // name
 			false, // durable
 			true,  // auto-delete
-			false, // exclusive
+			true,  // exclusive
 			false, // noWait
 			nil,   // arguments
 		); err != nil {
@@ -369,11 +369,11 @@ func TestIntegrationPassiveQueue(t *testing.T) {
 			name,  // name
 			true,  // durable (note: differs)
 			true,  // auto-delete
-			false, // exclusive
+			true,  // exclusive
 			false, // noWait
 			nil,   // arguments
 		); err != nil {
-			t.Fatalf("QueueDeclarePassive on declared queue with different flags should error")
+			t.Fatalf("QueueDeclarePassive on declared queue with different flags should not error, got: %q", err)
 		}
 	}
 }
@@ -613,12 +613,12 @@ func TestIntegrationMeaningfulChannelErrors(t *testing.T) {
 
 		queue := "test.integration.channel.error"
 
-		_, err = ch.QueueDeclare(queue, false, true, false, false, nil)
+		_, err = ch.QueueDeclare(queue, false, true, true, false, nil)
 		if err != nil {
 			t.Fatalf("Could not declare")
 		}
 
-		_, err = ch.QueueDeclare(queue, true, false, false, false, nil)
+		_, err = ch.QueueDeclare(queue, true, false, true, false, nil)
 		if err == nil {
 			t.Fatalf("Expected error, got nil")
 		}
@@ -632,7 +632,7 @@ func TestIntegrationMeaningfulChannelErrors(t *testing.T) {
 			t.Fatalf("Expected PreconditionFailed, got: %+v", e)
 		}
 
-		_, err = ch.QueueDeclare(queue, false, true, false, false, nil)
+		_, err = ch.QueueDeclare(queue, false, true, true, false, nil)
 		if err != ErrClosed {
 			t.Fatalf("Expected channel to be closed, got: %T", err)
 		}
@@ -652,7 +652,7 @@ func TestIntegrationNonBlockingClose(t *testing.T) {
 
 		queue := "test.integration.blocking.close"
 
-		_, err = ch.QueueDeclare(queue, false, true, false, false, nil)
+		_, err = ch.QueueDeclare(queue, false, true, true, false, nil)
 		if err != nil {
 			t.Fatalf("Could not declare")
 		}
@@ -704,11 +704,11 @@ func TestIntegrationPublishConsume(t *testing.T) {
 		pub, _ := c1.Channel()
 		sub, _ := c2.Channel()
 
-		if _, e := pub.QueueDeclare(queue, false, true, false, false, nil); e != nil {
+		if _, e := pub.QueueDeclare(queue, true, true, false, false, nil); e != nil {
 			t.Fatalf("error declaring queue %s: %v", queue, e)
 		}
 
-		if _, e := sub.QueueDeclare(queue, false, true, false, false, nil); e != nil {
+		if _, e := sub.QueueDeclare(queue, true, true, false, false, nil); e != nil {
 			t.Fatalf("error declaring queue %s: %v", queue, e)
 		}
 
@@ -745,11 +745,11 @@ func TestIntegrationConsumeFlow(t *testing.T) {
 		pub, _ := c1.Channel()
 		sub, _ := c2.Channel()
 
-		if _, e := pub.QueueDeclare(queue, false, true, false, false, nil); e != nil {
+		if _, e := pub.QueueDeclare(queue, true, true, false, false, nil); e != nil {
 			t.Fatalf("error declaring queue %s: %v", queue, e)
 		}
 
-		if _, e := sub.QueueDeclare(queue, false, true, false, false, nil); e != nil {
+		if _, e := sub.QueueDeclare(queue, true, true, false, false, nil); e != nil {
 			t.Fatalf("error declaring queue %s: %v", queue, e)
 		}
 
@@ -834,7 +834,7 @@ func TestIntegrationConsumeCancel(t *testing.T) {
 
 		ch, _ := c.Channel()
 
-		if _, e := ch.QueueDeclare(queue, false, true, false, false, nil); e != nil {
+		if _, e := ch.QueueDeclare(queue, false, true, true, false, nil); e != nil {
 			t.Fatalf("error declaring queue %s: %v", queue, e)
 		}
 
@@ -878,7 +878,7 @@ func TestIntegrationConsumeCancelWithContext(t *testing.T) {
 
 		ch, _ := c.Channel()
 
-		if _, e := ch.QueueDeclare(queue, false, true, false, false, nil); e != nil {
+		if _, e := ch.QueueDeclare(queue, false, true, true, false, nil); e != nil {
 			t.Fatalf("error declaring queue %s: %v", queue, e)
 		}
 
@@ -978,7 +978,7 @@ func TestQuickPublishOnly(t *testing.T) {
 		}
 		queue := "test-publish"
 
-		if _, err = pub.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err = pub.QueueDeclare(queue, false, true, true, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 			return
 		}
@@ -1006,7 +1006,7 @@ func TestPublishEmptyBody(t *testing.T) {
 
 		queue := "test-TestPublishEmptyBody"
 
-		if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
 			t.Fatalf("Could not declare")
 		}
 
@@ -1046,7 +1046,7 @@ func TestPublishEmptyBodyWithHeadersIssue67(t *testing.T) {
 
 		queue := "test-TestPublishEmptyBodyWithHeaders"
 
-		if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
 			t.Fatalf("Could not declare")
 		}
 
@@ -1100,12 +1100,12 @@ func TestQuickPublishConsumeOnly(t *testing.T) {
 
 		queue := "TestPublishConsumeOnly"
 
-		if _, err = pub.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err = pub.QueueDeclare(queue, true, true, false, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 			return
 		}
 
-		if _, err = sub.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err = sub.QueueDeclare(queue, true, true, false, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 			return
 		}
@@ -1157,7 +1157,7 @@ func TestQuickPublishConsumeBigBody(t *testing.T) {
 
 		queue := "test-pubsub"
 
-		if _, err = sub.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err = sub.QueueDeclare(queue, true, true, false, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
@@ -1170,7 +1170,7 @@ func TestQuickPublishConsumeBigBody(t *testing.T) {
 			Body: make([]byte, 1e4+1000),
 		}
 
-		if _, err = pub.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err = pub.QueueDeclare(queue, true, true, false, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
@@ -1197,7 +1197,7 @@ func TestIntegrationGetOk(t *testing.T) {
 		queue := "test.get-ok"
 		ch, _ := c.Channel()
 
-		if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, true, true, false, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
@@ -1227,7 +1227,7 @@ func TestIntegrationGetEmpty(t *testing.T) {
 		queue := "test.get-ok"
 		ch, _ := c.Channel()
 
-		if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, true, true, false, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
@@ -1249,7 +1249,7 @@ func TestIntegrationTxCommit(t *testing.T) {
 		queue := "test.tx.commit"
 		ch, _ := c.Channel()
 
-		if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
@@ -1284,7 +1284,7 @@ func TestIntegrationTxRollback(t *testing.T) {
 		queue := "test.tx.rollback"
 		ch, _ := c.Channel()
 
-		if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
@@ -1443,7 +1443,7 @@ func TestRoundTripAllFieldValueTypes61(t *testing.T) {
 		queue := "test.issue61-roundtrip"
 		ch, _ := conn.Channel()
 
-		if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
 			t.Fatalf("Could not declare")
 		}
 
@@ -1498,7 +1498,7 @@ func TestIntegrationPublishConsumeUnsignedInts(t *testing.T) {
 			}
 
 			queue := t.Name()
-			if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+			if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
 				t.Fatalf("declare queue: %s", err)
 			}
 			defer integrationQueueDelete(t, ch, queue)
@@ -1556,7 +1556,7 @@ func TestDeclareArgsXMessageTTL(t *testing.T) {
 		args := Table{"x-message-ttl": int32(9000000)}
 
 		// should not drop the connection
-		if _, err := ch.QueueDeclare("declareWithTTL", false, true, false, false, args); err != nil {
+		if _, err := ch.QueueDeclare("declareWithTTL", false, true, true, false, args); err != nil {
 			t.Fatalf("cannot declare with TTL: got: %v", err)
 		}
 	}
@@ -1583,7 +1583,7 @@ func TestDeclareArgsRejectToDeadLetterQueue(t *testing.T) {
 			t.Fatalf("cannot declare %v: got: %v", dlex, err)
 		}
 
-		if _, err := ch.QueueDeclare(dlq, false, true, false, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(dlq, false, true, true, false, nil); err != nil {
 			t.Fatalf("cannot declare %v: got: %v", dlq, err)
 		}
 
@@ -1591,7 +1591,7 @@ func TestDeclareArgsRejectToDeadLetterQueue(t *testing.T) {
 			t.Fatalf("cannot bind %v to %v: got: %v", dlq, dlex, err)
 		}
 
-		if _, err := ch.QueueDeclare(q, false, true, false, false, Table{
+		if _, err := ch.QueueDeclare(q, false, true, true, false, Table{
 			"x-dead-letter-exchange": dlex,
 		}); err != nil {
 			t.Fatalf("cannot declare %v with dlq %v: got: %v", q, dlex, err)
@@ -1666,7 +1666,7 @@ func TestDeadlockConsumerIssue48(t *testing.T) {
 
 		queue := "test-issue48"
 
-		if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
 			t.Fatalf("expected to declare a queue: %v", err)
 		}
 
@@ -1825,11 +1825,11 @@ func TestCorruptedMessageIssue7(t *testing.T) {
 
 		queue := "test-corrupted-message-regression"
 
-		if _, err := pub.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := pub.QueueDeclare(queue, true, true, false, false, nil); err != nil {
 			t.Fatalf("Cannot declare")
 		}
 
-		if _, err := sub.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := sub.QueueDeclare(queue, true, true, false, false, nil); err != nil {
 			t.Fatalf("Cannot declare")
 		}
 
@@ -1959,7 +1959,7 @@ func TestRabbitMQQueueTTLGet(t *testing.T) {
 
 		if _, err = channel.QueueDeclare(
 			queue,
-			false,
+			true,
 			true,
 			false,
 			false,
@@ -1997,7 +1997,7 @@ func TestRabbitMQQueueNackMultipleRequeue(t *testing.T) {
 				t.Fatalf("channel: %v", err)
 			}
 
-			if _, err = channel.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+			if _, err = channel.QueueDeclare(queue, false, false, true, false, nil); err != nil {
 				t.Fatalf("queue declare: %s", err)
 			}
 
@@ -2046,7 +2046,7 @@ func TestConsumerCancelNotification(t *testing.T) {
 
 		queue := "test-consumer-cancel-notification"
 
-		if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, false, true, false, nil); err != nil {
 			t.Fatalf("expected to declare a queue: %v", err)
 		}
 
@@ -2413,7 +2413,7 @@ func integrationQueue(t *testing.T, name string) (*Connection, *Channel) {
 
 	if conn := integrationConnection(t, name); conn != nil {
 		if channel, err := conn.Channel(); err == nil {
-			if _, err = channel.QueueDeclare(name, false, true, false, false, nil); err == nil {
+			if _, err = channel.QueueDeclare(name, false, false, true, false, nil); err == nil {
 				return conn, channel
 			}
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -276,7 +276,7 @@ func TestIntegrationQueueDeclarePassiveOnMissingExchangeShouldError(t *testing.T
 		if _, err := ch.QueueDeclarePassive(
 			"test-integration-missing-passive-queue", // name
 			false,                                    // duration (note: not durable)
-			true,                                     // auto-delete
+			false,                                    // auto-delete
 			true,                                     // exclusive
 			false,                                    // noWait
 			nil,                                      // arguments
@@ -306,7 +306,7 @@ func TestIntegrationQueueDeclarePassiveOnQueueTypeMismatchShouldError(t *testing
 		if _, err := ch.QueueDeclare(
 			queueName, // name
 			false,     // durable
-			true,      // auto-delete
+			false,     // auto-delete
 			true,      // exclusive
 			false,     // noWait
 			nil,       // arguments
@@ -319,7 +319,7 @@ func TestIntegrationQueueDeclarePassiveOnQueueTypeMismatchShouldError(t *testing
 		if _, err := ch.QueueDeclarePassive(
 			queueName, // name
 			false,     // duration (note: not durable)
-			true,      // auto-delete
+			false,     // auto-delete
 			true,      // exclusive
 			false,     // noWait
 			args,      // arguments
@@ -346,7 +346,7 @@ func TestIntegrationPassiveQueue(t *testing.T) {
 		if _, err := ch.QueueDeclare(
 			name,  // name
 			false, // durable
-			true,  // auto-delete
+			false, // auto-delete
 			true,  // exclusive
 			false, // noWait
 			nil,   // arguments
@@ -357,7 +357,7 @@ func TestIntegrationPassiveQueue(t *testing.T) {
 		if _, err := ch.QueueDeclarePassive(
 			name,  // name
 			false, // durable
-			true,  // auto-delete
+			false, // auto-delete
 			true,  // exclusive
 			false, // noWait
 			nil,   // arguments
@@ -368,7 +368,7 @@ func TestIntegrationPassiveQueue(t *testing.T) {
 		if _, err := ch.QueueDeclarePassive(
 			name,  // name
 			true,  // durable (note: differs)
-			true,  // auto-delete
+			false, // auto-delete
 			true,  // exclusive
 			false, // noWait
 			nil,   // arguments
@@ -632,7 +632,7 @@ func TestIntegrationMeaningfulChannelErrors(t *testing.T) {
 			t.Fatalf("Expected PreconditionFailed, got: %+v", e)
 		}
 
-		_, err = ch.QueueDeclare(queue, false, true, true, false, nil)
+		_, err = ch.QueueDeclare(queue, false, false, true, false, nil)
 		if err != ErrClosed {
 			t.Fatalf("Expected channel to be closed, got: %T", err)
 		}
@@ -652,7 +652,7 @@ func TestIntegrationNonBlockingClose(t *testing.T) {
 
 		queue := "test.integration.blocking.close"
 
-		_, err = ch.QueueDeclare(queue, false, true, true, false, nil)
+		_, err = ch.QueueDeclare(queue, false, false, true, false, nil)
 		if err != nil {
 			t.Fatalf("Could not declare")
 		}
@@ -834,7 +834,7 @@ func TestIntegrationConsumeCancel(t *testing.T) {
 
 		ch, _ := c.Channel()
 
-		if _, e := ch.QueueDeclare(queue, false, true, true, false, nil); e != nil {
+		if _, e := ch.QueueDeclare(queue, false, false, true, false, nil); e != nil {
 			t.Fatalf("error declaring queue %s: %v", queue, e)
 		}
 
@@ -878,7 +878,7 @@ func TestIntegrationConsumeCancelWithContext(t *testing.T) {
 
 		ch, _ := c.Channel()
 
-		if _, e := ch.QueueDeclare(queue, false, true, true, false, nil); e != nil {
+		if _, e := ch.QueueDeclare(queue, false, false, true, false, nil); e != nil {
 			t.Fatalf("error declaring queue %s: %v", queue, e)
 		}
 
@@ -978,7 +978,7 @@ func TestQuickPublishOnly(t *testing.T) {
 		}
 		queue := "test-publish"
 
-		if _, err = pub.QueueDeclare(queue, false, true, true, false, nil); err != nil {
+		if _, err = pub.QueueDeclare(queue, false, false, true, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 			return
 		}
@@ -1006,7 +1006,7 @@ func TestPublishEmptyBody(t *testing.T) {
 
 		queue := "test-TestPublishEmptyBody"
 
-		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, false, true, false, nil); err != nil {
 			t.Fatalf("Could not declare")
 		}
 
@@ -1046,7 +1046,7 @@ func TestPublishEmptyBodyWithHeadersIssue67(t *testing.T) {
 
 		queue := "test-TestPublishEmptyBodyWithHeaders"
 
-		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, false, true, false, nil); err != nil {
 			t.Fatalf("Could not declare")
 		}
 
@@ -1249,7 +1249,7 @@ func TestIntegrationTxCommit(t *testing.T) {
 		queue := "test.tx.commit"
 		ch, _ := c.Channel()
 
-		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, false, true, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
@@ -1284,7 +1284,7 @@ func TestIntegrationTxRollback(t *testing.T) {
 		queue := "test.tx.rollback"
 		ch, _ := c.Channel()
 
-		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, false, true, false, nil); err != nil {
 			t.Fatalf("Failed to declare: %s", err)
 		}
 
@@ -1443,7 +1443,7 @@ func TestRoundTripAllFieldValueTypes61(t *testing.T) {
 		queue := "test.issue61-roundtrip"
 		ch, _ := conn.Channel()
 
-		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, false, true, false, nil); err != nil {
 			t.Fatalf("Could not declare")
 		}
 
@@ -1498,7 +1498,7 @@ func TestIntegrationPublishConsumeUnsignedInts(t *testing.T) {
 			}
 
 			queue := t.Name()
-			if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
+			if _, err := ch.QueueDeclare(queue, false, false, true, false, nil); err != nil {
 				t.Fatalf("declare queue: %s", err)
 			}
 			defer integrationQueueDelete(t, ch, queue)
@@ -1556,7 +1556,7 @@ func TestDeclareArgsXMessageTTL(t *testing.T) {
 		args := Table{"x-message-ttl": int32(9000000)}
 
 		// should not drop the connection
-		if _, err := ch.QueueDeclare("declareWithTTL", false, true, true, false, args); err != nil {
+		if _, err := ch.QueueDeclare("declareWithTTL", false, false, true, false, args); err != nil {
 			t.Fatalf("cannot declare with TTL: got: %v", err)
 		}
 	}
@@ -1583,7 +1583,7 @@ func TestDeclareArgsRejectToDeadLetterQueue(t *testing.T) {
 			t.Fatalf("cannot declare %v: got: %v", dlex, err)
 		}
 
-		if _, err := ch.QueueDeclare(dlq, false, true, true, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(dlq, false, false, true, false, nil); err != nil {
 			t.Fatalf("cannot declare %v: got: %v", dlq, err)
 		}
 
@@ -1591,7 +1591,7 @@ func TestDeclareArgsRejectToDeadLetterQueue(t *testing.T) {
 			t.Fatalf("cannot bind %v to %v: got: %v", dlq, dlex, err)
 		}
 
-		if _, err := ch.QueueDeclare(q, false, true, true, false, Table{
+		if _, err := ch.QueueDeclare(q, false, false, true, false, Table{
 			"x-dead-letter-exchange": dlex,
 		}); err != nil {
 			t.Fatalf("cannot declare %v with dlq %v: got: %v", q, dlex, err)
@@ -1666,7 +1666,7 @@ func TestDeadlockConsumerIssue48(t *testing.T) {
 
 		queue := "test-issue48"
 
-		if _, err := ch.QueueDeclare(queue, false, true, true, false, nil); err != nil {
+		if _, err := ch.QueueDeclare(queue, false, false, true, false, nil); err != nil {
 			t.Fatalf("expected to declare a queue: %v", err)
 		}
 


### PR DESCRIPTION
## Proposed Changes

Starting from version 4.3 of RabbitMQ, Transient (non-durable) non-exclusive classic queues are [deprecated](https://www.rabbitmq.com/release-information/deprecated-features-list) and cannot be declared by default (https://www.rabbitmq.com/docs/queues#durability)

This fixes the integration tests to work with version RabbitMQ 4.3, setting the `durable=true` or `exclusive=true` when creating the queues based on the nature of the test.

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bugfix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)