### PR TITLE
Add integration test for publish with immediate flag

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1166,6 +1166,35 @@ func TestIntegrationConsumeFlow(t *testing.T) {
 	}
 }
 
+// Tests publish with immediate=true
+// Latest RabbitMQ does not support immediate=true, so the server should return a channel close exception
+func TestIntegrationPublishImmediate(t *testing.T) {
+	queue := "test.integration.publish-immediate"
+
+	c, ch := integrationQueue(t, queue)
+	if c != nil && ch != nil {
+		defer c.Close()
+		defer ch.Close()
+
+		// 1. Setup a channel to listen for asynchronous closure errors
+		closeChan := ch.NotifyClose(make(chan *Error, 1))
+		// 2. Publish with immediate=true, returns nil immediately because it's fire-and-forget
+		err := ch.PublishWithContext(context.TODO(), "", queue, false, true, Publishing{Body: []byte("test message")})
+		if err != nil {
+			t.Fatalf("Publish returned unexpected error: %v", err)
+		}
+		// 3. Wait for the server to asynchronously close the channel due to the exception
+		select {
+		case ex := <-closeChan:
+			if ex == nil || ex.Code != 540 {
+				t.Fatalf("Expected NOT IMPLEMENTED (540) got: %v", ex)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("Timeout waiting for channel close exception")
+		}
+	}
+}
+
 func TestIntegrationRecoverNotImplemented(t *testing.T) {
 	// TODO: remove this when Channel.Recover is removed
 	queue := "test.recover"


### PR DESCRIPTION
## Proposed Changes

This commit introduces `TestIntegrationPublishImmediate` to verify the behavior of publishing messages with the `immediate` flag set to `true`.

Since modern RabbitMQ versions (3.0+) no longer support the `immediate` flag, the test ensures that the broker correctly responds by throwing an asynchronous channel exception. It verifies that the channel is closed with the `NOT_IMPLEMENTED` (540) error code after the fire-and-forget publish operation.

## Types of Changes

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->
- [x] Test Changes

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
