### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+## Proposed Changes
+
+<!-- Please describe the purpose and overall impact of your changes.
+If this fixes an issue or implements a feature request, link it below under `Fixes` section. -->
+
+## Types of Changes
+
+<!-- What types of changes does your code introduce to this project?
+Put an `x` in the boxes that apply -->
+
+- [ ] Bugfix <!-- non-breaking change which fixes issue -->
+- [ ] New feature <!-- non-breaking change which adds functionality -->
+- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
+- [ ] Documentation <!-- correction or otherwise -->
+- [ ] Cosmetics <!-- whitespace, appearance -->
+
+## Checklist
+
+<!-- Put an `x` in the boxes that apply. You can also fill these out after
+creating the PR.  -->
+
+- [ ] I have read the `CONTRIBUTING.md` document
+- [ ] All tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+
+## Fixes
+
+<!-- Link related issues using GitHub keywords:
+- Fixes #123
+- Closes #456
+- Resolves owner/repo#789
+-->
+
+- Fixes #
+
+## Further Comments
+
+<!-- If this is a relatively large or complex change, kick off the discussion
+by explaining why you chose the solution you did and what alternatives
+you considered, etc. -->


### PR DESCRIPTION
Adding pull request template markdown file so that GitHub will automatically populate the description field with given template whenever someone opens a new PR.