### PR TITLE
Feature: implement automatic connection and channel recovery with state change notifications

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,10 @@ jobs:
         go-version: ['oldstable', 'stable']
     services:
       rabbitmq:
-        image: rabbitmq
+        image: rabbitmq:4-management
         ports:
           - 5672:5672
+          - 15672:15672
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/_examples/recovery/recovery.go
+++ b/_examples/recovery/recovery.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+func main() {
+	// Enable library logging
+	amqp.Logger = log.Default()
+
+	// 4. Register signal.NotifyContext with sigterm so that program exits gracefully on CTLR+C
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	url := "amqp://guest:guest@localhost:5672/"
+
+	// 1. Create a connection with DialRecovery(url, nil) , i.e. default recovery configuration
+	log.Printf("Dialing %s", url)
+	conn, err := amqp.DialRecovery(url, nil)
+	if err != nil {
+		log.Fatalf("Failed to connect to RabbitMQ: %v", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		log.Fatalf("Failed to open a channel: %v", err)
+	}
+	defer ch.Close()
+
+	queueName := "recovery_test_queue"
+	q, err := ch.QueueDeclare(
+		queueName,
+		true,  // durable
+		false, // auto-delete
+		false, // exclusive
+		false, // no-wait
+		nil,   // args
+	)
+	if err != nil {
+		log.Fatalf("Failed to declare a queue: %v", err)
+	}
+
+	var wg sync.WaitGroup
+
+	// 3. Consumer goroutine is continuosly consume message
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		msgs, err := ch.Consume(
+			q.Name,
+			"recovery-consumer", // consumer tag
+			true,                // auto-ack
+			false,               // exclusive
+			false,               // no-local
+			false,               // no-wait
+			nil,                 // args
+		)
+		if err != nil {
+			log.Printf("Failed to register a consumer: %v", err)
+			return
+		}
+
+		log.Println("Consumer started. Waiting for messages...")
+		for {
+			select {
+			case <-ctx.Done():
+				log.Println("Context cancelled, stopping consumer")
+				return
+			case d, ok := <-msgs:
+				if !ok {
+					log.Println("Consumer channel closed")
+					return
+				}
+				log.Printf("Received: %s", d.Body)
+			}
+		}
+	}()
+
+	// 2. Publisher goroutine will continuosly publish message, assume "Published Msg: 1" with increamental number.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		counter := 1
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
+		log.Println("Publisher started. Publishing messages...")
+		for {
+			select {
+			case <-ctx.Done():
+				log.Println("Context cancelled, stopping publisher")
+				return
+			case <-ticker.C:
+				body := fmt.Sprintf("Message %d", counter)
+				err := ch.PublishWithContext(ctx,
+					"",     // exchange
+					q.Name, // routing key
+					false,  // mandatory
+					false,  // immediate
+					amqp.Publishing{
+						ContentType: "text/plain",
+						Body:        []byte(body),
+					})
+				if err != nil {
+					log.Printf("Failed to publish message %d: %v", counter, err)
+				} else {
+					log.Printf("Published: %s", body)
+				}
+				counter++
+			}
+		}
+	}()
+
+	log.Println("Running. Press CTRL+C to exit.")
+
+	// Wait for goroutines to finish
+	wg.Wait()
+	log.Println("Shutting down gracefully.")
+}

--- a/_examples/recovery/recovery.go
+++ b/_examples/recovery/recovery.go
@@ -17,13 +17,13 @@ func main() {
 	// Enable library logging
 	amqp.Logger = log.Default()
 
-	// 4. Register signal.NotifyContext with sigterm so that program exits gracefully on CTLR+C
+	// Register signal.NotifyContext with sigterm so that program exits gracefully on CTLR+C
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
 	url := "amqp://guest:guest@localhost:5672/"
 
-	// 1. Create a connection with DialRecovery(url, nil) , i.e. default recovery configuration
+	// Create a connection with DialRecovery(url, nil) , i.e. default recovery configuration
 	log.Printf("Dialing %s", url)
 	conn, err := amqp.DialRecovery(url, nil)
 	if err != nil {
@@ -31,11 +31,55 @@ func main() {
 	}
 	defer conn.Close()
 
+	signalBlock := sync.Cond{L: &sync.Mutex{}}
+	var isReconnecting bool
+	stateChanged := make(chan *amqp.StateChanged, 1)
+	conn.NotifyStateChange(stateChanged)
+
+	go func(ch chan *amqp.StateChanged) {
+		for statusChanged := range ch {
+			log.Printf("[connection] Status changed: %v", statusChanged)
+			switch statusChanged.To.(type) {
+			case *amqp.StateOpen:
+				signalBlock.L.Lock()
+				isReconnecting = false
+				signalBlock.Broadcast()
+				signalBlock.L.Unlock()
+			case *amqp.StateReconnecting:
+				log.Printf("[connection] Reconnecting to the AMQP server")
+				signalBlock.L.Lock()
+				isReconnecting = true
+				signalBlock.L.Unlock()
+			case *amqp.StateClosed:
+				stateClosed := statusChanged.To.(*amqp.StateClosed)
+				if stateClosed.GetError() != nil {
+					log.Printf("[connection] Connection closed with error: %v", stateClosed.GetError())
+				} else {
+					log.Printf("[connection] Connection closed normally")
+				}
+				signalBlock.L.Lock()
+				isReconnecting = false
+				signalBlock.Broadcast()
+				signalBlock.L.Unlock()
+				cancel()
+			}
+		}
+	}(stateChanged)
+
 	ch, err := conn.Channel()
 	if err != nil {
 		log.Fatalf("Failed to open a channel: %v", err)
 	}
 	defer ch.Close()
+
+	chanStateChanged := make(chan *amqp.StateChanged, 1)
+	ch.NotifyStateChange(chanStateChanged)
+
+	go func(c chan *amqp.StateChanged) {
+		for statusChanged := range c {
+			log.Printf("[channel] Status changed: %v", statusChanged)
+		}
+	}(chanStateChanged)
 
 	queueName := "recovery_test_queue"
 	q, err := ch.QueueDeclare(
@@ -52,7 +96,7 @@ func main() {
 
 	var wg sync.WaitGroup
 
-	// 3. Consumer goroutine is continuosly consume message
+	// Consumer goroutine is continuosly consume message
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -79,6 +123,9 @@ func main() {
 				return
 			case d, ok := <-msgs:
 				if !ok {
+					// Note: Consume channel does not close during automatic recovery.
+					// It simply blocks until recovery is complete and new messages arrive.
+					// If it does close, it means recovery failed or was disabled.
 					log.Println("Consumer channel closed")
 					return
 				}
@@ -87,7 +134,7 @@ func main() {
 		}
 	}()
 
-	// 2. Publisher goroutine will continuosly publish message, assume "Published Msg: 1" with increamental number.
+	// Publisher goroutine will continuosly publish message.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -115,6 +162,16 @@ func main() {
 					})
 				if err != nil {
 					log.Printf("Failed to publish message %d: %v", counter, err)
+					log.Println("Publisher is blocked, waiting for recovery...")
+					time.Sleep(10 * time.Millisecond) // Let the notifier run to update the state
+					signalBlock.L.Lock()
+					for isReconnecting { // Avoid spurious wakeups
+						signalBlock.Wait()
+					}
+					signalBlock.L.Unlock()
+					log.Println("Publisher is unblocked")
+					// Retry publishing the same message
+					continue
 				} else {
 					log.Printf("Published: %s", body)
 				}

--- a/_examples/recovery/recovery.go
+++ b/_examples/recovery/recovery.go
@@ -102,7 +102,7 @@ func main() {
 
 	var wg sync.WaitGroup
 
-	// Consumer goroutine is continuosly consume message
+	// Consumer goroutine will continuously consume message
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -140,7 +140,7 @@ func main() {
 		}
 	}()
 
-	// Publisher goroutine will continuosly publish message.
+	// Publisher goroutine will continuously publish message
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -186,7 +186,7 @@ func main() {
 		}
 	}()
 
-	// Stats will continuosly monitor the number of active goroutines every 1 minute.
+	// Stats will continuously monitor the number of active goroutines every 1 minute
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/_examples/recovery/recovery.go
+++ b/_examples/recovery/recovery.go
@@ -45,21 +45,20 @@ func main() {
 	go func(ch chan *amqp.StateChanged) {
 		for statusChanged := range ch {
 			log.Printf("[connection] Status changed: %v", statusChanged)
-			switch statusChanged.To.(type) {
-			case *amqp.StateOpen:
+			switch statusChanged.To {
+			case amqp.StateOpen:
 				signalBlock.L.Lock()
 				isReconnecting = false
 				signalBlock.Broadcast()
 				signalBlock.L.Unlock()
-			case *amqp.StateReconnecting:
+			case amqp.StateReconnecting:
 				log.Printf("[connection] Reconnecting to the AMQP server")
 				signalBlock.L.Lock()
 				isReconnecting = true
 				signalBlock.L.Unlock()
-			case *amqp.StateClosed:
-				stateClosed := statusChanged.To.(*amqp.StateClosed)
-				if stateClosed.GetError() != nil {
-					log.Printf("[connection] Connection closed with error: %v", stateClosed.GetError())
+			case amqp.StateClosed:
+				if statusChanged.Err != nil {
+					log.Printf("[connection] Connection closed with error: %v", statusChanged.Err)
 				} else {
 					log.Printf("[connection] Connection closed normally")
 				}

--- a/_examples/recovery/recovery.go
+++ b/_examples/recovery/recovery.go
@@ -29,9 +29,11 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	// Create a connection with DialRecovery(url, nil) , i.e. default recovery configuration
+	// Create a connection with default recovery configuration
 	log.Printf("Dialing %s", *url)
-	conn, err := amqp.DialRecovery(*url, nil)
+	conn, err := amqp.DialConfig(*url, amqp.Config{
+		Recovery: &amqp.Recovery{},
+	})
 	if err != nil {
 		log.Fatalf("Failed to connect to RabbitMQ: %v", err)
 	}

--- a/_examples/recovery/recovery.go
+++ b/_examples/recovery/recovery.go
@@ -2,16 +2,24 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
 	"os/signal"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
+
+var url = flag.String("url", "amqp://guest:guest@localhost:5672/", "AMQP URL")
+
+func init() {
+	flag.Parse()
+}
 
 func main() {
 	// Enable library logging
@@ -21,11 +29,9 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	url := "amqp://guest:guest@localhost:5672/"
-
 	// Create a connection with DialRecovery(url, nil) , i.e. default recovery configuration
-	log.Printf("Dialing %s", url)
-	conn, err := amqp.DialRecovery(url, nil)
+	log.Printf("Dialing %s", *url)
+	conn, err := amqp.DialRecovery(*url, nil)
 	if err != nil {
 		log.Fatalf("Failed to connect to RabbitMQ: %v", err)
 	}
@@ -176,6 +182,26 @@ func main() {
 					log.Printf("Published: %s", body)
 				}
 				counter++
+			}
+		}
+	}()
+
+	// Stats will continuosly monitor the number of active goroutines every 1 minute.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+
+		log.Println("Stats started. Monitoring goroutines...")
+		for {
+			select {
+			case <-ctx.Done():
+				log.Println("Context cancelled, stopping stats")
+				return
+			case <-ticker.C:
+				log.Printf("[stats] Goroutines: %d", runtime.NumGoroutine())
 			}
 		}
 	}()

--- a/channel.go
+++ b/channel.go
@@ -540,6 +540,9 @@ func (ch *Channel) IsClosed() bool {
 }
 
 // NotifyStateChange registers a listener for state changes.
+//
+// It is necessary to continuously consume from the channel passed to NotifyStateChange
+// to avoid blocking internal state dispatch routines and leaking goroutines.
 func (ch *Channel) NotifyStateChange(c chan *StateChanged) {
 	ch.lifeCycle.notifyStateChange(c)
 }

--- a/channel.go
+++ b/channel.go
@@ -142,7 +142,7 @@ func (ch *Channel) shutdown(e *Error) {
 		}
 	}
 
-	if e == nil || !ch.connection.IsRecoveryEnabled() {
+	if e == nil || !ch.connection.IsRecoveryEnabled() || !ch.connection.isRecoverable(e) {
 		ch.consumers.close()
 
 		for _, c := range ch.closes {

--- a/channel.go
+++ b/channel.go
@@ -7,9 +7,11 @@ package amqp091
 
 import (
 	"context"
+	"math/rand"
 	"reflect"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // 0      1         3             7                  size+7 size+8
@@ -26,10 +28,11 @@ exchange.  Errors on methods with this Channel as a receiver means this channel
 should be discarded and a new channel established.
 */
 type Channel struct {
-	destructor sync.Once
-	m          sync.Mutex // struct field mutex
-	confirmM   sync.Mutex // publisher confirms state mutex
-	notifyM    sync.RWMutex
+	destructorM sync.Mutex
+	destructed  bool
+	m           sync.Mutex // struct field mutex
+	confirmM    sync.Mutex // publisher confirms state mutex
+	notifyM     sync.RWMutex
 
 	connection *Connection
 
@@ -74,6 +77,8 @@ type Channel struct {
 	message messageWithContent
 	header  *headerFrame
 	body    []byte
+
+	reconnecting sync.Mutex
 }
 
 // Constructs a new channel with the given framing rules
@@ -100,23 +105,34 @@ func (ch *Channel) setClosed() {
 func (ch *Channel) shutdown(e *Error) {
 	ch.setClosed()
 
-	ch.destructor.Do(func() {
-		ch.m.Lock()
-		defer ch.m.Unlock()
+	ch.destructorM.Lock()
+	if ch.destructed {
+		ch.destructorM.Unlock()
+		return
+	}
+	ch.destructed = true
+	ch.destructorM.Unlock()
 
-		// Grab an exclusive lock for the notify channels
-		ch.notifyM.Lock()
-		defer ch.notifyM.Unlock()
+	ch.m.Lock()
+	defer ch.m.Unlock()
 
-		// Broadcast abnormal shutdown
-		if e != nil {
-			for _, c := range ch.closes {
-				c <- e
-			}
-			// Notify RPC if we're selecting
-			ch.errors <- e
+	// Grab an exclusive lock for the notify channels
+	ch.notifyM.Lock()
+	defer ch.notifyM.Unlock()
+
+	// Broadcast abnormal shutdown
+	if e != nil {
+		for _, c := range ch.closes {
+			c <- e
 		}
+		// Notify RPC if we're selecting
+		select {
+		case ch.errors <- e:
+		default:
+		}
+	}
 
+	if e == nil || !ch.connection.IsRecoveryEnabled() {
 		ch.consumers.close()
 
 		for _, c := range ch.closes {
@@ -149,7 +165,10 @@ func (ch *Channel) shutdown(e *Error) {
 		close(ch.errors)
 		close(ch.close)
 		ch.noNotify = true
-	})
+	} else {
+		close(ch.errors)
+		close(ch.close)
+	}
 }
 
 // send calls Channel.sendOpen() during normal operation.
@@ -1124,7 +1143,16 @@ func (ch *Channel) Consume(queue, consumer string, autoAck, exclusive, noLocal, 
 
 	deliveries := make(chan Delivery)
 
-	ch.consumers.add(consumer, deliveries)
+	config := ConsumerConfig{
+		Queue:     queue,
+		Consumer:  consumer,
+		AutoAck:   autoAck,
+		Exclusive: exclusive,
+		NoLocal:   noLocal,
+		NoWait:    noWait,
+		Args:      args,
+	}
+	ch.consumers.add(consumer, deliveries, config)
 
 	if err := ch.call(req, res); err != nil {
 		ch.consumers.cancel(consumer)
@@ -1228,7 +1256,16 @@ func (ch *Channel) ConsumeWithContext(ctx context.Context, queue, consumer strin
 
 	deliveries := make(chan Delivery)
 
-	ch.consumers.add(consumer, deliveries)
+	config := ConsumerConfig{
+		Queue:     queue,
+		Consumer:  consumer,
+		AutoAck:   autoAck,
+		Exclusive: exclusive,
+		NoLocal:   noLocal,
+		NoWait:    noWait,
+		Args:      args,
+	}
+	ch.consumers.add(consumer, deliveries, config)
 
 	if err := ch.call(req, res); err != nil {
 		ch.consumers.cancel(consumer)
@@ -1840,4 +1877,142 @@ func (ch *Channel) GetNextPublishSeqNo() uint64 {
 	defer ch.confirms.publishedMut.Unlock()
 
 	return ch.confirms.published + 1
+}
+
+func (ch *Channel) cleanup() {
+	ch.m.Lock()
+	defer ch.m.Unlock()
+
+	ch.notifyM.Lock()
+	defer ch.notifyM.Unlock()
+
+	ch.consumers.close()
+
+	for _, c := range ch.closes {
+		close(c)
+	}
+
+	for _, c := range ch.flows {
+		close(c)
+	}
+
+	for _, c := range ch.returns {
+		close(c)
+	}
+
+	for _, c := range ch.cancels {
+		close(c)
+	}
+
+	ch.flows = nil
+	ch.closes = nil
+	ch.returns = nil
+	ch.cancels = nil
+
+	if ch.confirms != nil {
+		ch.confirms.Close()
+	}
+
+	ch.noNotify = true
+}
+
+func (ch *Channel) Reconnect() error {
+	if !ch.connection.IsRecoveryEnabled() {
+		return ErrClosed
+	}
+
+	ch.reconnecting.Lock()
+	defer ch.reconnecting.Unlock()
+
+	if !ch.IsClosed() {
+		return nil
+	}
+
+	var err error
+	for i := 0; i < ch.connection.MaxRetryCount(); i++ {
+		Logger.Printf("Channel %d recovery attempt %d of %d", ch.id, i+1, ch.connection.MaxRetryCount())
+		jitter := time.Duration(rand.Intn(500)) * time.Millisecond // Random 500ms jitter to avoid thundering herd
+		time.Sleep(ch.connection.RetryInterval() + jitter)
+
+		// Reset state
+		ch.m.Lock()
+		ch.resetState()
+		ch.m.Unlock()
+
+		if err = ch.open(); err != nil {
+			Logger.Printf("Channel %d recovery open error: %v", ch.id, err)
+			continue
+		}
+
+		// Re-enable confirms if needed
+		if ch.confirming {
+			if err = ch.Confirm(false); err != nil {
+				Logger.Printf("Channel %d recovery Confirm error: %v", ch.id, err)
+				continue
+			}
+		}
+
+		// Re-issue consumers
+		ch.consumers.Lock()
+		configs := make(map[string]ConsumerConfig, len(ch.consumers.configs))
+		for tag, config := range ch.consumers.configs {
+			configs[tag] = config
+		}
+		ch.consumers.Unlock()
+
+		var consumeErr error
+		for tag, config := range configs {
+			req := &basicConsume{
+				Queue:       config.Queue,
+				ConsumerTag: tag,
+				NoLocal:     config.NoLocal,
+				NoAck:       config.AutoAck,
+				Exclusive:   config.Exclusive,
+				NoWait:      config.NoWait,
+				Arguments:   config.Args,
+			}
+			res := &basicConsumeOk{}
+			if err = ch.call(req, res); err != nil {
+				Logger.Printf("Channel %d recovery consume error for tag %s: %v", ch.id, tag, err)
+				consumeErr = err
+				break
+			}
+		}
+
+		if consumeErr != nil {
+			continue
+		}
+
+		Logger.Printf("Channel %d recovery successful", ch.id)
+		return nil
+	}
+
+	Logger.Printf("Channel %d recovery exhausted all %d retries", ch.id, ch.connection.MaxRetryCount())
+	ch.setClosed()
+	return err
+}
+
+// resetState clears the shutdown flags and re-initializes the internal
+// channels so the AMQP channel can be reused after a successful reconnection.
+// The caller must hold ch.m.
+func (ch *Channel) resetState() {
+	ch.closed.Store(false)
+
+	ch.destructorM.Lock()
+	ch.destructed = false
+	ch.destructorM.Unlock()
+
+	ch.errors = make(chan *Error, 1)
+	ch.close = make(chan struct{})
+	ch.rpc = make(chan message)
+
+	if ch.confirms != nil {
+		ch.confirms.publishedMut.Lock()
+		ch.confirms.published = 0
+		ch.confirms.publishedMut.Unlock()
+
+		ch.confirms.m.Lock()
+		ch.confirms.expecting = 1
+		ch.confirms.m.Unlock()
+	}
 }

--- a/channel.go
+++ b/channel.go
@@ -1205,7 +1205,7 @@ func (ch *Channel) Consume(queue, consumer string, autoAck, exclusive, noLocal, 
 
 	deliveries := make(chan Delivery)
 
-	config := ConsumerConfig{
+	config := consumerConfig{
 		Queue:     queue,
 		Consumer:  consumer,
 		AutoAck:   autoAck,
@@ -1318,7 +1318,7 @@ func (ch *Channel) ConsumeWithContext(ctx context.Context, queue, consumer strin
 
 	deliveries := make(chan Delivery)
 
-	config := ConsumerConfig{
+	config := consumerConfig{
 		Queue:     queue,
 		Consumer:  consumer,
 		AutoAck:   autoAck,
@@ -2095,7 +2095,7 @@ func (ch *Channel) setupChannel() error {
 
 	// Re-subscribe consumers
 	ch.consumers.Lock()
-	configs := make(map[string]ConsumerConfig, len(ch.consumers.configs))
+	configs := make(map[string]consumerConfig, len(ch.consumers.configs))
 	for tag, config := range ch.consumers.configs {
 		configs[tag] = config
 	}

--- a/channel.go
+++ b/channel.go
@@ -1939,6 +1939,20 @@ func (ch *Channel) cleanup() {
 	ch.noNotify = true
 }
 
+func (ch *Channel) watchChannel() {
+	errCh := ch.NotifyClose(make(chan *Error, 1))
+	go func() {
+		for err := range errCh {
+			if err != nil {
+				Logger.Printf("Channel %d closed unexpectedly: %v", ch.id, err)
+				if ch.connection.Config.Recovery != nil && ch.connection.Config.Recovery.ConnectionRecovery != nil {
+					ch.connection.Config.Recovery.ConnectionRecovery.OnChannelClose(ch, err)
+				}
+			}
+		}
+	}()
+}
+
 func (ch *Channel) Reconnect() error {
 	if !ch.connection.IsRecoveryEnabled() {
 		return ErrClosed

--- a/channel.go
+++ b/channel.go
@@ -7,7 +7,7 @@ package amqp091
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -184,7 +184,7 @@ func (ch *Channel) shutdown(e *Error) {
 
 		var err error
 		if e != nil {
-			err = errors.New(e.Error())
+			err = fmt.Errorf("%w", e) // preserve the original error type for assertions
 		}
 		ch.lifeCycle.SetState(StateClosed, err)
 	} else {

--- a/channel.go
+++ b/channel.go
@@ -133,6 +133,9 @@ func (ch *Channel) shutdown(e *Error) {
 			default:
 				// If blocked/full, send in a goroutine so we never deadlock the shutdown sequence
 				go func(c chan *Error, e *Error) {
+					defer func() {
+						_ = recover() // Gracefully ignore panics if the channel is closed concurrently
+					}()
 					select {
 					case c <- e:
 					case <-time.After(5 * time.Second):

--- a/channel.go
+++ b/channel.go
@@ -132,8 +132,12 @@ func (ch *Channel) shutdown(e *Error) {
 			case c <- e:
 			default:
 				// If blocked/full, send in a goroutine so we never deadlock the shutdown sequence
-				go func(listener chan *Error, err *Error) {
-					listener <- err
+				go func(c chan *Error, e *Error) {
+					select {
+					case c <- e:
+					case <-time.After(5 * time.Second):
+						// Give up to avoid leaking the goroutine permanently
+					}
 				}(c, e)
 			}
 		}
@@ -2127,6 +2131,6 @@ func (ch *Channel) resetState() {
 	ch.rpc = make(chan message)
 
 	if ch.confirms != nil {
-		ch.confirms.Reset()
+		ch.confirms.reset()
 	}
 }

--- a/channel.go
+++ b/channel.go
@@ -81,6 +81,8 @@ type Channel struct {
 
 	reconnecting sync.Mutex // Mutex for reconnecting channel.
 	lifeCycle    *LifeCycle // The current state of the channel.
+
+	recoveryCancels []chan struct{} // listeners for channel recovery cancellation
 }
 
 // Constructs a new channel with the given framing rules
@@ -509,6 +511,8 @@ code set to '200'.
 It is safe to call this method multiple times.
 */
 func (ch *Channel) Close() error {
+	ch.CloseRecovery() // Stop any active recovery process
+
 	if ch.IsClosed() {
 		return nil
 	}
@@ -557,6 +561,37 @@ func (ch *Channel) NotifyClose(c chan *Error) chan *Error {
 	}
 
 	return c
+}
+
+/*
+NotifyRecoveryCancel registers a listener that is notified (via a channel close)
+when channel recovery has been canceled or aborted (for example, when Close()
+is called during an active channel reconnect process).
+*/
+func (ch *Channel) NotifyRecoveryCancel(receiver chan struct{}) chan struct{} {
+	ch.m.Lock()
+	defer ch.m.Unlock()
+
+	state := ch.lifeCycle.State().getState()
+	if state == stateClosing || state == stateClosed {
+		close(receiver)
+	} else {
+		ch.recoveryCancels = append(ch.recoveryCancels, receiver)
+	}
+
+	return receiver
+}
+
+// CloseRecovery stops any active channel recovery process by notifying
+// and closing all recovery cancellation listeners.
+func (ch *Channel) CloseRecovery() {
+	ch.m.Lock()
+	defer ch.m.Unlock()
+
+	for _, listener := range ch.recoveryCancels {
+		close(listener)
+	}
+	ch.recoveryCancels = nil
 }
 
 /*
@@ -1928,6 +1963,11 @@ func (ch *Channel) cleanup() {
 		close(c)
 	}
 
+	for _, c := range ch.recoveryCancels {
+		close(c)
+	}
+
+	ch.recoveryCancels = nil
 	ch.flows = nil
 	ch.closes = nil
 	ch.returns = nil
@@ -1972,12 +2012,29 @@ func (ch *Channel) Reconnect() error {
 
 	ch.lifeCycle.SetState(&StateReconnecting{})
 
+	cancelCh := ch.NotifyRecoveryCancel(make(chan struct{}))
+
 	var err error
 	for i := 0; i < ch.connection.MaxRetryCount(); i++ {
+		// Exit early if Close() was already called
+		select {
+		case <-cancelCh:
+			Logger.Printf("Channel %d recovery aborted: channel closed.", ch.id)
+			return ErrClosed
+		default:
+		}
+
 		Logger.Printf("Channel %d recovery attempt %d of %d", ch.id, i+1, ch.connection.MaxRetryCount())
 		if i > 0 {
 			jitter := time.Duration(rand.Intn(500)) * time.Millisecond // Random 500ms jitter to avoid thundering herd
-			time.Sleep(ch.connection.RetryInterval() + jitter)
+
+			// Wait with select to allow immediate interruption of sleep
+			select {
+			case <-cancelCh:
+				Logger.Printf("Channel %d recovery aborted: channel closed during backoff.", ch.id)
+				return ErrClosed
+			case <-time.After(ch.connection.RetryInterval() + jitter):
+			}
 		}
 
 		// 1. Reset client-side state

--- a/channel.go
+++ b/channel.go
@@ -1980,6 +1980,7 @@ func (ch *Channel) Reconnect() error {
 			time.Sleep(ch.connection.RetryInterval() + jitter)
 		}
 
+		// 1. Reset client-side state
 		// Reset state under locks to ensure atomicity and prevent data races.
 		// Acquiring destructorM -> m avoids any lock ordering deadlocks.
 		ch.destructorM.Lock()
@@ -1988,50 +1989,22 @@ func (ch *Channel) Reconnect() error {
 		ch.m.Unlock()
 		ch.destructorM.Unlock()
 
+		// 2. Open a fresh channel on the broker
 		if err = ch.open(); err != nil {
 			Logger.Printf("Channel %d recovery open error: %v", ch.id, err)
 			continue
 		}
 
-		// Re-enable confirms if needed
-		if ch.confirming {
-			if err = ch.Confirm(false); err != nil {
-				Logger.Printf("Channel %d recovery Confirm error: %v", ch.id, err)
-				continue
-			}
-		}
-
-		// Re-issue consumers
-		ch.consumers.Lock()
-		configs := make(map[string]ConsumerConfig, len(ch.consumers.configs))
-		for tag, config := range ch.consumers.configs {
-			configs[tag] = config
-		}
-		ch.consumers.Unlock()
-
-		var consumeErr error
-		for tag, config := range configs {
-			req := &basicConsume{
-				Queue:       config.Queue,
-				ConsumerTag: tag,
-				NoLocal:     config.NoLocal,
-				NoAck:       config.AutoAck,
-				Exclusive:   config.Exclusive,
-				NoWait:      config.NoWait,
-				Arguments:   config.Args,
-			}
-			res := &basicConsumeOk{}
-			if err = ch.call(req, res); err != nil {
-				Logger.Printf("Channel %d recovery consume error for tag %s: %v", ch.id, tag, err)
-				consumeErr = err
-				break
-			}
-		}
-
-		if consumeErr != nil {
+		// 3. Perform setup steps. If ANY step fails, we close the channel and retry.
+		if err = ch.setupChannel(); err != nil {
+			Logger.Printf("Channel %d setup failed: %v, closing and retrying...", ch.id, err)
+			ch.setClosed() // Marks closed locally
+			// Send channel.close to the broker so it knows this channel is defunct
+			_ = ch.call(&channelClose{ReplyCode: replySuccess, ReplyText: "Recovery retry"}, &channelCloseOk{})
 			continue
 		}
 
+		// If we reached here, recovery was 100% successful!
 		Logger.Printf("Channel %d recovery successful", ch.id)
 		ch.lifeCycle.SetState(&StateOpen{})
 		return nil
@@ -2041,6 +2014,48 @@ func (ch *Channel) Reconnect() error {
 	ch.setClosed()
 	ch.lifeCycle.SetState(&StateClosed{error: err})
 	return err
+}
+
+// setupChannel performs all channel-level setup steps sequentially.
+// If any of these fail, we return the error immediately so the reconnect loop can try a new channel.
+func (ch *Channel) setupChannel() error {
+	var err error
+	// TODO Re-enable QoS if it was tracked
+
+	// Re-enable confirms if needed
+	if ch.confirming {
+		if err = ch.Confirm(false); err != nil {
+			Logger.Printf("Channel %d recovery Confirm error: %v", ch.id, err)
+			return err
+		}
+	}
+
+	// TODO Recover Topology (Exchanges, Queues, Bindings) here
+
+	// Re-subscribe consumers
+	ch.consumers.Lock()
+	configs := make(map[string]ConsumerConfig, len(ch.consumers.configs))
+	for tag, config := range ch.consumers.configs {
+		configs[tag] = config
+	}
+	ch.consumers.Unlock()
+	for tag, config := range configs {
+		req := &basicConsume{
+			Queue:       config.Queue,
+			ConsumerTag: tag,
+			NoLocal:     config.NoLocal,
+			NoAck:       config.AutoAck,
+			Exclusive:   config.Exclusive,
+			NoWait:      config.NoWait,
+			Arguments:   config.Args,
+		}
+		res := &basicConsumeOk{}
+		if err = ch.call(req, res); err != nil {
+			Logger.Printf("Channel %d recovery consume error for tag %s: %v", ch.id, tag, err)
+			return err
+		}
+	}
+	return nil
 }
 
 // resetState clears the shutdown flags and re-initializes the internal

--- a/channel.go
+++ b/channel.go
@@ -7,6 +7,7 @@ package amqp091
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -29,7 +30,7 @@ should be discarded and a new channel established.
 */
 type Channel struct {
 	destructorM sync.Mutex
-	destructed  bool
+	destructed  bool       // Will be true if the channel has been destroyed, false otherwise.
 	m           sync.Mutex // struct field mutex
 	confirmM    sync.Mutex // publisher confirms state mutex
 	notifyM     sync.RWMutex
@@ -78,7 +79,8 @@ type Channel struct {
 	header  *headerFrame
 	body    []byte
 
-	reconnecting sync.Mutex
+	reconnecting sync.Mutex // Will be true if the channel is reconnecting, false otherwise.
+	lifeCycle    *LifeCycle // The current state of the channel.
 }
 
 // Constructs a new channel with the given framing rules
@@ -92,6 +94,7 @@ func newChannel(c *Connection, id uint16) *Channel {
 		recv:       (*Channel).recvMethod,
 		errors:     make(chan *Error, 1),
 		close:      make(chan struct{}),
+		lifeCycle:  NewLifeCycle(),
 	}
 }
 
@@ -123,7 +126,14 @@ func (ch *Channel) shutdown(e *Error) {
 	// Broadcast abnormal shutdown
 	if e != nil {
 		for _, c := range ch.closes {
-			c <- e
+			select {
+			case c <- e:
+			default:
+				// If blocked/full, send in a goroutine so we never deadlock the shutdown sequence
+				go func(listener chan *Error, err *Error) {
+					listener <- err
+				}(c, e)
+			}
 		}
 		// Notify RPC if we're selecting
 		select {
@@ -165,6 +175,12 @@ func (ch *Channel) shutdown(e *Error) {
 		close(ch.errors)
 		close(ch.close)
 		ch.noNotify = true
+
+		var err error
+		if e != nil {
+			err = errors.New(e.Error())
+		}
+		ch.lifeCycle.SetState(&StateClosed{error: err})
 	} else {
 		close(ch.errors)
 		close(ch.close)
@@ -497,6 +513,8 @@ func (ch *Channel) Close() error {
 		return nil
 	}
 
+	ch.lifeCycle.SetState(&StateClosing{})
+
 	defer ch.connection.closeChannel(ch, nil)
 	return ch.call(
 		&channelClose{ReplyCode: replySuccess},
@@ -508,6 +526,11 @@ func (ch *Channel) Close() error {
 // is returned.
 func (ch *Channel) IsClosed() bool {
 	return ch.closed.Load()
+}
+
+// NotifyStateChange registers a listener for state changes.
+func (ch *Channel) NotifyStateChange(c chan *StateChanged) {
+	ch.lifeCycle.notifyStateChange(c)
 }
 
 /*
@@ -1928,11 +1951,15 @@ func (ch *Channel) Reconnect() error {
 		return nil
 	}
 
+	ch.lifeCycle.SetState(&StateReconnecting{})
+
 	var err error
 	for i := 0; i < ch.connection.MaxRetryCount(); i++ {
 		Logger.Printf("Channel %d recovery attempt %d of %d", ch.id, i+1, ch.connection.MaxRetryCount())
-		jitter := time.Duration(rand.Intn(500)) * time.Millisecond // Random 500ms jitter to avoid thundering herd
-		time.Sleep(ch.connection.RetryInterval() + jitter)
+		if i > 0 {
+			jitter := time.Duration(rand.Intn(500)) * time.Millisecond // Random 500ms jitter to avoid thundering herd
+			time.Sleep(ch.connection.RetryInterval() + jitter)
+		}
 
 		// Reset state
 		ch.m.Lock()
@@ -1984,11 +2011,13 @@ func (ch *Channel) Reconnect() error {
 		}
 
 		Logger.Printf("Channel %d recovery successful", ch.id)
+		ch.lifeCycle.SetState(&StateOpen{})
 		return nil
 	}
 
 	Logger.Printf("Channel %d recovery exhausted all %d retries", ch.id, ch.connection.MaxRetryCount())
 	ch.setClosed()
+	ch.lifeCycle.SetState(&StateClosed{error: err})
 	return err
 }
 
@@ -2007,12 +2036,6 @@ func (ch *Channel) resetState() {
 	ch.rpc = make(chan message)
 
 	if ch.confirms != nil {
-		ch.confirms.publishedMut.Lock()
-		ch.confirms.published = 0
-		ch.confirms.publishedMut.Unlock()
-
-		ch.confirms.m.Lock()
-		ch.confirms.expecting = 1
-		ch.confirms.m.Unlock()
+		ch.confirms.Reset()
 	}
 }

--- a/channel.go
+++ b/channel.go
@@ -29,11 +29,11 @@ exchange.  Errors on methods with this Channel as a receiver means this channel
 should be discarded and a new channel established.
 */
 type Channel struct {
-	destructorM sync.Mutex
-	destructed  bool       // Will be true if the channel has been destroyed, false otherwise.
-	m           sync.Mutex // struct field mutex
-	confirmM    sync.Mutex // publisher confirms state mutex
-	notifyM     sync.RWMutex
+	destructorM sync.Mutex   // Mutex for destroying the channel.
+	destructed  bool         // Will be true if the channel has been destroyed, false otherwise.
+	m           sync.Mutex   // Mutex for the channel.
+	confirmM    sync.Mutex   // Mutex for the publisher confirms state.
+	notifyM     sync.RWMutex // Mutex for the notify state.
 
 	connection *Connection
 
@@ -79,7 +79,7 @@ type Channel struct {
 	header  *headerFrame
 	body    []byte
 
-	reconnecting sync.Mutex // Will be true if the channel is reconnecting, false otherwise.
+	reconnecting sync.Mutex // Mutex for reconnecting channel.
 	lifeCycle    *LifeCycle // The current state of the channel.
 }
 
@@ -1902,6 +1902,7 @@ func (ch *Channel) GetNextPublishSeqNo() uint64 {
 	return ch.confirms.published + 1
 }
 
+// cleanup closes all the channels and the confirms.
 func (ch *Channel) cleanup() {
 	ch.m.Lock()
 	defer ch.m.Unlock()
@@ -1939,6 +1940,7 @@ func (ch *Channel) cleanup() {
 	ch.noNotify = true
 }
 
+// watchChannel watches the channel for close events and triggers recovery if needed.
 func (ch *Channel) watchChannel() {
 	errCh := ch.NotifyClose(make(chan *Error, 1))
 	go func() {
@@ -1953,6 +1955,9 @@ func (ch *Channel) watchChannel() {
 	}()
 }
 
+// Reconnect initiates automatic channel recovery,
+// re-opens the AMQP channel with the same channel id and configuration,
+// and re-establishes all active publisher confirmations and consumer subscriptions.
 func (ch *Channel) Reconnect() error {
 	if !ch.connection.IsRecoveryEnabled() {
 		return ErrClosed

--- a/channel.go
+++ b/channel.go
@@ -80,7 +80,7 @@ type Channel struct {
 	body    []byte
 
 	reconnecting sync.Mutex // Mutex for reconnecting channel.
-	lifeCycle    *LifeCycle // The current state of the channel.
+	lifeCycle    *lifeCycle // The current state of the channel.
 
 	recoveryCancels []chan struct{} // listeners for channel recovery cancellation
 }
@@ -96,7 +96,7 @@ func newChannel(c *Connection, id uint16) *Channel {
 		recv:       (*Channel).recvMethod,
 		errors:     make(chan *Error, 1),
 		close:      make(chan struct{}),
-		lifeCycle:  NewLifeCycle(),
+		lifeCycle:  newLifeCycle(),
 	}
 }
 
@@ -186,7 +186,7 @@ func (ch *Channel) shutdown(e *Error) {
 		if e != nil {
 			err = errors.New(e.Error())
 		}
-		ch.lifeCycle.SetState(&StateClosed{error: err})
+		ch.lifeCycle.SetState(StateClosed, err)
 	} else {
 		close(ch.errors)
 		close(ch.close)
@@ -521,7 +521,7 @@ func (ch *Channel) Close() error {
 		return nil
 	}
 
-	ch.lifeCycle.SetState(&StateClosing{})
+	ch.lifeCycle.SetState(StateClosing, nil)
 
 	defer ch.connection.closeChannel(ch, nil)
 	return ch.call(
@@ -576,8 +576,8 @@ func (ch *Channel) NotifyRecoveryCancel(receiver chan struct{}) chan struct{} {
 	ch.m.Lock()
 	defer ch.m.Unlock()
 
-	state := ch.lifeCycle.State().getState()
-	if state == stateClosing || state == stateClosed {
+	state := ch.lifeCycle.State()
+	if state == StateClosing || state == StateClosed {
 		close(receiver)
 	} else {
 		ch.recoveryCancels = append(ch.recoveryCancels, receiver)
@@ -2014,7 +2014,7 @@ func (ch *Channel) Reconnect() error {
 		return nil
 	}
 
-	ch.lifeCycle.SetState(&StateReconnecting{})
+	ch.lifeCycle.SetState(StateReconnecting, nil)
 
 	cancelCh := ch.NotifyRecoveryCancel(make(chan struct{}))
 
@@ -2067,13 +2067,13 @@ func (ch *Channel) Reconnect() error {
 
 		// If we reached here, recovery was 100% successful!
 		Logger.Printf("Channel %d recovery successful", ch.id)
-		ch.lifeCycle.SetState(&StateOpen{})
+		ch.lifeCycle.SetState(StateOpen, nil)
 		return nil
 	}
 
 	Logger.Printf("Channel %d recovery exhausted all %d retries", ch.id, ch.connection.MaxRetryCount())
 	ch.setClosed()
-	ch.lifeCycle.SetState(&StateClosed{error: err})
+	ch.lifeCycle.SetState(StateClosed, err)
 	return err
 }
 

--- a/channel.go
+++ b/channel.go
@@ -515,7 +515,7 @@ code set to '200'.
 It is safe to call this method multiple times.
 */
 func (ch *Channel) Close() error {
-	ch.CloseRecovery() // Stop any active recovery process
+	ch.closeRecovery() // Stop any active recovery process
 
 	if ch.IsClosed() {
 		return nil
@@ -586,9 +586,9 @@ func (ch *Channel) NotifyRecoveryCancel(receiver chan struct{}) chan struct{} {
 	return receiver
 }
 
-// CloseRecovery stops any active channel recovery process by notifying
+// closeRecovery stops any active channel recovery process by notifying
 // and closing all recovery cancellation listeners.
-func (ch *Channel) CloseRecovery() {
+func (ch *Channel) closeRecovery() {
 	ch.m.Lock()
 	defer ch.m.Unlock()
 

--- a/channel.go
+++ b/channel.go
@@ -114,7 +114,7 @@ func (ch *Channel) shutdown(e *Error) {
 		return
 	}
 	ch.destructed = true
-	ch.destructorM.Unlock()
+	defer ch.destructorM.Unlock()
 
 	ch.m.Lock()
 	defer ch.m.Unlock()
@@ -1961,10 +1961,13 @@ func (ch *Channel) Reconnect() error {
 			time.Sleep(ch.connection.RetryInterval() + jitter)
 		}
 
-		// Reset state
+		// Reset state under locks to ensure atomicity and prevent data races.
+		// Acquiring destructorM -> m avoids any lock ordering deadlocks.
+		ch.destructorM.Lock()
 		ch.m.Lock()
 		ch.resetState()
 		ch.m.Unlock()
+		ch.destructorM.Unlock()
 
 		if err = ch.open(); err != nil {
 			Logger.Printf("Channel %d recovery open error: %v", ch.id, err)
@@ -2023,13 +2026,10 @@ func (ch *Channel) Reconnect() error {
 
 // resetState clears the shutdown flags and re-initializes the internal
 // channels so the AMQP channel can be reused after a successful reconnection.
-// The caller must hold ch.m.
+// The caller must hold ch.destructorM and ch.m.
 func (ch *Channel) resetState() {
 	ch.closed.Store(false)
-
-	ch.destructorM.Lock()
 	ch.destructed = false
-	ch.destructorM.Unlock()
 
 	ch.errors = make(chan *Error, 1)
 	ch.close = make(chan struct{})

--- a/confirms.go
+++ b/confirms.go
@@ -123,9 +123,9 @@ func (c *confirms) Close() error {
 	return nil
 }
 
-// Reset clears any pending deferred confirmations and resets the sequencer
+// reset clears any pending deferred confirmations and resets the sequencer
 // state for recovery, while keeping the listeners intact.
-func (c *confirms) Reset() {
+func (c *confirms) reset() {
 	c.m.Lock()
 	defer c.m.Unlock()
 

--- a/confirms.go
+++ b/confirms.go
@@ -126,13 +126,13 @@ func (c *confirms) Close() error {
 // Reset clears any pending deferred confirmations and resets the sequencer
 // state for recovery, while keeping the listeners intact.
 func (c *confirms) Reset() {
-	c.publishedMut.Lock()
-	c.published = 0
-	c.publishedMut.Unlock()
-
 	c.m.Lock()
 	defer c.m.Unlock()
 
+	c.publishedMut.Lock()
+	defer c.publishedMut.Unlock()
+
+	c.published = 0
 	c.expecting = 1
 	c.deferredConfirmations.Close()
 	c.sequencer = map[uint64]Confirmation{}

--- a/confirms.go
+++ b/confirms.go
@@ -123,6 +123,21 @@ func (c *confirms) Close() error {
 	return nil
 }
 
+// Reset clears any pending deferred confirmations and resets the sequencer
+// state for recovery, while keeping the listeners intact.
+func (c *confirms) Reset() {
+	c.publishedMut.Lock()
+	c.published = 0
+	c.publishedMut.Unlock()
+
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	c.expecting = 1
+	c.deferredConfirmations.Close()
+	c.sequencer = map[uint64]Confirmation{}
+}
+
 type deferredConfirmations struct {
 	m             sync.Mutex
 	confirmations map[uint64]*DeferredConfirmation

--- a/connection.go
+++ b/connection.go
@@ -331,7 +331,7 @@ func DialConfig(url string, config Config) (*Connection, error) {
 	c, err := Open(conn, config)
 	if c != nil && c.IsRecoveryEnabled() {
 		c.url = url
-		config.Recovery.ConnectionRecovery.WatchConnection(c)
+		c.watchConnection()
 	}
 
 	return c, err
@@ -1025,7 +1025,7 @@ func (c *Connection) openChannel() (*Channel, error) {
 	ch.lifeCycle.SetState(&StateOpen{})
 
 	if c.IsRecoveryEnabled() {
-		c.Config.Recovery.ConnectionRecovery.WatchChannel(ch)
+		ch.watchChannel()
 	}
 
 	return ch, nil
@@ -1340,6 +1340,20 @@ func (c *Connection) cleanup() {
 	c.noNotify = true
 }
 
+func (c *Connection) watchConnection() {
+	errCh := c.NotifyClose(make(chan *Error, 1))
+	go func() {
+		for err := range errCh {
+			if err != nil {
+				Logger.Printf("Connection closed unexpectedly: %v", err)
+				if c.Config.Recovery != nil && c.Config.Recovery.ConnectionRecovery != nil {
+					c.Config.Recovery.ConnectionRecovery.OnConnectionClose(c, err)
+				}
+			}
+		}
+	}()
+}
+
 // ReconnectionConfig is the configuration for the reconnection.
 type ReconnectionConfig struct {
 	MaxRetryCount int           // The maximum number of retries.
@@ -1347,11 +1361,15 @@ type ReconnectionConfig struct {
 }
 
 // IConnectionRecovery is the interface for the connection recovery.
+//
+// The err parameter in OnConnectionClose and OnChannelClose provides the reason
+// why the connection or channel was closed. Custom implementations can use this
+// parameter to perform conditional recovery (e.g., skip recovery for specific
+// protocol errors like 403 ACCESS_REFUSED or 404 NOT_FOUND), log errors to
+// external monitoring systems (e.g., Prometheus), or trigger alerts.
 type IConnectionRecovery interface {
 	OnConnectionClose(conn *Connection, err *Error) // Called when the connection is closed.
 	OnChannelClose(ch *Channel, err *Error)         // Called when the channel is closed.
-	WatchConnection(conn *Connection)               // Watch the connection for closed events.
-	WatchChannel(ch *Channel)                       // Watch the channel for closed events.
 }
 
 // Recovery is the configuration for the recovery.
@@ -1365,54 +1383,34 @@ type DefaultConnectionRecovery struct {
 	config *ReconnectionConfig // The configuration for the reconnection.
 }
 
-func (d *DefaultConnectionRecovery) WatchConnection(conn *Connection) {
-	errCh := conn.NotifyClose(make(chan *Error, 1))
-	go func() {
-		for err := range errCh {
-			if err != nil {
-				Logger.Printf("Connection closed unexpectedly: %v", err)
-				d.OnConnectionClose(conn, err)
-			}
-		}
-	}()
-}
-
-func (d *DefaultConnectionRecovery) WatchChannel(ch *Channel) {
-	errCh := ch.NotifyClose(make(chan *Error, 1))
-	go func() {
-		for err := range errCh {
-			if err != nil {
-				Logger.Printf("Channel %d closed unexpectedly: %v", ch.id, err)
-				d.OnChannelClose(ch, err)
-			}
-		}
-	}()
-}
-
 func (d *DefaultConnectionRecovery) OnConnectionClose(conn *Connection, err *Error) {
+	Logger.Printf("Connection closed with error: %v", err)
 	if !conn.IsRecoveryEnabled() {
-		Logger.Printf("Connection %d recovery is not enabled, skipping reconnect", conn.url)
+		Logger.Printf("Connection %s recovery is not enabled, skipping reconnect. ", conn.url)
 		return
 	}
 
+	Logger.Printf("Initiating connection recovery for %s.", conn.url)
 	// Reconnect connection
 	if err := conn.Reconnect(); err != nil {
-		Logger.Printf("Connection %d recovery failed: %v.", conn.url, err)
+		Logger.Printf("Connection %s recovery failed: %v.", conn.url, err)
 		conn.cleanup()
 	}
 }
 
 func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
+	Logger.Printf("Channel %d closed with error: %v", ch.id, err)
 	if !ch.connection.IsRecoveryEnabled() {
-		Logger.Printf("Channel %d recovery is not enabled, skipping reconnect", ch.id)
+		Logger.Printf("Channel %d recovery is not enabled, skipping reconnect.", ch.id)
 		return
 	}
 
 	if ch.connection.IsClosed() {
-		Logger.Printf("Connection is closed, letting connection recovery handle channel %d", ch.id)
+		Logger.Printf("Connection is closed, letting connection recovery handle channel %d.", ch.id)
 		return
 	}
 
+	Logger.Printf("Initiating channel %d recovery", ch.id)
 	// Reconnect channel
 	if err := ch.Reconnect(); err != nil {
 		Logger.Printf("Channel %d recovery failed: %v.", ch.id, err)

--- a/connection.go
+++ b/connection.go
@@ -766,8 +766,12 @@ func (c *Connection) shutdown(err *Error) {
 			case listener <- err:
 			default:
 				// If blocked/full, send in a goroutine so we never deadlock the shutdown sequence
-				go func(l chan *Error, e *Error) {
-					l <- e
+				go func(listener chan *Error, err *Error) {
+					select {
+					case listener <- err:
+					case <-time.After(5 * time.Second):
+						// Give up to avoid leaking the goroutine permanently
+					}
 				}(listener, err)
 			}
 		}

--- a/connection.go
+++ b/connection.go
@@ -135,7 +135,7 @@ type Connection struct {
 	closed atomic.Bool // Will be true if the connection is closed, false otherwise.
 
 	reconnecting sync.Mutex // Mutex for protecting reconnect/recovery operations to ensure serialization and prevent race conditions.
-	lifeCycle    *LifeCycle // The current state of the connection.
+	lifeCycle    *lifeCycle // The current state of the connection.
 
 	recoveryCancels []chan struct{} // listeners for connection recovery cancellation
 }
@@ -353,12 +353,12 @@ func Open(conn io.ReadWriteCloser, config Config) (*Connection, error) {
 		close:     make(chan struct{}),
 		deadlines: make(chan readDeadliner, 1),
 		Config:    config,
-		lifeCycle: NewLifeCycle(),
+		lifeCycle: newLifeCycle(),
 	}
 	go c.reader(conn)
 	err := c.open(config)
 	if err == nil {
-		c.lifeCycle.SetState(&StateOpen{})
+		c.lifeCycle.SetState(StateOpen, nil)
 	}
 	return c, err
 }
@@ -459,8 +459,8 @@ func (c *Connection) NotifyRecoveryCancel(receiver chan struct{}) chan struct{} 
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	state := c.lifeCycle.State().getState()
-	if state == stateClosing || state == stateClosed {
+	state := c.lifeCycle.State()
+	if state == StateClosing || state == StateClosed {
 		close(receiver)
 	} else {
 		c.recoveryCancels = append(c.recoveryCancels, receiver)
@@ -524,7 +524,7 @@ func (c *Connection) Close() error {
 		return ErrClosed
 	}
 
-	c.lifeCycle.SetState(&StateClosing{})
+	c.lifeCycle.SetState(StateClosing, nil)
 
 	var handshakeErr error
 	var initiated bool
@@ -817,7 +817,7 @@ func (c *Connection) shutdown(err *Error) {
 		if err != nil {
 			e = errors.New(err.Error())
 		}
-		c.lifeCycle.SetState(&StateClosed{error: e})
+		c.lifeCycle.SetState(StateClosed, e)
 	}
 }
 
@@ -1064,7 +1064,7 @@ func (c *Connection) openChannel() (*Channel, error) {
 		return nil, err
 	}
 
-	ch.lifeCycle.SetState(&StateOpen{})
+	ch.lifeCycle.SetState(StateOpen, nil)
 
 	if c.IsRecoveryEnabled() {
 		ch.watchChannel()
@@ -1424,7 +1424,7 @@ func (c *Connection) Reconnect() error {
 		return nil
 	}
 
-	c.lifeCycle.SetState(&StateReconnecting{})
+	c.lifeCycle.SetState(StateReconnecting, nil)
 
 	cancelCh := c.NotifyRecoveryCancel(make(chan struct{}))
 
@@ -1521,7 +1521,7 @@ func (c *Connection) Reconnect() error {
 		}
 
 		Logger.Printf("Connection recovery successful")
-		c.lifeCycle.SetState(&StateOpen{})
+		c.lifeCycle.SetState(StateOpen, nil)
 		return nil
 	}
 
@@ -1530,7 +1530,7 @@ func (c *Connection) Reconnect() error {
 		c.conn.Close()
 	}
 	c.closed.Store(true)
-	c.lifeCycle.SetState(&StateClosed{error: err})
+	c.lifeCycle.SetState(StateClosed, err)
 
 	return err
 }

--- a/connection.go
+++ b/connection.go
@@ -76,10 +76,18 @@ type Config struct {
 	// used during TLS and AMQP handshaking.
 	Dial func(network, addr string) (net.Conn, error)
 
-	// Recovery configuration for automatic reconnection
+	// Recovery configuration for automatic reconnection.
+	//
+	// Experimental: This is an experimental feature and may be subject to API or
+	// behavioral changes in future releases.
+	//
 	// When a network failure occurs, the connection and all its channels will automatically
 	// attempt to reconnect based on the parameters specified in the Recovery configuration.
-	// If `recovery` is nil, a default recovery configuration is used.
+	//
+	// If Recovery is nil, automatic reconnection is disabled.
+	// If Recovery.ReconnectionConfig is nil, a default reconnection configuration (DefaultReconnectionConfig) is used.
+	// If Recovery.ConnectionRecovery is nil, a default connection recovery implementation (DefaultConnectionRecovery) is used.
+	//
 	// During the recovery process, applications can monitor state changes (such as reconnecting
 	// or closed) by registering a listener using `Connection.NotifyStateChange` and
 	// `Channel.NotifyStateChange`.
@@ -405,6 +413,9 @@ func (c *Connection) ConnectionState() tls.ConnectionState {
 }
 
 // NotifyStateChange registers a listener for state changes.
+//
+// It is necessary to continuously consume from the channel passed to NotifyStateChange
+// to avoid blocking internal state dispatch routines and leaking goroutines.
 func (c *Connection) NotifyStateChange(ch chan *StateChanged) {
 	c.lifeCycle.notifyStateChange(ch)
 }

--- a/connection.go
+++ b/connection.go
@@ -97,10 +97,10 @@ func NewConnectionProperties() Table {
 // multiplexed on this channel.  There must always be active receivers for
 // every asynchronous message on this connection.
 type Connection struct {
-	destructorM sync.Mutex // teardown: notify listeners, close channels and the socket
-	destructed  bool
-	closeM      sync.Mutex // handshake: send one `connection.close` frame
-	closeInit   bool
+	destructorM sync.Mutex // Mutex for connection teardown: notifying close/block listeners, closing channels, and closing the underlying socket
+	destructed  bool       // true when the connection has been destructed (teardown is initiated or completed)
+	closeM      sync.Mutex // Mutex for connection close handshake: sending a single connection.close frame to the broker
+	closeInit   bool       // true when a connection close has been initiated (connection.close frame has been or is being sent)
 	sendM       sync.Mutex // conn writer mutex
 	m           sync.Mutex // struct field mutex
 
@@ -124,7 +124,7 @@ type Connection struct {
 
 	Config Config // The negotiated Config after connection.open
 
-	url string // Stored for recovery
+	url string // Connection URL stored for recovery
 
 	Major      int      // Server's major version
 	Minor      int      // Server's minor version
@@ -133,7 +133,7 @@ type Connection struct {
 
 	closed atomic.Bool // Will be true if the connection is closed, false otherwise.
 
-	reconnecting sync.Mutex // Will be true if the connection is reconnecting, false otherwise.
+	reconnecting sync.Mutex // Mutex for protecting reconnect/recovery operations to ensure serialization and prevent race conditions.
 	lifeCycle    *LifeCycle // The current state of the connection.
 }
 
@@ -317,8 +317,8 @@ func DialConfig(url string, config Config) (*Connection, error) {
 	if config.Recovery != nil {
 		if config.Recovery.ReconnectionConfig == nil {
 			config.Recovery.ReconnectionConfig = DefaultReconnectionConfig.Clone()
-		} else if config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes == nil {
-			config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes = DefaultRecoverableExceptionsCodes
+		} else if config.Recovery.ReconnectionConfig.RecoverableErrorCodes == nil {
+			config.Recovery.ReconnectionConfig.RecoverableErrorCodes = DefaultRecoverableErrorCodes
 		}
 		if config.Recovery.ConnectionRecovery == nil {
 			config.Recovery.ConnectionRecovery = &DefaultConnectionRecovery{
@@ -1318,6 +1318,7 @@ func pick(client, server int) int {
 	return min(client, server)
 }
 
+// cleanup releases registered resources and performs final teardown of the connection.
 func (c *Connection) cleanup() {
 	c.m.Lock()
 	defer c.m.Unlock()
@@ -1339,6 +1340,7 @@ func (c *Connection) cleanup() {
 	c.noNotify = true
 }
 
+// watchConnection watches the connection for close events and triggers recovery if needed.
 func (c *Connection) watchConnection() {
 	errCh := c.NotifyClose(make(chan *Error, 1))
 	go func() {
@@ -1353,7 +1355,10 @@ func (c *Connection) watchConnection() {
 	}()
 }
 
-// Reconnect reconnects the connection.
+// Reconnect establishes a new socket connection, replaces the existing closed/closing connection,
+// and recovers both connection and channel states.
+// It performs a retry loop to dial the broker, negotiate the AMQP handshake, and recover all
+// active channels and their registered consumers sequentially.
 func (c *Connection) Reconnect() error {
 	if !c.IsRecoveryEnabled() {
 		return ErrClosed
@@ -1497,7 +1502,23 @@ func (c *Connection) IsRecoveryEnabled() bool {
 	return c.Config.Recovery != nil &&
 		c.Config.Recovery.ReconnectionConfig != nil &&
 		c.Config.Recovery.ReconnectionConfig.MaxRetryCount > 0 &&
-		len(c.Config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes) > 0
+		len(c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes) > 0
+}
+
+// isRecoverable returns true if the given error is recoverable based on RecoverableErrorCodes.
+func (c *Connection) isRecoverable(err *Error) bool {
+	if !c.IsRecoveryEnabled() {
+		return false
+	}
+	if err == nil {
+		return true
+	}
+	for _, code := range c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes {
+		if err.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 // MaxRetryCount returns the maximum number of retries if recovery is enabled, otherwise returns 0.
@@ -1514,4 +1535,28 @@ func (c *Connection) RetryInterval() time.Duration {
 		return c.Config.Recovery.ReconnectionConfig.RetryInterval
 	}
 	return 0
+}
+
+// SetRecoverableErrorCodes sets the list of error codes that trigger recovery.
+func (c *Connection) SetRecoverableErrorCodes(codes []int) error {
+	if c == nil {
+		return ErrClosed
+	}
+	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
+		return ErrRecoveryNotEnabled
+	}
+	c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes = codes
+	return nil
+}
+
+// AddRecoverableErrorCodes adds one or more error codes to the list of recoverable error codes.
+func (c *Connection) AddRecoverableErrorCodes(codes ...int) error {
+	if c == nil {
+		return ErrClosed
+	}
+	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
+		return ErrRecoveryNotEnabled
+	}
+	c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes = append(c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes, codes...)
+	return nil
 }

--- a/connection.go
+++ b/connection.go
@@ -133,7 +133,8 @@ type Connection struct {
 
 	closed atomic.Bool // Will be true if the connection is closed, false otherwise.
 
-	reconnecting sync.Mutex
+	reconnecting sync.Mutex // Will be true if the connection is reconnecting, false otherwise.
+	lifeCycle    *LifeCycle // The current state of the connection.
 }
 
 type readDeadliner interface {
@@ -198,6 +199,28 @@ func DialTLS_ExternalAuth(url string, amqps *tls.Config) (*Connection, error) {
 		TLSClientConfig: amqps,
 		SASL:            []Authentication{&ExternalAuth{}},
 	})
+}
+
+/*
+DialRecovery dials a connection with the given URL and recovery configuration.
+
+When a network failure occurs, the connection and all its channels will automatically
+attempt to reconnect based on the parameters specified in the Recovery configuration.
+If `recovery` is nil, a default recovery configuration is used.
+
+During the recovery process, applications can monitor state changes (such as reconnecting
+or closed) by registering a listener using `Connection.NotifyStateChange` and
+`Channel.NotifyStateChange`.
+*/
+func DialRecovery(url string, recovery *Recovery) (*Connection, error) {
+	if recovery == nil {
+		recovery = &Recovery{}
+	}
+	config := Config{
+		Locale:   defaultLocale,
+		Recovery: recovery,
+	}
+	return DialConfig(url, config)
 }
 
 // DialConfig accepts a string in the AMQP URI format and a configuration for
@@ -330,9 +353,14 @@ func Open(conn io.ReadWriteCloser, config Config) (*Connection, error) {
 		close:     make(chan struct{}),
 		deadlines: make(chan readDeadliner, 1),
 		Config:    config,
+		lifeCycle: NewLifeCycle(),
 	}
 	go c.reader(conn)
-	return c, c.open(config)
+	err := c.open(config)
+	if err == nil {
+		c.lifeCycle.SetState(&StateOpen{})
+	}
+	return c, err
 }
 
 /*
@@ -386,6 +414,11 @@ func (c *Connection) ConnectionState() tls.ConnectionState {
 		return conn.ConnectionState()
 	}
 	return tls.ConnectionState{}
+}
+
+// NotifyStateChange registers a listener for state changes.
+func (c *Connection) NotifyStateChange(ch chan *StateChanged) {
+	c.lifeCycle.notifyStateChange(ch)
 }
 
 /*
@@ -454,6 +487,8 @@ func (c *Connection) Close() error {
 	if c.IsClosed() {
 		return ErrClosed
 	}
+
+	c.lifeCycle.SetState(&StateClosing{})
 
 	var handshakeErr error
 	var initiated bool
@@ -690,7 +725,14 @@ func (c *Connection) shutdown(err *Error) {
 
 	if err != nil {
 		for _, listener := range c.closes {
-			listener <- err
+			select {
+			case listener <- err:
+			default:
+				// If blocked/full, send in a goroutine so we never deadlock the shutdown sequence
+				go func(l chan *Error, e *Error) {
+					l <- e
+				}(listener, err)
+			}
 		}
 
 		select {
@@ -729,6 +771,12 @@ func (c *Connection) shutdown(err *Error) {
 		c.channels = nil
 		c.allocator = nil
 		c.noNotify = true
+
+		var e error
+		if err != nil {
+			e = errors.New(err.Error())
+		}
+		c.lifeCycle.SetState(&StateClosed{error: e})
 	}
 }
 
@@ -866,7 +914,7 @@ func (c *Connection) reader(r io.Reader) {
 
 // Ensures that at least one frame is being sent at the tuned interval with a
 // jitter tolerance of 1s
-func (c *Connection) heartbeater(interval time.Duration, done chan *Error) {
+func (c *Connection) heartbeater(interval time.Duration, done chan struct{}) {
 	const maxServerHeartbeatsInFlight = 3
 
 	var sendTicks <-chan time.Time
@@ -974,6 +1022,8 @@ func (c *Connection) openChannel() (*Channel, error) {
 		c.releaseChannel(ch)
 		return nil, err
 	}
+
+	ch.lifeCycle.SetState(&StateOpen{})
 
 	if c.IsRecoveryEnabled() {
 		c.Config.Recovery.ConnectionRecovery.WatchChannel(ch)
@@ -1143,7 +1193,7 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 
 	// "The client should start sending heartbeats after receiving a
 	// Connection.Tune method"
-	go c.heartbeater(c.Config.Heartbeat/2, c.NotifyClose(make(chan *Error, 1)))
+	go c.heartbeater(c.Config.Heartbeat/2, c.close)
 
 	if err := c.send(&methodFrame{
 		ChannelId: 0,
@@ -1291,29 +1341,29 @@ func (c *Connection) cleanup() {
 	c.noNotify = true
 }
 
+// ReconnectionConfig is the configuration for the reconnection.
 type ReconnectionConfig struct {
-	MaxRetryCount int
-	RetryInterval time.Duration
+	MaxRetryCount int           // The maximum number of retries.
+	RetryInterval time.Duration // The interval between retries.
 }
 
+// IConnectionRecovery is the interface for the connection recovery.
 type IConnectionRecovery interface {
-	OnConnectionClose(conn *Connection, err *Error)
-	OnChannelClose(ch *Channel, err *Error)
-	WatchConnection(conn *Connection)
-	WatchChannel(ch *Channel)
+	OnConnectionClose(conn *Connection, err *Error) // Called when the connection is closed.
+	OnChannelClose(ch *Channel, err *Error)         // Called when the channel is closed.
+	WatchConnection(conn *Connection)               // Watch the connection for closed events.
+	WatchChannel(ch *Channel)                       // Watch the channel for closed events.
 }
 
-type ITopologyRecovery interface {
-}
-
+// Recovery is the configuration for the recovery.
 type Recovery struct {
-	ReconnectionConfig *ReconnectionConfig
-	ConnectionRecovery IConnectionRecovery
-	TopologyRecovery   ITopologyRecovery
+	ReconnectionConfig *ReconnectionConfig // The configuration for the reconnection.
+	ConnectionRecovery IConnectionRecovery // The implementation of the connection recovery.
 }
 
+// DefaultConnectionRecovery is the default implementation of the connection recovery.
 type DefaultConnectionRecovery struct {
-	config *ReconnectionConfig
+	config *ReconnectionConfig // The configuration for the reconnection.
 }
 
 func (d *DefaultConnectionRecovery) WatchConnection(conn *Connection) {
@@ -1371,17 +1421,7 @@ func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
 	}
 }
 
-func DialRecovery(url string, recovery *Recovery) (*Connection, error) {
-	if recovery == nil {
-		recovery = &Recovery{}
-	}
-	config := Config{
-		Locale:   defaultLocale,
-		Recovery: recovery,
-	}
-	return DialConfig(url, config)
-}
-
+// Reconnect reconnects the connection.
 func (c *Connection) Reconnect() error {
 	if !c.IsRecoveryEnabled() {
 		return ErrClosed
@@ -1393,6 +1433,8 @@ func (c *Connection) Reconnect() error {
 	if !c.IsClosed() {
 		return nil
 	}
+
+	c.lifeCycle.SetState(&StateReconnecting{})
 
 	var err error
 	for i := 0; i < c.MaxRetryCount(); i++ {
@@ -1408,7 +1450,8 @@ func (c *Connection) Reconnect() error {
 		}
 
 		// We need to parse URL to get addr
-		uri, err := ParseURI(c.url)
+		var uri URI
+		uri, err = ParseURI(c.url)
 		if err != nil {
 			Logger.Printf("Connection recovery failed to parse URI: %v", err)
 			return err
@@ -1471,6 +1514,7 @@ func (c *Connection) Reconnect() error {
 		}
 
 		Logger.Printf("Connection recovery successful")
+		c.lifeCycle.SetState(&StateOpen{})
 		return nil
 	}
 
@@ -1479,6 +1523,7 @@ func (c *Connection) Reconnect() error {
 		c.conn.Close()
 	}
 	c.closed.Store(true)
+	c.lifeCycle.SetState(&StateClosed{error: err})
 
 	return err
 }
@@ -1504,10 +1549,12 @@ func (c *Connection) resetState() {
 	c.rpc = make(chan message)
 }
 
+// IsRecoveryEnabled checks if the recovery is enabled.
 func (c *Connection) IsRecoveryEnabled() bool {
 	return c.Config.Recovery != nil && c.Config.Recovery.ReconnectionConfig != nil && c.Config.Recovery.ReconnectionConfig.MaxRetryCount > 0
 }
 
+// MaxRetryCount returns the maximum number of retries if recovery is enabled, otherwise returns 0.
 func (c *Connection) MaxRetryCount() int {
 	if c.IsRecoveryEnabled() {
 		return c.Config.Recovery.ReconnectionConfig.MaxRetryCount
@@ -1515,10 +1562,10 @@ func (c *Connection) MaxRetryCount() int {
 	return 0
 }
 
+// RetryInterval returns the interval between retries if recovery is enabled, otherwise returns 0.
 func (c *Connection) RetryInterval() time.Duration {
 	if c.IsRecoveryEnabled() {
 		return c.Config.Recovery.ReconnectionConfig.RetryInterval
 	}
 	return 0
 }
-

--- a/connection.go
+++ b/connection.go
@@ -241,6 +241,10 @@ func DialConfig(url string, config Config) (*Connection, error) {
 		return nil, err
 	}
 
+	if config.Locale == "" {
+		config.Locale = defaultLocale
+	}
+
 	if config.SASL == nil {
 		if uri.AuthMechanism != nil {
 			for _, identifier := range uri.AuthMechanism {
@@ -815,7 +819,7 @@ func (c *Connection) shutdown(err *Error) {
 
 		var e error
 		if err != nil {
-			e = errors.New(err.Error())
+			e = fmt.Errorf("%w", err) // preserve the original error type for assertions
 		}
 		c.lifeCycle.SetState(StateClosed, e)
 	}

--- a/connection.go
+++ b/connection.go
@@ -473,9 +473,9 @@ func (c *Connection) NotifyRecoveryCancel(receiver chan struct{}) chan struct{} 
 	return receiver
 }
 
-// CloseRecovery stops any active connection recovery process by notifying
+// closeRecovery stops any active connection recovery process by notifying
 // and closing all recovery cancellation listeners.
-func (c *Connection) CloseRecovery() {
+func (c *Connection) closeRecovery() {
 	c.m.Lock()
 	defer c.m.Unlock()
 
@@ -522,7 +522,7 @@ including the underlying io, Channels, Notify listeners and Channel consumers
 will also be closed.
 */
 func (c *Connection) Close() error {
-	c.CloseRecovery() // Stop any active recovery process
+	c.closeRecovery() // Stop any active recovery process
 
 	if c.IsClosed() {
 		return ErrClosed
@@ -570,7 +570,7 @@ func (c *Connection) Close() error {
 // including the underlying io, Channels, Notify listeners and Channel consumers
 // will also be closed.
 func (c *Connection) CloseDeadline(deadline time.Time) error {
-	c.CloseRecovery() // Stop any active recovery process
+	c.closeRecovery() // Stop any active recovery process
 
 	if c.IsClosed() {
 		return ErrClosed

--- a/connection.go
+++ b/connection.go
@@ -547,7 +547,6 @@ func (c *Connection) CloseDeadline(deadline time.Time) error {
 	if initiated {
 		defer c.shutdown(nil)
 		if err := c.setDeadline(deadline); err != nil {
-			handshakeErr = err
 			return err
 		}
 		handshakeErr = c.call(

--- a/connection.go
+++ b/connection.go
@@ -97,12 +97,13 @@ func NewConnectionProperties() Table {
 // multiplexed on this channel.  There must always be active receivers for
 // every asynchronous message on this connection.
 type Connection struct {
-	destructorM sync.Mutex // Mutex for connection teardown: notifying close/block listeners, closing channels, and closing the underlying socket
-	destructed  bool       // true when the connection has been destructed (teardown is initiated or completed)
-	closeM      sync.Mutex // Mutex for connection close handshake: sending a single connection.close frame to the broker
-	closeInit   bool       // true when a connection close has been initiated (connection.close frame has been or is being sent)
-	sendM       sync.Mutex // conn writer mutex
-	m           sync.Mutex // struct field mutex
+	destructorM         sync.Mutex // Mutex for connection teardown: notifying close/block listeners, closing channels, and closing the underlying socket
+	destructed          bool       // true when the connection has been destructed (teardown is initiated or completed)
+	closeM              sync.Mutex // Mutex for connection close handshake: sending a single connection.close frame to the broker
+	closeInit           bool       // true when a connection close has been initiated (connection.close frame has been or is being sent)
+	sendM               sync.Mutex // conn writer mutex
+	m                   sync.Mutex // struct field mutex
+	recoveryErrorCodesM sync.Mutex // Mutex for protecting RecoverableErrorCodes updates and reads
 
 	conn io.ReadWriteCloser
 
@@ -318,7 +319,7 @@ func DialConfig(url string, config Config) (*Connection, error) {
 		if config.Recovery.ReconnectionConfig == nil {
 			config.Recovery.ReconnectionConfig = DefaultReconnectionConfig.Clone()
 		} else if config.Recovery.ReconnectionConfig.RecoverableErrorCodes == nil {
-			config.Recovery.ReconnectionConfig.RecoverableErrorCodes = DefaultRecoverableErrorCodes
+			config.Recovery.ReconnectionConfig.RecoverableErrorCodes = cloneRecoverableErrorCodes(defaultRecoverableErrorCodes)
 		}
 		if config.Recovery.ConnectionRecovery == nil {
 			config.Recovery.ConnectionRecovery = &DefaultConnectionRecovery{
@@ -1502,7 +1503,7 @@ func (c *Connection) IsRecoveryEnabled() bool {
 	return c.Config.Recovery != nil &&
 		c.Config.Recovery.ReconnectionConfig != nil &&
 		c.Config.Recovery.ReconnectionConfig.MaxRetryCount > 0 &&
-		len(c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes) > 0
+		len(c.GetRecoverableErrorCodes()) > 0
 }
 
 // isRecoverable returns true if the given error is recoverable based on RecoverableErrorCodes.
@@ -1513,12 +1514,26 @@ func (c *Connection) isRecoverable(err *Error) bool {
 	if err == nil {
 		return true
 	}
-	for _, code := range c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes {
+	for _, code := range c.GetRecoverableErrorCodes() {
 		if err.Code == code {
 			return true
 		}
 	}
 	return false
+}
+
+// GetRecoverableErrorCodes returns a copy of the recoverable error codes.
+func (c *Connection) GetRecoverableErrorCodes() []int {
+	if c == nil {
+		return nil
+	}
+	c.recoveryErrorCodesM.Lock()
+	defer c.recoveryErrorCodesM.Unlock()
+	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
+		return nil
+	}
+
+	return cloneRecoverableErrorCodes(c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes)
 }
 
 // MaxRetryCount returns the maximum number of retries if recovery is enabled, otherwise returns 0.
@@ -1545,6 +1560,8 @@ func (c *Connection) SetRecoverableErrorCodes(codes []int) error {
 	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
 		return ErrRecoveryNotEnabled
 	}
+	c.recoveryErrorCodesM.Lock()
+	defer c.recoveryErrorCodesM.Unlock()
 	c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes = codes
 	return nil
 }
@@ -1557,6 +1574,8 @@ func (c *Connection) AddRecoverableErrorCodes(codes ...int) error {
 	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
 		return ErrRecoveryNotEnabled
 	}
+	c.recoveryErrorCodesM.Lock()
+	defer c.recoveryErrorCodesM.Unlock()
 	c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes = append(c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes, codes...)
 	return nil
 }

--- a/connection.go
+++ b/connection.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"os"
 	"reflect"
@@ -74,6 +75,9 @@ type Config struct {
 	// If Dial is nil, net.DialTimeout with a 30s connection and 30s deadline is
 	// used during TLS and AMQP handshaking.
 	Dial func(network, addr string) (net.Conn, error)
+
+	// Recovery configuration for automatic reconnection
+	Recovery *Recovery
 }
 
 // NewConnectionProperties creates an amqp.Table to be used as amqp.Config.Properties.
@@ -93,10 +97,12 @@ func NewConnectionProperties() Table {
 // multiplexed on this channel.  There must always be active receivers for
 // every asynchronous message on this connection.
 type Connection struct {
-	destructor sync.Once  // teardown: notify listeners, close channels and the socket
-	closeOnce  sync.Once  // handshake: send one `connection.close` frame
-	sendM      sync.Mutex // conn writer mutex
-	m          sync.Mutex // struct field mutex
+	destructorM sync.Mutex // teardown: notify listeners, close channels and the socket
+	destructed  bool
+	closeM      sync.Mutex // handshake: send one `connection.close` frame
+	closeInit   bool
+	sendM       sync.Mutex // conn writer mutex
+	m           sync.Mutex // struct field mutex
 
 	conn io.ReadWriteCloser
 
@@ -118,12 +124,16 @@ type Connection struct {
 
 	Config Config // The negotiated Config after connection.open
 
+	url string // Stored for recovery
+
 	Major      int      // Server's major version
 	Minor      int      // Server's minor version
 	Properties Table    // Server properties
 	Locales    []string // Server locales
 
 	closed atomic.Bool // Will be true if the connection is closed, false otherwise.
+
+	reconnecting sync.Mutex
 }
 
 type readDeadliner interface {
@@ -281,7 +291,27 @@ func DialConfig(url string, config Config) (*Connection, error) {
 		conn = client
 	}
 
-	return Open(conn, config)
+	if config.Recovery != nil {
+		if config.Recovery.ReconnectionConfig == nil {
+			config.Recovery.ReconnectionConfig = &ReconnectionConfig{
+				MaxRetryCount: 5,
+				RetryInterval: 5 * time.Second,
+			}
+		}
+		if config.Recovery.ConnectionRecovery == nil {
+			config.Recovery.ConnectionRecovery = &DefaultConnectionRecovery{
+				config: config.Recovery.ReconnectionConfig,
+			}
+		}
+	}
+
+	c, err := Open(conn, config)
+	if c != nil && c.IsRecoveryEnabled() {
+		c.url = url
+		config.Recovery.ConnectionRecovery.WatchConnection(c)
+	}
+
+	return c, err
 }
 
 /*
@@ -299,6 +329,7 @@ func Open(conn io.ReadWriteCloser, config Config) (*Connection, error) {
 		errors:    make(chan *Error, 1),
 		close:     make(chan struct{}),
 		deadlines: make(chan readDeadliner, 1),
+		Config:    config,
 	}
 	go c.reader(conn)
 	return c, c.open(config)
@@ -426,8 +457,15 @@ func (c *Connection) Close() error {
 
 	var handshakeErr error
 	var initiated bool
-	c.closeOnce.Do(func() {
+
+	c.closeM.Lock()
+	if !c.closeInit {
+		c.closeInit = true
 		initiated = true
+	}
+	c.closeM.Unlock()
+
+	if initiated {
 		defer c.shutdown(nil)
 		handshakeErr = c.call(
 			&connectionClose{
@@ -436,7 +474,7 @@ func (c *Connection) Close() error {
 			},
 			&connectionCloseOk{},
 		)
-	})
+	}
 	if !initiated {
 		return ErrClosed
 	}
@@ -463,12 +501,19 @@ func (c *Connection) CloseDeadline(deadline time.Time) error {
 
 	var handshakeErr error
 	var initiated bool
-	c.closeOnce.Do(func() {
+
+	c.closeM.Lock()
+	if !c.closeInit {
+		c.closeInit = true
 		initiated = true
+	}
+	c.closeM.Unlock()
+
+	if initiated {
 		defer c.shutdown(nil)
 		if err := c.setDeadline(deadline); err != nil {
 			handshakeErr = err
-			return
+			return err
 		}
 		handshakeErr = c.call(
 			&connectionClose{
@@ -477,7 +522,7 @@ func (c *Connection) CloseDeadline(deadline time.Time) error {
 			},
 			&connectionCloseOk{},
 		)
-	})
+	}
 	if !initiated {
 		return ErrClosed
 	}
@@ -491,8 +536,15 @@ func (c *Connection) closeWith(err *Error) error {
 
 	var handshakeErr error
 	var initiated bool
-	c.closeOnce.Do(func() {
+
+	c.closeM.Lock()
+	if !c.closeInit {
+		c.closeInit = true
 		initiated = true
+	}
+	c.closeM.Unlock()
+
+	if initiated {
 		defer c.shutdown(err)
 		handshakeErr = c.call(
 			&connectionClose{
@@ -501,7 +553,7 @@ func (c *Connection) closeWith(err *Error) error {
 			},
 			&connectionCloseOk{},
 		)
-	})
+	}
 	if !initiated {
 		return ErrClosed
 	}
@@ -625,44 +677,59 @@ func (c *Connection) flush() (err error) {
 func (c *Connection) shutdown(err *Error) {
 	c.closed.Store(true)
 
-	c.destructor.Do(func() {
-		c.m.Lock()
-		defer c.m.Unlock()
+	c.destructorM.Lock()
+	if c.destructed {
+		c.destructorM.Unlock()
+		return
+	}
+	c.destructed = true
+	c.destructorM.Unlock()
 
-		if err != nil {
-			for _, c := range c.closes {
-				c <- err
-			}
-			c.errors <- err
-		}
-		// Shutdown handler goroutine can still receive the result.
-		close(c.errors)
+	c.m.Lock()
+	defer c.m.Unlock()
 
-		for _, c := range c.closes {
-			close(c)
-		}
-
-		for _, c := range c.blocks {
-			close(c)
+	if err != nil {
+		for _, listener := range c.closes {
+			listener <- err
 		}
 
-		// Shutdown the channel, but do not use closeChannel() as it calls
-		// releaseChannel() which requires the connection lock.
-		//
-		// Ranging over c.channels and calling releaseChannel() that mutates
-		// c.channels is racy - see commit 6063341 for an example.
-		for _, ch := range c.channels {
-			ch.shutdown(err)
+		select {
+		case c.errors <- err:
+		default:
+		}
+	}
+
+	// Shutdown handler goroutine can still receive the result.
+	close(c.errors)
+
+	if err == nil || !c.IsRecoveryEnabled() {
+		for _, listener := range c.closes {
+			close(listener)
 		}
 
-		c.conn.Close()
-		// reader exit
-		close(c.close)
+		for _, block := range c.blocks {
+			close(block)
+		}
+	}
 
+	// Shutdown the channel, but do not use closeChannel() as it calls
+	// releaseChannel() which requires the connection lock.
+	//
+	// Ranging over c.channels and calling releaseChannel() that mutates
+	// c.channels is racy - see commit 6063341 for an example.
+	for _, ch := range c.channels {
+		ch.shutdown(err)
+	}
+
+	c.conn.Close()
+	// reader exit
+	close(c.close)
+
+	if err == nil || !c.IsRecoveryEnabled() {
 		c.channels = nil
 		c.allocator = nil
 		c.noNotify = true
-	})
+	}
 }
 
 // All methods sent to the connection channel should be synchronous so we
@@ -907,6 +974,11 @@ func (c *Connection) openChannel() (*Channel, error) {
 		c.releaseChannel(ch)
 		return nil, err
 	}
+
+	if c.IsRecoveryEnabled() {
+		c.Config.Recovery.ConnectionRecovery.WatchChannel(ch)
+	}
+
 	return ch, nil
 }
 
@@ -1197,3 +1269,256 @@ func pick(client, server int) int {
 	}
 	return min(client, server)
 }
+
+func (c *Connection) cleanup() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	for _, listener := range c.closes {
+		close(listener)
+	}
+
+	for _, block := range c.blocks {
+		close(block)
+	}
+
+	for _, ch := range c.channels {
+		ch.cleanup()
+	}
+
+	c.channels = nil
+	c.allocator = nil
+	c.noNotify = true
+}
+
+type ReconnectionConfig struct {
+	MaxRetryCount int
+	RetryInterval time.Duration
+}
+
+type IConnectionRecovery interface {
+	OnConnectionClose(conn *Connection, err *Error)
+	OnChannelClose(ch *Channel, err *Error)
+	WatchConnection(conn *Connection)
+	WatchChannel(ch *Channel)
+}
+
+type ITopologyRecovery interface {
+}
+
+type Recovery struct {
+	ReconnectionConfig *ReconnectionConfig
+	ConnectionRecovery IConnectionRecovery
+	TopologyRecovery   ITopologyRecovery
+}
+
+type DefaultConnectionRecovery struct {
+	config *ReconnectionConfig
+}
+
+func (d *DefaultConnectionRecovery) WatchConnection(conn *Connection) {
+	errCh := conn.NotifyClose(make(chan *Error, 1))
+	go func() {
+		for err := range errCh {
+			if err != nil {
+				Logger.Printf("Connection closed unexpectedly: %v", err)
+				d.OnConnectionClose(conn, err)
+			}
+		}
+	}()
+}
+
+func (d *DefaultConnectionRecovery) WatchChannel(ch *Channel) {
+	errCh := ch.NotifyClose(make(chan *Error, 1))
+	go func() {
+		for err := range errCh {
+			if err != nil {
+				Logger.Printf("Channel %d closed unexpectedly: %v", ch.id, err)
+				d.OnChannelClose(ch, err)
+			}
+		}
+	}()
+}
+
+func (d *DefaultConnectionRecovery) OnConnectionClose(conn *Connection, err *Error) {
+	if !conn.IsRecoveryEnabled() {
+		Logger.Printf("Connection %d recovery is not enabled, skipping reconnect", conn.url)
+		return
+	}
+
+	// Reconnect connection
+	if err := conn.Reconnect(); err != nil {
+		Logger.Printf("Connection %d recovery failed: %v.", conn.url, err)
+		conn.cleanup()
+	}
+}
+
+func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
+	if !ch.connection.IsRecoveryEnabled() {
+		Logger.Printf("Channel %d recovery is not enabled, skipping reconnect", ch.id)
+		return
+	}
+
+	if ch.connection.IsClosed() {
+		Logger.Printf("Connection is closed, letting connection recovery handle channel %d", ch.id)
+		return
+	}
+
+	// Reconnect channel
+	if err := ch.Reconnect(); err != nil {
+		Logger.Printf("Channel %d recovery failed: %v.", ch.id, err)
+		ch.cleanup()
+	}
+}
+
+func DialRecovery(url string, recovery *Recovery) (*Connection, error) {
+	if recovery == nil {
+		recovery = &Recovery{}
+	}
+	config := Config{
+		Locale:   defaultLocale,
+		Recovery: recovery,
+	}
+	return DialConfig(url, config)
+}
+
+func (c *Connection) Reconnect() error {
+	if !c.IsRecoveryEnabled() {
+		return ErrClosed
+	}
+
+	c.reconnecting.Lock()
+	defer c.reconnecting.Unlock()
+
+	if !c.IsClosed() {
+		return nil
+	}
+
+	var err error
+	for i := 0; i < c.MaxRetryCount(); i++ {
+		Logger.Printf("Connection recovery attempt %d of %d", i+1, c.MaxRetryCount())
+		jitter := time.Duration(rand.Intn(500)) * time.Millisecond // Random 500ms jitter to avoid thundering herd
+		time.Sleep(c.RetryInterval() + jitter)
+
+		// Re-dial
+		var conn net.Conn
+		dialer := c.Config.Dial
+		if dialer == nil {
+			dialer = DefaultDial(defaultConnectionTimeout)
+		}
+
+		// We need to parse URL to get addr
+		uri, err := ParseURI(c.url)
+		if err != nil {
+			Logger.Printf("Connection recovery failed to parse URI: %v", err)
+			return err
+		}
+		addr := net.JoinHostPort(uri.Host, strconv.FormatInt(int64(uri.Port), 10))
+
+		conn, err = dialer("tcp", addr)
+		if err != nil {
+			Logger.Printf("Connection recovery dial error: %v", err)
+			continue
+		}
+
+		// TLS handshake if needed
+		if uri.Scheme == "amqps" {
+			client := tls.Client(conn, c.Config.TLSClientConfig)
+			if err = client.Handshake(); err != nil {
+				Logger.Printf("Connection recovery TLS handshake error: %v", err)
+				conn.Close()
+				continue
+			}
+			conn = client
+		}
+
+		c.m.Lock()
+		// Swap the connection
+		c.conn = conn
+		c.writer = &writer{bufio.NewWriter(conn)}
+
+		// Reset state
+		c.resetState()
+		c.m.Unlock()
+
+		go c.reader(conn)
+
+		if err = c.open(c.Config); err != nil {
+			Logger.Printf("Connection recovery open error: %v", err)
+			conn.Close()
+			continue
+		}
+
+		// Reconnect channels
+		c.m.Lock()
+		channels := make([]*Channel, 0, len(c.channels))
+		for _, ch := range c.channels {
+			channels = append(channels, ch)
+		}
+		c.m.Unlock()
+
+		for _, ch := range channels {
+			if err = ch.Reconnect(); err != nil {
+				Logger.Printf("Connection recovery failed to reconnect channel %d: %v", ch.id, err)
+				conn.Close()
+				break
+			}
+		}
+
+		// This error check is for retrying when the channels are not able to reconnect
+		if err != nil {
+			continue
+		}
+
+		Logger.Printf("Connection recovery successful")
+		return nil
+	}
+
+	Logger.Printf("Connection recovery exhausted all %d retries", c.MaxRetryCount())
+	if c.conn != nil {
+		c.conn.Close()
+	}
+	c.closed.Store(true)
+
+	return err
+}
+
+// resetState clears the shutdown and close flags and re-initializes the internal
+// channels so the connection can be reused after a successful reconnection.
+// The caller must hold c.m.
+func (c *Connection) resetState() {
+	c.closed.Store(false)
+
+	c.destructorM.Lock()
+	c.destructed = false
+	c.destructorM.Unlock()
+
+	c.closeM.Lock()
+	c.closeInit = false
+	c.closeM.Unlock()
+
+	c.errors = make(chan *Error, 1)
+	c.close = make(chan struct{})
+
+	// Re-create the rpc channel so we don't read stale messages from the previous connection
+	c.rpc = make(chan message)
+}
+
+func (c *Connection) IsRecoveryEnabled() bool {
+	return c.Config.Recovery != nil && c.Config.Recovery.ReconnectionConfig != nil && c.Config.Recovery.ReconnectionConfig.MaxRetryCount > 0
+}
+
+func (c *Connection) MaxRetryCount() int {
+	if c.IsRecoveryEnabled() {
+		return c.Config.Recovery.ReconnectionConfig.MaxRetryCount
+	}
+	return 0
+}
+
+func (c *Connection) RetryInterval() time.Duration {
+	if c.IsRecoveryEnabled() {
+		return c.Config.Recovery.ReconnectionConfig.RetryInterval
+	}
+	return 0
+}
+

--- a/connection.go
+++ b/connection.go
@@ -77,6 +77,12 @@ type Config struct {
 	Dial func(network, addr string) (net.Conn, error)
 
 	// Recovery configuration for automatic reconnection
+	// When a network failure occurs, the connection and all its channels will automatically
+	// attempt to reconnect based on the parameters specified in the Recovery configuration.
+	// If `recovery` is nil, a default recovery configuration is used.
+	// During the recovery process, applications can monitor state changes (such as reconnecting
+	// or closed) by registering a listener using `Connection.NotifyStateChange` and
+	// `Channel.NotifyStateChange`.
 	Recovery *Recovery
 }
 
@@ -202,28 +208,6 @@ func DialTLS_ExternalAuth(url string, amqps *tls.Config) (*Connection, error) {
 		TLSClientConfig: amqps,
 		SASL:            []Authentication{&ExternalAuth{}},
 	})
-}
-
-/*
-DialRecovery dials a connection with the given URL and recovery configuration.
-
-When a network failure occurs, the connection and all its channels will automatically
-attempt to reconnect based on the parameters specified in the Recovery configuration.
-If `recovery` is nil, a default recovery configuration is used.
-
-During the recovery process, applications can monitor state changes (such as reconnecting
-or closed) by registering a listener using `Connection.NotifyStateChange` and
-`Channel.NotifyStateChange`.
-*/
-func DialRecovery(url string, recovery *Recovery) (*Connection, error) {
-	if recovery == nil {
-		recovery = &Recovery{}
-	}
-	config := Config{
-		Locale:   defaultLocale,
-		Recovery: recovery,
-	}
-	return DialConfig(url, config)
 }
 
 // DialConfig accepts a string in the AMQP URI format and a configuration for
@@ -771,6 +755,9 @@ func (c *Connection) shutdown(err *Error) {
 			default:
 				// If blocked/full, send in a goroutine so we never deadlock the shutdown sequence
 				go func(listener chan *Error, err *Error) {
+					defer func() {
+						_ = recover() // Gracefully ignore panics if the channel is closed concurrently
+					}()
 					select {
 					case listener <- err:
 					case <-time.After(5 * time.Second):
@@ -789,7 +776,7 @@ func (c *Connection) shutdown(err *Error) {
 	// Shutdown handler goroutine can still receive the result.
 	close(c.errors)
 
-	if err == nil || !c.IsRecoveryEnabled() {
+	if err == nil || !c.IsRecoveryEnabled() || !c.isRecoverable(err) {
 		for _, listener := range c.closes {
 			close(listener)
 		}
@@ -812,7 +799,7 @@ func (c *Connection) shutdown(err *Error) {
 	// reader exit
 	close(c.close)
 
-	if err == nil || !c.IsRecoveryEnabled() {
+	if err == nil || !c.IsRecoveryEnabled() || !c.isRecoverable(err) {
 		c.channels = nil
 		c.allocator = nil
 		c.noNotify = true

--- a/connection.go
+++ b/connection.go
@@ -322,9 +322,7 @@ func DialConfig(url string, config Config) (*Connection, error) {
 			config.Recovery.ReconnectionConfig.RecoverableErrorCodes = cloneRecoverableErrorCodes(defaultRecoverableErrorCodes)
 		}
 		if config.Recovery.ConnectionRecovery == nil {
-			config.Recovery.ConnectionRecovery = &DefaultConnectionRecovery{
-				config: config.Recovery.ReconnectionConfig,
-			}
+			config.Recovery.ConnectionRecovery = &DefaultConnectionRecovery{}
 		}
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -717,7 +717,7 @@ func (c *Connection) shutdown(err *Error) {
 		return
 	}
 	c.destructed = true
-	c.destructorM.Unlock()
+	defer c.destructorM.Unlock()
 
 	c.m.Lock()
 	defer c.m.Unlock()
@@ -1474,14 +1474,22 @@ func (c *Connection) Reconnect() error {
 			conn = client
 		}
 
+		// Reset state and swap connection under locks to ensure atomicity
+		// and prevent data races with concurrent readers/writers.
+		// Acquiring destructorM -> closeM -> m avoids any lock ordering deadlocks.
+		c.destructorM.Lock()
+		c.closeM.Lock()
 		c.m.Lock()
+
 		// Swap the connection
 		c.conn = conn
 		c.writer = &writer{bufio.NewWriter(conn)}
 
-		// Reset state
 		c.resetState()
+
 		c.m.Unlock()
+		c.closeM.Unlock()
+		c.destructorM.Unlock()
 
 		go c.reader(conn)
 
@@ -1529,17 +1537,11 @@ func (c *Connection) Reconnect() error {
 
 // resetState clears the shutdown and close flags and re-initializes the internal
 // channels so the connection can be reused after a successful reconnection.
-// The caller must hold c.m.
+// The caller must hold c.destructorM, c.closeM and c.m.
 func (c *Connection) resetState() {
 	c.closed.Store(false)
-
-	c.destructorM.Lock()
 	c.destructed = false
-	c.destructorM.Unlock()
-
-	c.closeM.Lock()
 	c.closeInit = false
-	c.closeM.Unlock()
 
 	c.errors = make(chan *Error, 1)
 	c.close = make(chan struct{})
@@ -1550,6 +1552,15 @@ func (c *Connection) resetState() {
 
 // IsRecoveryEnabled checks if the recovery is enabled.
 func (c *Connection) IsRecoveryEnabled() bool {
+	if c == nil {
+		return false
+	}
+	c.closeM.Lock()
+	closedOrClosing := c.closeInit
+	c.closeM.Unlock()
+	if closedOrClosing {
+		return false
+	}
 	return c.Config.Recovery != nil && c.Config.Recovery.ReconnectionConfig != nil && c.Config.Recovery.ReconnectionConfig.MaxRetryCount > 0
 }
 

--- a/connection.go
+++ b/connection.go
@@ -1177,6 +1177,11 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 	c.Config.ChannelMax = minUInt16(c.Config.ChannelMax, maxChannelMax)
 
 	c.allocator = newAllocator(1, int(c.Config.ChannelMax))
+	// Reserve all the channels that are already open
+	// This is to avoid allocating the same channel ID after a reconnection
+	for id := range c.channels {
+		c.allocator.reserve(int(id))
+	}
 
 	c.m.Unlock()
 

--- a/connection.go
+++ b/connection.go
@@ -136,6 +136,8 @@ type Connection struct {
 
 	reconnecting sync.Mutex // Mutex for protecting reconnect/recovery operations to ensure serialization and prevent race conditions.
 	lifeCycle    *LifeCycle // The current state of the connection.
+
+	recoveryCancels []chan struct{} // listeners for connection recovery cancellation
 }
 
 type readDeadliner interface {
@@ -446,6 +448,40 @@ func (c *Connection) NotifyClose(receiver chan *Error) chan *Error {
 }
 
 /*
+NotifyRecoveryCancel registers a listener that is notified (via a channel close)
+when connection recovery has been canceled or aborted (for example, when Close()
+or CloseDeadline() is called during an active reconnect process).
+
+The returned channel will be closed immediately if the connection is already closing
+or closed, or when Close() is called.
+*/
+func (c *Connection) NotifyRecoveryCancel(receiver chan struct{}) chan struct{} {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	state := c.lifeCycle.State().getState()
+	if state == stateClosing || state == stateClosed {
+		close(receiver)
+	} else {
+		c.recoveryCancels = append(c.recoveryCancels, receiver)
+	}
+
+	return receiver
+}
+
+// CloseRecovery stops any active connection recovery process by notifying
+// and closing all recovery cancellation listeners.
+func (c *Connection) CloseRecovery() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	for _, listener := range c.recoveryCancels {
+		close(listener)
+	}
+	c.recoveryCancels = nil
+}
+
+/*
 NotifyBlocked registers a listener for RabbitMQ specific TCP flow control
 method extensions connection.blocked and connection.unblocked.  Flow control is
 active with a reason when Blocking.Blocked is true.  When a Connection is
@@ -482,6 +518,8 @@ including the underlying io, Channels, Notify listeners and Channel consumers
 will also be closed.
 */
 func (c *Connection) Close() error {
+	c.CloseRecovery() // Stop any active recovery process
+
 	if c.IsClosed() {
 		return ErrClosed
 	}
@@ -528,6 +566,8 @@ func (c *Connection) Close() error {
 // including the underlying io, Channels, Notify listeners and Channel consumers
 // will also be closed.
 func (c *Connection) CloseDeadline(deadline time.Time) error {
+	c.CloseRecovery() // Stop any active recovery process
+
 	if c.IsClosed() {
 		return ErrClosed
 	}
@@ -1339,6 +1379,11 @@ func (c *Connection) cleanup() {
 		ch.cleanup()
 	}
 
+	for _, listener := range c.recoveryCancels {
+		close(listener)
+	}
+
+	c.recoveryCancels = nil
 	c.channels = nil
 	c.allocator = nil
 	c.noNotify = true
@@ -1377,11 +1422,20 @@ func (c *Connection) Reconnect() error {
 
 	c.lifeCycle.SetState(&StateReconnecting{})
 
+	cancelCh := c.NotifyRecoveryCancel(make(chan struct{}))
+
 	var err error
 	for i := 0; i < c.MaxRetryCount(); i++ {
 		Logger.Printf("Connection recovery attempt %d of %d", i+1, c.MaxRetryCount())
 		jitter := time.Duration(rand.Intn(500)) * time.Millisecond // Random 500ms jitter to avoid thundering herd
-		time.Sleep(c.RetryInterval() + jitter)
+
+		// Wait with select to allow immediate interruption of sleep
+		select {
+		case <-cancelCh:
+			Logger.Printf("Connection recovery aborted: connection closed during backoff.")
+			return ErrClosed
+		case <-time.After(c.RetryInterval() + jitter):
+		}
 
 		// Re-dial
 		var conn net.Conn

--- a/connection.go
+++ b/connection.go
@@ -316,10 +316,9 @@ func DialConfig(url string, config Config) (*Connection, error) {
 
 	if config.Recovery != nil {
 		if config.Recovery.ReconnectionConfig == nil {
-			config.Recovery.ReconnectionConfig = &ReconnectionConfig{
-				MaxRetryCount: 5,
-				RetryInterval: 5 * time.Second,
-			}
+			config.Recovery.ReconnectionConfig = DefaultReconnectionConfig.Clone()
+		} else if config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes == nil {
+			config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes = DefaultRecoverableExceptionsCodes
 		}
 		if config.Recovery.ConnectionRecovery == nil {
 			config.Recovery.ConnectionRecovery = &DefaultConnectionRecovery{
@@ -1354,70 +1353,6 @@ func (c *Connection) watchConnection() {
 	}()
 }
 
-// ReconnectionConfig is the configuration for the reconnection.
-type ReconnectionConfig struct {
-	MaxRetryCount int           // The maximum number of retries.
-	RetryInterval time.Duration // The interval between retries.
-}
-
-// IConnectionRecovery is the interface for the connection recovery.
-//
-// The err parameter in OnConnectionClose and OnChannelClose provides the reason
-// why the connection or channel was closed. Custom implementations can use this
-// parameter to perform conditional recovery (e.g., skip recovery for specific
-// protocol errors like 403 ACCESS_REFUSED or 404 NOT_FOUND), log errors to
-// external monitoring systems (e.g., Prometheus), or trigger alerts.
-type IConnectionRecovery interface {
-	OnConnectionClose(conn *Connection, err *Error) // Called when the connection is closed.
-	OnChannelClose(ch *Channel, err *Error)         // Called when the channel is closed.
-}
-
-// Recovery is the configuration for the recovery.
-type Recovery struct {
-	ReconnectionConfig *ReconnectionConfig // The configuration for the reconnection.
-	ConnectionRecovery IConnectionRecovery // The implementation of the connection recovery.
-}
-
-// DefaultConnectionRecovery is the default implementation of the connection recovery.
-type DefaultConnectionRecovery struct {
-	config *ReconnectionConfig // The configuration for the reconnection.
-}
-
-func (d *DefaultConnectionRecovery) OnConnectionClose(conn *Connection, err *Error) {
-	Logger.Printf("Connection closed with error: %v", err)
-	if !conn.IsRecoveryEnabled() {
-		Logger.Printf("Connection %s recovery is not enabled, skipping reconnect. ", conn.url)
-		return
-	}
-
-	Logger.Printf("Initiating connection recovery for %s.", conn.url)
-	// Reconnect connection
-	if err := conn.Reconnect(); err != nil {
-		Logger.Printf("Connection %s recovery failed: %v.", conn.url, err)
-		conn.cleanup()
-	}
-}
-
-func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
-	Logger.Printf("Channel %d closed with error: %v", ch.id, err)
-	if !ch.connection.IsRecoveryEnabled() {
-		Logger.Printf("Channel %d recovery is not enabled, skipping reconnect.", ch.id)
-		return
-	}
-
-	if ch.connection.IsClosed() {
-		Logger.Printf("Connection is closed, letting connection recovery handle channel %d.", ch.id)
-		return
-	}
-
-	Logger.Printf("Initiating channel %d recovery", ch.id)
-	// Reconnect channel
-	if err := ch.Reconnect(); err != nil {
-		Logger.Printf("Channel %d recovery failed: %v.", ch.id, err)
-		ch.cleanup()
-	}
-}
-
 // Reconnect reconnects the connection.
 func (c *Connection) Reconnect() error {
 	if !c.IsRecoveryEnabled() {
@@ -1559,7 +1494,10 @@ func (c *Connection) IsRecoveryEnabled() bool {
 	if closedOrClosing {
 		return false
 	}
-	return c.Config.Recovery != nil && c.Config.Recovery.ReconnectionConfig != nil && c.Config.Recovery.ReconnectionConfig.MaxRetryCount > 0
+	return c.Config.Recovery != nil &&
+		c.Config.Recovery.ReconnectionConfig != nil &&
+		c.Config.Recovery.ReconnectionConfig.MaxRetryCount > 0 &&
+		len(c.Config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes) > 0
 }
 
 // MaxRetryCount returns the maximum number of retries if recovery is enabled, otherwise returns 0.

--- a/consumers.go
+++ b/consumers.go
@@ -32,11 +32,11 @@ func commandNameBasedUniqueConsumerTag(commandName string) string {
 	return tagPrefix + tagInfix + tagSuffix
 }
 
-// ConsumerConfig stores the configuration parameters used when a consumer is registered.
+// consumerConfig stores the configuration parameters used when a consumer is registered.
 // This is required during automatic connection and channel recovery. When a network connection
 // drops and is restored, the library uses these stored parameters to automatically re-register
 // and resume all consumers on the recovered channels seamlessly, preserving the subscriber topology.
-type ConsumerConfig struct {
+type consumerConfig struct {
 	Queue     string
 	Consumer  string
 	AutoAck   bool
@@ -48,9 +48,9 @@ type ConsumerConfig struct {
 
 type consumerBuffers map[string]chan *Delivery
 
-// consumerConfigs maps unique consumer tags to their respective ConsumerConfig parameters,
+// consumerConfigs maps unique consumer tags to their respective consumerConfig parameters,
 // facilitating the automatic re-registration of all consumers during channel recovery.
-type consumerConfigs map[string]ConsumerConfig
+type consumerConfigs map[string]consumerConfig
 
 // Concurrent type that manages the consumerTag ->
 // ingress consumerBuffer mapping
@@ -129,7 +129,7 @@ func (subs *consumers) buffer(in chan *Delivery, out chan Delivery) {
 }
 
 // On key conflict, close the previous channel.
-func (subs *consumers) add(tag string, consumer chan Delivery, config ConsumerConfig) {
+func (subs *consumers) add(tag string, consumer chan Delivery, config consumerConfig) {
 	subs.Lock()
 	defer subs.Unlock()
 

--- a/consumers.go
+++ b/consumers.go
@@ -32,6 +32,10 @@ func commandNameBasedUniqueConsumerTag(commandName string) string {
 	return tagPrefix + tagInfix + tagSuffix
 }
 
+// ConsumerConfig stores the configuration parameters used when a consumer is registered.
+// This is required during automatic connection and channel recovery. When a network connection
+// drops and is restored, the library uses these stored parameters to automatically re-register
+// and resume all consumers on the recovered channels seamlessly, preserving the subscriber topology.
 type ConsumerConfig struct {
 	Queue     string
 	Consumer  string
@@ -43,6 +47,9 @@ type ConsumerConfig struct {
 }
 
 type consumerBuffers map[string]chan *Delivery
+
+// consumerConfigs maps unique consumer tags to their respective ConsumerConfig parameters,
+// facilitating the automatic re-registration of all consumers during channel recovery.
 type consumerConfigs map[string]ConsumerConfig
 
 // Concurrent type that manages the consumerTag ->

--- a/consumers.go
+++ b/consumers.go
@@ -32,7 +32,18 @@ func commandNameBasedUniqueConsumerTag(commandName string) string {
 	return tagPrefix + tagInfix + tagSuffix
 }
 
+type ConsumerConfig struct {
+	Queue     string
+	Consumer  string
+	AutoAck   bool
+	Exclusive bool
+	NoLocal   bool
+	NoWait    bool
+	Args      Table
+}
+
 type consumerBuffers map[string]chan *Delivery
+type consumerConfigs map[string]ConsumerConfig
 
 // Concurrent type that manages the consumerTag ->
 // ingress consumerBuffer mapping
@@ -42,12 +53,14 @@ type consumers struct {
 
 	sync.Mutex // protects below
 	chans      consumerBuffers
+	configs    consumerConfigs
 }
 
 func makeConsumers() *consumers {
 	return &consumers{
-		closed: make(chan struct{}),
-		chans:  make(consumerBuffers),
+		closed:  make(chan struct{}),
+		chans:   make(consumerBuffers),
+		configs: make(consumerConfigs),
 	}
 }
 
@@ -109,7 +122,7 @@ func (subs *consumers) buffer(in chan *Delivery, out chan Delivery) {
 }
 
 // On key conflict, close the previous channel.
-func (subs *consumers) add(tag string, consumer chan Delivery) {
+func (subs *consumers) add(tag string, consumer chan Delivery, config ConsumerConfig) {
 	subs.Lock()
 	defer subs.Unlock()
 
@@ -119,6 +132,7 @@ func (subs *consumers) add(tag string, consumer chan Delivery) {
 
 	in := make(chan *Delivery)
 	subs.chans[tag] = in
+	subs.configs[tag] = config
 
 	subs.Add(1)
 	go subs.buffer(in, consumer)
@@ -132,6 +146,7 @@ func (subs *consumers) cancel(tag string) (found bool) {
 
 	if found {
 		delete(subs.chans, tag)
+		delete(subs.configs, tag)
 		close(ch)
 	}
 
@@ -146,6 +161,7 @@ func (subs *consumers) close() {
 
 	for tag, ch := range subs.chans {
 		delete(subs.chans, tag)
+		delete(subs.configs, tag)
 		close(ch)
 	}
 

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -75,18 +75,18 @@ func baseCall(url, username, password string, method string) (string, error) {
 	}
 	req.SetBasicAuth(username, password)
 
-	resp, err3 := client.Do(req)
+	resp, err := client.Do(req)
 
-	if err3 != nil {
-		return "", err3
+	if err != nil {
+		return "", err
 	}
 
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 200 { // OK
-		bodyBytes, err2 := io.ReadAll(resp.Body)
-		if err2 != nil {
-			return "", err2
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
 		}
 		return string(bodyBytes), nil
 	}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -88,13 +88,39 @@ func (s StateChanged) String() string {
 	return fmt.Sprintf("From: %s, To: %s", statusToString(s.From), statusToString(s.To))
 }
 
+type stateListener struct {
+	ch      chan *StateChanged
+	queue   []*StateChanged
+	sending bool
+}
+
+// enqueue appends a state change to the listener's bounded queue using a sliding window.
+// If the queue size exceeds maxQueueSize, the oldest state change is dropped.
+// This assumes the caller holds the LifeCycle mutex.
+func (sl *stateListener) enqueue(sc *StateChanged) {
+	const maxQueueSize = 50
+	if len(sl.queue) < maxQueueSize {
+		sl.queue = append(sl.queue, sc)
+	} else {
+		sl.queue = append(sl.queue[1:], sc)
+	}
+}
+
 // LifeCycle is the lifecycle of the connection or channel.
+//
+// The listener framework manages state change notifications for registered channels.
+// Key characteristics:
+//   - Multiple listeners can register concurrently via NotifyStateChange.
+//   - Each listener operates concurrently and is isolated from others; a blocked or slow
+//     listener will not block other listeners or the main SetState() execution.
+//   - Strict FIFO ordering of state transitions is guaranteed for each listener by spawning
+//     at most one dedicated delivery goroutine per listener.
+//   - Memory usage is strictly bounded by a sliding-window queue per listener (maxQueueSize = 50).
+//   - Listener channels are cleanly closed as soon as the final StateClosed transition is sent.
 type LifeCycle struct {
-	state           ILifeCycleState    // The current state of the connection or channel.
-	chStatusChanged chan *StateChanged // The channel to send the state changes to.
-	mutex           *sync.Mutex        // The mutex to protect the state changes.
-	queue           []*StateChanged    // Queue to hold state transitions for sequential FIFO delivery.
-	sending         bool               // True if deliverLoop is currently active.
+	state     ILifeCycleState  // The current state of the connection or channel.
+	listeners []*stateListener // The registered state change listeners.
+	mutex     *sync.Mutex      // The mutex to protect the state changes.
 }
 
 func NewLifeCycle() *LifeCycle {
@@ -120,41 +146,80 @@ func (l *LifeCycle) SetState(value ILifeCycleState) {
 	oldState := l.state
 	l.state = value
 
-	if l.chStatusChanged == nil {
-		return
-	}
-
 	sc := &StateChanged{
 		From: oldState,
 		To:   value,
 	}
 
-	l.queue = append(l.queue, sc)
-	if !l.sending {
-		l.sending = true
-		go l.deliverLoop()
+	for _, listener := range l.listeners {
+		listener.enqueue(sc)
+		if !listener.sending {
+			listener.sending = true
+			go l.deliverToListener(listener)
+		}
 	}
 }
 
-func (l *LifeCycle) deliverLoop() {
+func (l *LifeCycle) deliverToListener(listener *stateListener) {
 	for {
 		l.mutex.Lock()
-		if len(l.queue) == 0 || l.chStatusChanged == nil {
-			l.sending = false
+		if len(listener.queue) == 0 {
+			listener.sending = false
 			l.mutex.Unlock()
 			return
 		}
-		sc := l.queue[0]
-		l.queue = l.queue[1:]
-		ch := l.chStatusChanged
+		sc := listener.queue[0]
+		listener.queue = listener.queue[1:]
+		ch := listener.ch
 		l.mutex.Unlock()
 
 		ch <- sc
+
+		// If the transition is to StateClosed, this is the terminal state.
+		// We can safely close the channel now because:
+		// 1. No more states will be appended (StateClosed is final).
+		// 2. The StateClosed notification was just successfully sent.
+		if _, ok := sc.To.(*StateClosed); ok {
+			l.mutex.Lock()
+			close(ch)
+			l.removeListener(listener)
+			l.mutex.Unlock()
+			return
+		}
+	}
+}
+
+func (l *LifeCycle) removeListener(listener *stateListener) {
+	for i, lis := range l.listeners {
+		if lis == listener {
+			l.listeners = append(l.listeners[:i], l.listeners[i+1:]...)
+			break
+		}
 	}
 }
 
 func (l *LifeCycle) notifyStateChange(channel chan *StateChanged) {
+	if channel == nil {
+		return
+	}
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	l.chStatusChanged = channel
+
+	// If the connection/channel is already closed, close the channel immediately.
+	if _, ok := l.state.(*StateClosed); ok {
+		close(channel)
+		return
+	}
+
+	// Prevent duplicate registration of the same channel.
+	for _, lis := range l.listeners {
+		if lis.ch == channel {
+			return
+		}
+	}
+
+	listener := &stateListener{
+		ch: channel,
+	}
+	l.listeners = append(l.listeners, listener)
 }

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -62,6 +62,7 @@ func (sl *stateListener) enqueue(sc *StateChanged) {
 	if len(sl.queue) < maxQueueSize {
 		sl.queue = append(sl.queue, sc)
 	} else {
+		sl.queue[0] = nil // Allow GC to reclaim the dropped element
 		sl.queue = append(sl.queue[1:], sc)
 	}
 }
@@ -130,6 +131,7 @@ func (l *lifeCycle) deliverToListener(listener *stateListener) {
 			return
 		}
 		sc := listener.queue[0]
+		listener.queue[0] = nil // Allow GC to reclaim the popped element
 		listener.queue = listener.queue[1:]
 		ch := listener.ch
 		l.mutex.Unlock()
@@ -153,7 +155,9 @@ func (l *lifeCycle) deliverToListener(listener *stateListener) {
 func (l *lifeCycle) removeListener(listener *stateListener) {
 	for i, lis := range l.listeners {
 		if lis == listener {
-			l.listeners = append(l.listeners[:i], l.listeners[i+1:]...)
+			copy(l.listeners[i:], l.listeners[i+1:])
+			l.listeners[len(l.listeners)-1] = nil // Allow GC to reclaim the listener
+			l.listeners = l.listeners[:len(l.listeners)-1]
 			break
 		}
 	}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -5,87 +5,47 @@ import (
 	"sync"
 )
 
+// LifeCycleState defines the connection or channel state type.
+type LifeCycleState byte
+
 const (
-	stateOpen         = iota
-	stateReconnecting = iota
-	stateClosing      = iota
-	stateClosed       = iota
+	// StateOpen represents a connection or channel that is active and open.
+	StateOpen LifeCycleState = iota
+	// StateReconnecting represents a connection or channel that is actively undergoing automatic recovery.
+	StateReconnecting
+	// StateClosing represents a connection or channel that is in the process of closing down.
+	StateClosing
+	// StateClosed represents a connection or channel that is fully closed and shut down.
+	StateClosed
 )
 
-// ILifeCycleState defines the connection or channel state
-// see the iota constants for possible states: open, reconnecting, closing, closed
-type ILifeCycleState interface {
-	getState() int
-}
-
-type StateOpen struct {
-}
-
-func (o *StateOpen) getState() int {
-	return stateOpen
-}
-
-type StateReconnecting struct {
-}
-
-func (r *StateReconnecting) getState() int {
-	return stateReconnecting
-}
-
-type StateClosing struct {
-}
-
-func (c *StateClosing) getState() int {
-	return stateClosing
-}
-
-type StateClosed struct {
-	error error
-}
-
-func (c *StateClosed) GetError() error {
-	return c.error
-}
-
-func (c *StateClosed) getState() int {
-	return stateClosed
-}
-
-func statusToString(status ILifeCycleState) string {
-	switch status.getState() {
-	case stateOpen:
+func (s LifeCycleState) String() string {
+	switch s {
+	case StateOpen:
 		return "open"
-	case stateReconnecting:
+	case StateReconnecting:
 		return "reconnecting"
-	case stateClosing:
+	case StateClosing:
 		return "closing"
-	case stateClosed:
+	case StateClosed:
 		return "closed"
+	default:
+		return "unknown"
 	}
-	return "unknown"
-
 }
 
-// StateChanged defines the connection or channel life cycle.
-// See ILifeCycleState for more details about the possible states.
-// Every time the state changes,
-// a StateChanged struct is sent to the channel defined in the
-// NotifyStateChange method.
+// StateChanged defines the connection or channel life cycle transitions.
 type StateChanged struct {
-	From ILifeCycleState
-	To   ILifeCycleState
+	From LifeCycleState
+	To   LifeCycleState
+	Err  error // Stores the error when transitioning to StateClosed
 }
 
 func (s StateChanged) String() string {
-	switch s.To.(type) {
-	case *StateClosed:
-		if s.To.(*StateClosed).error == nil {
-			return fmt.Sprintf("From: %s, To: %s", statusToString(s.From), statusToString(s.To))
-		}
-		return fmt.Sprintf("From: %s, To: %s, Error: %s", statusToString(s.From), statusToString(s.To), s.To.(*StateClosed).error)
-
+	if s.Err != nil {
+		return fmt.Sprintf("From: %s, To: %s, Error: %v", s.From, s.To, s.Err)
 	}
-	return fmt.Sprintf("From: %s, To: %s", statusToString(s.From), statusToString(s.To))
+	return fmt.Sprintf("From: %s, To: %s", s.From, s.To)
 }
 
 type stateListener struct {
@@ -96,7 +56,7 @@ type stateListener struct {
 
 // enqueue appends a state change to the listener's bounded queue using a sliding window.
 // If the queue size exceeds maxQueueSize, the oldest state change is dropped.
-// This assumes the caller holds the LifeCycle mutex.
+// This assumes the caller holds the lifeCycle mutex.
 func (sl *stateListener) enqueue(sc *StateChanged) {
 	const maxQueueSize = 50
 	if len(sl.queue) < maxQueueSize {
@@ -106,7 +66,7 @@ func (sl *stateListener) enqueue(sc *StateChanged) {
 	}
 }
 
-// LifeCycle is the lifecycle of the connection or channel.
+// lifeCycle is the lifecycle of the connection or channel.
 //
 // The listener framework manages state change notifications for registered channels.
 // Key characteristics:
@@ -117,26 +77,26 @@ func (sl *stateListener) enqueue(sc *StateChanged) {
 //     at most one dedicated delivery goroutine per listener.
 //   - Memory usage is strictly bounded by a sliding-window queue per listener (maxQueueSize = 50).
 //   - Listener channels are cleanly closed as soon as the final StateClosed transition is sent.
-type LifeCycle struct {
-	state     ILifeCycleState  // The current state of the connection or channel.
+type lifeCycle struct {
+	state     LifeCycleState   // The current state of the connection or channel.
 	listeners []*stateListener // The registered state change listeners.
 	mutex     *sync.Mutex      // The mutex to protect the state changes.
 }
 
-func NewLifeCycle() *LifeCycle {
-	return &LifeCycle{
-		state: &StateClosed{},
+func newLifeCycle() *lifeCycle {
+	return &lifeCycle{
+		state: StateClosed,
 		mutex: &sync.Mutex{},
 	}
 }
 
-func (l *LifeCycle) State() ILifeCycleState {
+func (l *lifeCycle) State() LifeCycleState {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	return l.state
 }
 
-func (l *LifeCycle) SetState(value ILifeCycleState) {
+func (l *lifeCycle) SetState(value LifeCycleState, err error) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 	if l.state == value {
@@ -149,6 +109,7 @@ func (l *LifeCycle) SetState(value ILifeCycleState) {
 	sc := &StateChanged{
 		From: oldState,
 		To:   value,
+		Err:  err,
 	}
 
 	for _, listener := range l.listeners {
@@ -160,7 +121,7 @@ func (l *LifeCycle) SetState(value ILifeCycleState) {
 	}
 }
 
-func (l *LifeCycle) deliverToListener(listener *stateListener) {
+func (l *lifeCycle) deliverToListener(listener *stateListener) {
 	for {
 		l.mutex.Lock()
 		if len(listener.queue) == 0 {
@@ -179,7 +140,7 @@ func (l *LifeCycle) deliverToListener(listener *stateListener) {
 		// We can safely close the channel now because:
 		// 1. No more states will be appended (StateClosed is final).
 		// 2. The StateClosed notification was just successfully sent.
-		if _, ok := sc.To.(*StateClosed); ok {
+		if sc.To == StateClosed {
 			l.mutex.Lock()
 			close(ch)
 			l.removeListener(listener)
@@ -189,7 +150,7 @@ func (l *LifeCycle) deliverToListener(listener *stateListener) {
 	}
 }
 
-func (l *LifeCycle) removeListener(listener *stateListener) {
+func (l *lifeCycle) removeListener(listener *stateListener) {
 	for i, lis := range l.listeners {
 		if lis == listener {
 			l.listeners = append(l.listeners[:i], l.listeners[i+1:]...)
@@ -198,7 +159,7 @@ func (l *LifeCycle) removeListener(listener *stateListener) {
 	}
 }
 
-func (l *LifeCycle) notifyStateChange(channel chan *StateChanged) {
+func (l *lifeCycle) notifyStateChange(channel chan *StateChanged) {
 	if channel == nil {
 		return
 	}
@@ -206,7 +167,7 @@ func (l *LifeCycle) notifyStateChange(channel chan *StateChanged) {
 	defer l.mutex.Unlock()
 
 	// If the connection/channel is already closed, close the channel immediately.
-	if _, ok := l.state.(*StateClosed); ok {
+	if l.state == StateClosed {
 		close(channel)
 		return
 	}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -1,0 +1,160 @@
+package amqp091
+
+import (
+	"fmt"
+	"sync"
+)
+
+const (
+	stateOpen         = iota
+	stateReconnecting = iota
+	stateClosing      = iota
+	stateClosed       = iota
+)
+
+// ILifeCycleState defines the connection or channel state
+// see the iota constants for possible states: open, reconnecting, closing, closed
+type ILifeCycleState interface {
+	getState() int
+}
+
+type StateOpen struct {
+}
+
+func (o *StateOpen) getState() int {
+	return stateOpen
+}
+
+type StateReconnecting struct {
+}
+
+func (r *StateReconnecting) getState() int {
+	return stateReconnecting
+}
+
+type StateClosing struct {
+}
+
+func (c *StateClosing) getState() int {
+	return stateClosing
+}
+
+type StateClosed struct {
+	error error
+}
+
+func (c *StateClosed) GetError() error {
+	return c.error
+}
+
+func (c *StateClosed) getState() int {
+	return stateClosed
+}
+
+func statusToString(status ILifeCycleState) string {
+	switch status.getState() {
+	case stateOpen:
+		return "open"
+	case stateReconnecting:
+		return "reconnecting"
+	case stateClosing:
+		return "closing"
+	case stateClosed:
+		return "closed"
+	}
+	return "unknown"
+
+}
+
+// StateChanged defines the connection or channel life cycle.
+// See ILifeCycleState for more details about the possible states.
+// Every time the state changes,
+// a StateChanged struct is sent to the channel defined in the
+// NotifyStateChange method.
+type StateChanged struct {
+	From ILifeCycleState
+	To   ILifeCycleState
+}
+
+func (s StateChanged) String() string {
+	switch s.To.(type) {
+	case *StateClosed:
+		if s.To.(*StateClosed).error == nil {
+			return fmt.Sprintf("From: %s, To: %s", statusToString(s.From), statusToString(s.To))
+		}
+		return fmt.Sprintf("From: %s, To: %s, Error: %s", statusToString(s.From), statusToString(s.To), s.To.(*StateClosed).error)
+
+	}
+	return fmt.Sprintf("From: %s, To: %s", statusToString(s.From), statusToString(s.To))
+}
+
+// LifeCycle is the lifecycle of the connection or channel.
+type LifeCycle struct {
+	state           ILifeCycleState    // The current state of the connection or channel.
+	chStatusChanged chan *StateChanged // The channel to send the state changes to.
+	mutex           *sync.Mutex        // The mutex to protect the state changes.
+	queue           []*StateChanged    // Queue to hold state transitions for sequential FIFO delivery.
+	sending         bool               // True if deliverLoop is currently active.
+}
+
+func NewLifeCycle() *LifeCycle {
+	return &LifeCycle{
+		state: &StateClosed{},
+		mutex: &sync.Mutex{},
+	}
+}
+
+func (l *LifeCycle) State() ILifeCycleState {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return l.state
+}
+
+func (l *LifeCycle) SetState(value ILifeCycleState) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if l.state == value {
+		return
+	}
+
+	oldState := l.state
+	l.state = value
+
+	if l.chStatusChanged == nil {
+		return
+	}
+
+	sc := &StateChanged{
+		From: oldState,
+		To:   value,
+	}
+
+	l.queue = append(l.queue, sc)
+	if !l.sending {
+		l.sending = true
+		go l.deliverLoop()
+	}
+}
+
+func (l *LifeCycle) deliverLoop() {
+	for {
+		l.mutex.Lock()
+		if len(l.queue) == 0 || l.chStatusChanged == nil {
+			l.sending = false
+			l.mutex.Unlock()
+			return
+		}
+		sc := l.queue[0]
+		l.queue = l.queue[1:]
+		ch := l.chStatusChanged
+		l.mutex.Unlock()
+
+		ch <- sc
+	}
+}
+
+func (l *LifeCycle) notifyStateChange(channel chan *StateChanged) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.chStatusChanged = channel
+}

--- a/recovery.go
+++ b/recovery.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+package amqp091
+
+import (
+	"time"
+)
+
+const (
+	// DefaultMaxRetryCount is the default maximum number of retries for recovery.
+	DefaultMaxRetryCount = 5
+
+	// DefaultRetryInterval is the default interval between retries for recovery.
+	DefaultRetryInterval = 5 * time.Second
+)
+
+var (
+	// DefaultRecoverableExceptionsCodes contains the default exception codes that trigger recovery.
+	DefaultRecoverableExceptionsCodes = []int{ConnectionForced, InternalError}
+
+	// DefaultReconnectionConfig is the default reconnection config settings.
+	DefaultReconnectionConfig = &ReconnectionConfig{
+		MaxRetryCount:              DefaultMaxRetryCount,
+		RetryInterval:              DefaultRetryInterval,
+		RecoverableExceptionsCodes: DefaultRecoverableExceptionsCodes,
+	}
+)
+
+// ReconnectionConfig is the configuration for the reconnection.
+type ReconnectionConfig struct {
+	MaxRetryCount              int           // The maximum number of retries.
+	RetryInterval              time.Duration // The interval between retries.
+	RecoverableExceptionsCodes []int         // Predefined error codes that trigger recovery.
+}
+
+// Clone returns a deep copy of the ReconnectionConfig.
+func (rc *ReconnectionConfig) Clone() *ReconnectionConfig {
+	if rc == nil {
+		return nil
+	}
+	var codes []int
+	if rc.RecoverableExceptionsCodes != nil {
+		codes = make([]int, len(rc.RecoverableExceptionsCodes))
+		copy(codes, rc.RecoverableExceptionsCodes)
+	}
+	return &ReconnectionConfig{
+		MaxRetryCount:              rc.MaxRetryCount,
+		RetryInterval:              rc.RetryInterval,
+		RecoverableExceptionsCodes: codes,
+	}
+}
+
+// IConnectionRecovery is the interface for the connection recovery.
+//
+// The err parameter in OnConnectionClose and OnChannelClose provides the reason
+// why the connection or channel was closed. Under the hood, DefaultConnectionRecovery
+// performs conditional recovery based on RecoverableExceptionsCodes. You can also customize
+// the list of recoverable errors dynamically using Connection.SetRecoverableExceptionsCodes and
+// Connection.AddRecoverableExceptionsCodes, or use custom implementations of this interface to
+// perform more advanced logic, log errors to external monitoring systems (e.g., Prometheus),
+// or trigger alerts.
+type IConnectionRecovery interface {
+	OnConnectionClose(conn *Connection, err *Error) // Called when the connection is closed.
+	OnChannelClose(ch *Channel, err *Error)         // Called when the channel is closed.
+}
+
+// Recovery is the configuration for the recovery.
+type Recovery struct {
+	ReconnectionConfig *ReconnectionConfig // The configuration for the reconnection.
+	ConnectionRecovery IConnectionRecovery // The implementation of the connection recovery.
+}
+
+// DefaultConnectionRecovery is the default implementation of the connection recovery.
+type DefaultConnectionRecovery struct {
+	config *ReconnectionConfig // The configuration for the reconnection.
+}
+
+func (d *DefaultConnectionRecovery) OnConnectionClose(conn *Connection, err *Error) {
+	Logger.Printf("Connection closed with error: %v", err)
+	if !conn.IsRecoveryEnabled() {
+		Logger.Printf("Connection %s recovery is not enabled, skipping reconnect. ", conn.url)
+		return
+	}
+
+	if !conn.isRecoverable(err) {
+		code := 0
+		if err != nil {
+			code = err.Code
+		}
+		Logger.Printf("Connection %s closed with non-recoverable error code %d, skipping reconnect.", conn.url, code)
+		return
+	}
+
+	Logger.Printf("Initiating connection recovery for %s.", conn.url)
+	// Reconnect connection
+	if err := conn.Reconnect(); err != nil {
+		Logger.Printf("Connection %s recovery failed: %v.", conn.url, err)
+		conn.cleanup()
+	}
+}
+
+func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
+	Logger.Printf("Channel %d closed with error: %v", ch.id, err)
+	if !ch.connection.IsRecoveryEnabled() {
+		Logger.Printf("Channel %d recovery is not enabled, skipping reconnect.", ch.id)
+		return
+	}
+
+	if ch.connection.IsClosed() {
+		Logger.Printf("Connection is closed, letting connection recovery handle channel %d.", ch.id)
+		return
+	}
+
+	if !ch.connection.isRecoverable(err) {
+		code := 0
+		if err != nil {
+			code = err.Code
+		}
+		Logger.Printf("Channel %d closed with non-recoverable error code %d, skipping reconnect.", ch.id, code)
+		return
+	}
+
+	Logger.Printf("Initiating channel %d recovery", ch.id)
+	// Reconnect channel
+	if err := ch.Reconnect(); err != nil {
+		Logger.Printf("Channel %d recovery failed: %v.", ch.id, err)
+		ch.cleanup()
+	}
+}
+
+// isRecoverable returns true if the given error is recoverable based on RecoverableExceptionsCodes.
+func (c *Connection) isRecoverable(err *Error) bool {
+	if !c.IsRecoveryEnabled() {
+		return false
+	}
+	if err == nil {
+		return true
+	}
+	for _, code := range c.Config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes {
+		if err.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+// SetRecoverableExceptionsCodes sets the list of exception codes that trigger recovery.
+func (c *Connection) SetRecoverableExceptionsCodes(codes []int) error {
+	if c == nil {
+		return ErrClosed
+	}
+	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
+		return ErrRecoveryNotEnabled
+	}
+	c.Config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes = codes
+	return nil
+}
+
+// AddRecoverableExceptionsCodes adds one or more exception codes to the list of recoverable exceptions.
+func (c *Connection) AddRecoverableExceptionsCodes(codes ...int) error {
+	if c == nil {
+		return ErrClosed
+	}
+	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
+		return ErrRecoveryNotEnabled
+	}
+	c.Config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes = append(c.Config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes, codes...)
+	return nil
+}

--- a/recovery.go
+++ b/recovery.go
@@ -4,6 +4,7 @@
 package amqp091
 
 import (
+	"net/url"
 	"time"
 )
 
@@ -78,14 +79,19 @@ type Recovery struct {
 }
 
 // DefaultConnectionRecovery is the default implementation of the connection recovery.
-type DefaultConnectionRecovery struct {
-	config *ReconnectionConfig // The configuration for the reconnection.
-}
+type DefaultConnectionRecovery struct{}
 
 func (d *DefaultConnectionRecovery) OnConnectionClose(conn *Connection, err *Error) {
 	Logger.Printf("Connection closed with error: %v", err)
+
+	parsedURL, err1 := url.Parse(conn.url)
+	if err1 != nil {
+		Logger.Printf("Error parsing connection URL: %v", err1)
+		return
+	}
+
 	if !conn.IsRecoveryEnabled() {
-		Logger.Printf("Connection %s recovery is not enabled, skipping reconnect. ", conn.url)
+		Logger.Printf("Connection %s recovery is not enabled, skipping reconnect. ", parsedURL.Redacted())
 		return
 	}
 
@@ -94,14 +100,14 @@ func (d *DefaultConnectionRecovery) OnConnectionClose(conn *Connection, err *Err
 		if err != nil {
 			code = err.Code
 		}
-		Logger.Printf("Connection %s closed with non-recoverable error code %d, skipping reconnect.", conn.url, code)
+		Logger.Printf("Connection %s closed with non-recoverable error code %d, skipping reconnect.", parsedURL.Redacted(), code)
 		return
 	}
 
-	Logger.Printf("Initiating connection recovery for %s.", conn.url)
+	Logger.Printf("Initiating connection recovery for %s.", parsedURL.Redacted())
 	// Reconnect connection
 	if err := conn.Reconnect(); err != nil {
-		Logger.Printf("Connection %s recovery failed: %v.", conn.url, err)
+		Logger.Printf("Connection %s recovery failed: %v.", parsedURL.Redacted(), err)
 		conn.cleanup()
 	}
 }

--- a/recovery.go
+++ b/recovery.go
@@ -16,22 +16,22 @@ const (
 )
 
 var (
-	// DefaultRecoverableExceptionsCodes contains the default exception codes that trigger recovery.
-	DefaultRecoverableExceptionsCodes = []int{ConnectionForced, InternalError}
+	// DefaultRecoverableErrorCodes contains the default exception codes that trigger recovery.
+	DefaultRecoverableErrorCodes = []int{ConnectionForced, InternalError}
 
 	// DefaultReconnectionConfig is the default reconnection config settings.
 	DefaultReconnectionConfig = &ReconnectionConfig{
-		MaxRetryCount:              DefaultMaxRetryCount,
-		RetryInterval:              DefaultRetryInterval,
-		RecoverableExceptionsCodes: DefaultRecoverableExceptionsCodes,
+		MaxRetryCount:         DefaultMaxRetryCount,
+		RetryInterval:         DefaultRetryInterval,
+		RecoverableErrorCodes: DefaultRecoverableErrorCodes,
 	}
 )
 
 // ReconnectionConfig is the configuration for the reconnection.
 type ReconnectionConfig struct {
-	MaxRetryCount              int           // The maximum number of retries.
-	RetryInterval              time.Duration // The interval between retries.
-	RecoverableExceptionsCodes []int         // Predefined error codes that trigger recovery.
+	MaxRetryCount         int           // The maximum number of retries.
+	RetryInterval         time.Duration // The interval between retries.
+	RecoverableErrorCodes []int         // The error codes that trigger recovery.
 }
 
 // Clone returns a deep copy of the ReconnectionConfig.
@@ -40,14 +40,14 @@ func (rc *ReconnectionConfig) Clone() *ReconnectionConfig {
 		return nil
 	}
 	var codes []int
-	if rc.RecoverableExceptionsCodes != nil {
-		codes = make([]int, len(rc.RecoverableExceptionsCodes))
-		copy(codes, rc.RecoverableExceptionsCodes)
+	if rc.RecoverableErrorCodes != nil {
+		codes = make([]int, len(rc.RecoverableErrorCodes))
+		copy(codes, rc.RecoverableErrorCodes)
 	}
 	return &ReconnectionConfig{
-		MaxRetryCount:              rc.MaxRetryCount,
-		RetryInterval:              rc.RetryInterval,
-		RecoverableExceptionsCodes: codes,
+		MaxRetryCount:         rc.MaxRetryCount,
+		RetryInterval:         rc.RetryInterval,
+		RecoverableErrorCodes: codes,
 	}
 }
 
@@ -55,9 +55,9 @@ func (rc *ReconnectionConfig) Clone() *ReconnectionConfig {
 //
 // The err parameter in OnConnectionClose and OnChannelClose provides the reason
 // why the connection or channel was closed. Under the hood, DefaultConnectionRecovery
-// performs conditional recovery based on RecoverableExceptionsCodes. You can also customize
-// the list of recoverable errors dynamically using Connection.SetRecoverableExceptionsCodes and
-// Connection.AddRecoverableExceptionsCodes, or use custom implementations of this interface to
+// performs conditional recovery based on RecoverableErrorCodes. You can also customize
+// the list of recoverable errors dynamically using Connection.SetRecoverableErrorCodes and
+// Connection.AddRecoverableErrorCodes, or use custom implementations of this interface to
 // perform more advanced logic, log errors to external monitoring systems (e.g., Prometheus),
 // or trigger alerts.
 type IConnectionRecovery interface {
@@ -127,44 +127,4 @@ func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
 		Logger.Printf("Channel %d recovery failed: %v.", ch.id, err)
 		ch.cleanup()
 	}
-}
-
-// isRecoverable returns true if the given error is recoverable based on RecoverableExceptionsCodes.
-func (c *Connection) isRecoverable(err *Error) bool {
-	if !c.IsRecoveryEnabled() {
-		return false
-	}
-	if err == nil {
-		return true
-	}
-	for _, code := range c.Config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes {
-		if err.Code == code {
-			return true
-		}
-	}
-	return false
-}
-
-// SetRecoverableExceptionsCodes sets the list of exception codes that trigger recovery.
-func (c *Connection) SetRecoverableExceptionsCodes(codes []int) error {
-	if c == nil {
-		return ErrClosed
-	}
-	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
-		return ErrRecoveryNotEnabled
-	}
-	c.Config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes = codes
-	return nil
-}
-
-// AddRecoverableExceptionsCodes adds one or more exception codes to the list of recoverable exceptions.
-func (c *Connection) AddRecoverableExceptionsCodes(codes ...int) error {
-	if c == nil {
-		return ErrClosed
-	}
-	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
-		return ErrRecoveryNotEnabled
-	}
-	c.Config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes = append(c.Config.Recovery.ReconnectionConfig.RecoverableExceptionsCodes, codes...)
-	return nil
 }

--- a/recovery.go
+++ b/recovery.go
@@ -16,16 +16,27 @@ const (
 )
 
 var (
-	// DefaultRecoverableErrorCodes contains the default exception codes that trigger recovery.
-	DefaultRecoverableErrorCodes = []int{ConnectionForced, InternalError}
+	// defaultRecoverableErrorCodes contains the default exception codes that trigger recovery.
+	defaultRecoverableErrorCodes = []int{ConnectionForced, InternalError}
 
 	// DefaultReconnectionConfig is the default reconnection config settings.
 	DefaultReconnectionConfig = &ReconnectionConfig{
 		MaxRetryCount:         DefaultMaxRetryCount,
 		RetryInterval:         DefaultRetryInterval,
-		RecoverableErrorCodes: DefaultRecoverableErrorCodes,
+		RecoverableErrorCodes: cloneRecoverableErrorCodes(defaultRecoverableErrorCodes),
 	}
 )
+
+// cloneRecoverableErrorCodes returns a clone of given RecoverableErrorCodes slice.
+// It is used to avoid modifying the original slice.
+func cloneRecoverableErrorCodes(inRecoverableErrorCodes []int) []int {
+	if inRecoverableErrorCodes == nil {
+		return nil
+	}
+	codes := make([]int, len(inRecoverableErrorCodes))
+	copy(codes, inRecoverableErrorCodes)
+	return codes
+}
 
 // ReconnectionConfig is the configuration for the reconnection.
 type ReconnectionConfig struct {
@@ -39,15 +50,10 @@ func (rc *ReconnectionConfig) Clone() *ReconnectionConfig {
 	if rc == nil {
 		return nil
 	}
-	var codes []int
-	if rc.RecoverableErrorCodes != nil {
-		codes = make([]int, len(rc.RecoverableErrorCodes))
-		copy(codes, rc.RecoverableErrorCodes)
-	}
 	return &ReconnectionConfig{
 		MaxRetryCount:         rc.MaxRetryCount,
 		RetryInterval:         rc.RetryInterval,
-		RecoverableErrorCodes: codes,
+		RecoverableErrorCodes: cloneRecoverableErrorCodes(rc.RecoverableErrorCodes),
 	}
 }
 

--- a/recovery.go
+++ b/recovery.go
@@ -58,7 +58,7 @@ func (rc *ReconnectionConfig) Clone() *ReconnectionConfig {
 	}
 }
 
-// IConnectionRecovery is the interface for the connection recovery.
+// ConnectionRecovery is the interface for the connection recovery.
 //
 // The err parameter in OnConnectionClose and OnChannelClose provides the reason
 // why the connection or channel was closed. Under the hood, DefaultConnectionRecovery
@@ -67,7 +67,7 @@ func (rc *ReconnectionConfig) Clone() *ReconnectionConfig {
 // Connection.AddRecoverableErrorCodes, or use custom implementations of this interface to
 // perform more advanced logic, log errors to external monitoring systems (e.g., Prometheus),
 // or trigger alerts.
-type IConnectionRecovery interface {
+type ConnectionRecovery interface {
 	OnConnectionClose(conn *Connection, err *Error) // Called when the connection is closed.
 	OnChannelClose(ch *Channel, err *Error)         // Called when the channel is closed.
 }
@@ -75,7 +75,7 @@ type IConnectionRecovery interface {
 // Recovery is the configuration for the recovery.
 type Recovery struct {
 	ReconnectionConfig *ReconnectionConfig // The configuration for the reconnection.
-	ConnectionRecovery IConnectionRecovery // The implementation of the connection recovery.
+	ConnectionRecovery ConnectionRecovery  // The implementation of the connection recovery.
 }
 
 // DefaultConnectionRecovery is the default implementation of the connection recovery.

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -368,7 +368,16 @@ func waitForChannelClose(t *testing.T, chanStateChanged chan *StateChanged, chan
 	loopDeadline := time.After(3 * time.Second)
 	for {
 		select {
-		case sc := <-chanStateChanged:
+		case sc, ok := <-chanStateChanged:
+			if !ok {
+				if !chanClosedSeen {
+					t.Fatalf("Expected Channel %d to transition to StateClosed before channel closed", chanID)
+				}
+				if chanReconnectingSeen || chanOpenSeen {
+					t.Fatalf("Channel %d recovery was triggered for %s!", chanID, reason)
+				}
+				return
+			}
 			t.Logf("Channel %d state changed: %s", chanID, sc)
 			if _, ok := sc.To.(*StateClosed); ok {
 				chanClosedSeen = true
@@ -388,6 +397,21 @@ func waitForChannelClose(t *testing.T, chanStateChanged chan *StateChanged, chan
 			}
 			return
 		}
+	}
+}
+
+func waitForStateChangeClose(t *testing.T, ch chan *StateChanged, name, listenerName string) {
+	done := make(chan struct{})
+	go func() {
+		for range ch {
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Logf("State change channel for %s %s cleanly closed", name, listenerName)
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Timeout waiting for state change channel for %s %s to close", name, listenerName)
 	}
 }
 
@@ -646,4 +670,90 @@ func TestConnectionRecoveryChannelIDReservation(t *testing.T) {
 	for _, ch := range activeChannels {
 		ch.Close()
 	}
+}
+
+// TestConnectionRecoveryLifeCycleNotifyStateChange tests that state change listener channels
+// are cleanly closed when connection or channels are closed.
+func TestConnectionRecoveryLifeCycleNotifyStateChange(t *testing.T) {
+	connectionName := "test-connection-recovery-lifecycle-notify-state-change"
+	// Create a connection with Recovery
+	properties := NewConnectionProperties()
+	properties.SetClientConnectionName(connectionName)
+	conn, err := DialConfig(amqpURL, Config{
+		Recovery:   &Recovery{},
+		Locale:     defaultLocale,
+		Properties: properties,
+	})
+	if err != nil {
+		t.Fatalf("DialConfig failed: %v", err)
+	}
+	defer conn.Close()
+
+	ch1Name := "channel 1"
+	ch1, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("%s creation failed: %v", ch1Name, err)
+	}
+	defer ch1.Close()
+
+	ch2Name := "channel 2"
+	ch2, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("%s creation failed: %v", ch2Name, err)
+	}
+	defer ch2.Close()
+
+	// Register state change notifications on connection and channels
+	stateChanged := make(chan *StateChanged, 10)
+	conn.NotifyStateChange(stateChanged)
+
+	chanStateChanged11 := make(chan *StateChanged, 10)
+	ch1.NotifyStateChange(chanStateChanged11)
+
+	// Register one more listener for channel 1
+	chanStateChanged12 := make(chan *StateChanged, 10)
+	ch1.NotifyStateChange(chanStateChanged12)
+
+	chanStateChanged21 := make(chan *StateChanged, 10)
+	ch2.NotifyStateChange(chanStateChanged21)
+
+	// Register one more listener for channel 2
+	chanStateChanged22 := make(chan *StateChanged, 10)
+	ch2.NotifyStateChange(chanStateChanged22)
+
+	// Drop connection
+	dropConnection(t, connectionName)
+
+	// Wait for connection and channels to recover
+	waitForConnectionOpen(t, stateChanged)
+	waitForChannelOpen(t, chanStateChanged11)
+	waitForChannelOpen(t, chanStateChanged21)
+
+	// Close channels
+	if err := ch1.Close(); err != nil {
+		t.Fatalf("Failed to close %s: %v", ch1Name, err)
+	}
+	if err := ch2.Close(); err != nil {
+		t.Fatalf("Failed to close %s: %v", ch2Name, err)
+	}
+
+	// Verify channel 1 listener 1 is cleanly closed within a timeout
+	waitForStateChangeClose(t, chanStateChanged11, ch1Name, "listener 1")
+
+	// Verify channel 1 listener 2 is cleanly closed within a timeout
+	waitForStateChangeClose(t, chanStateChanged12, ch1Name, "listener 2")
+
+	// Verify channel 2 listener is cleanly closed within a timeout
+	waitForStateChangeClose(t, chanStateChanged21, ch2Name, "listener 1")
+
+	// Verify channel 2 listener 2 is cleanly closed within a timeout
+	waitForStateChangeClose(t, chanStateChanged22, ch2Name, "listener 2")
+
+	// Close connection
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Failed to close %s: %v", connectionName, err)
+	}
+
+	// Verify connection listener is cleanly closed within a timeout
+	waitForStateChangeClose(t, stateChanged, connectionName, "listener 1")
 }

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -392,7 +392,7 @@ func waitForChannelClose(t *testing.T, chanStateChanged chan *StateChanged, chan
 }
 
 // TestConnectionRecoveryNonRecoverableChannelClose tests that channel recovery is NOT triggered
-// when a channel is closed due to soft exceptions (errors not present in RecoverableExceptionsCodes).
+// when a channel is closed due to soft exceptions (errors not present in RecoverableErrorCodes).
 // It verifies both PRECONDITION_FAILED (406) and RESOURCE_LOCKED (405) leave the connection open,
 // transition the channel to StateClosed, and do not trigger automatic recovery.
 func TestConnectionRecoveryNonRecoverableChannelClose(t *testing.T) {

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -757,3 +757,124 @@ func TestConnectionRecoveryLifeCycleNotifyStateChange(t *testing.T) {
 	// Verify connection listener is cleanly closed within a timeout
 	waitForStateChangeClose(t, stateChanged, connectionName, "listener 1")
 }
+
+// TestConnectionRecoveryCancelInterrupt tests that connection and channel recovery cancel events
+// are received when the connection or channel is closed during an active recovery process.
+func TestConnectionRecoveryCancelInterrupt(t *testing.T) {
+	connectionName := "test-connection-recovery-cancel-interrupt"
+	properties := NewConnectionProperties()
+	properties.SetClientConnectionName(connectionName)
+	conn, err := DialConfig(amqpURL, Config{
+		Recovery: &Recovery{
+			ReconnectionConfig: &ReconnectionConfig{
+				MaxRetryCount: 5,
+				RetryInterval: 5 * time.Second,
+			},
+		},
+		Locale:     defaultLocale,
+		Properties: properties,
+	})
+	if err != nil {
+		t.Fatalf("DialConfig failed: %v", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel creation failed: %v", err)
+	}
+	defer ch.Close()
+
+	// 1. Register for NotifyRecoveryCancel on connection and channel
+	connCancelCh := conn.NotifyRecoveryCancel(make(chan struct{}))
+	chCancelCh := ch.NotifyRecoveryCancel(make(chan struct{}))
+
+	// Register state change notifications on connection and channel
+	connStateCh := make(chan *StateChanged, 10)
+	conn.NotifyStateChange(connStateCh)
+
+	chanStateCh := make(chan *StateChanged, 10)
+	ch.NotifyStateChange(chanStateCh)
+
+	// 2. Drop connection
+	dropConnection(t, connectionName)
+
+	// 3. Wait for status to change to Reconnecting for both connection and channel
+	var connReconnectingSeen bool
+	var chanReconnectingSeen bool
+
+	timeout := time.After(10 * time.Second)
+	for !connReconnectingSeen || !chanReconnectingSeen {
+		select {
+		case sc := <-connStateCh:
+			t.Logf("Connection state changed: %s", sc)
+			if _, ok := sc.To.(*StateReconnecting); ok {
+				connReconnectingSeen = true
+			}
+		case sc := <-chanStateCh:
+			t.Logf("Channel state changed: %s", sc)
+			if _, ok := sc.To.(*StateReconnecting); ok {
+				chanReconnectingSeen = true
+			}
+		case <-timeout:
+			t.Fatalf("Timeout waiting for connection and channel to enter Reconnecting state")
+		}
+	}
+
+	// 4. Close channel
+	t.Log("Closing channel during recovery to trigger abort...")
+	if err := ch.Close(); err != nil {
+		t.Fatalf("Channel Close failed: %v", err)
+	}
+
+	// 5. Close connection
+	t.Log("Closing connection during recovery to trigger abort...")
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Connection Close failed: %v", err)
+	}
+
+	// 6. Verify immediately recovery is terminated and event is received on NotifyRecoveryCancel channel
+	select {
+	case <-chCancelCh:
+		t.Log("Channel recovery cancel event received successfully")
+	case <-time.After(2 * time.Second):
+		t.Error("Timeout waiting for channel recovery cancel event")
+	}
+
+	select {
+	case <-connCancelCh:
+		t.Log("Connection recovery cancel event received successfully")
+	case <-time.After(2 * time.Second):
+		t.Error("Timeout waiting for connection recovery cancel event")
+	}
+
+	// 7. Verify state changed to Closed
+	var connClosedSeen bool
+	var chanClosedSeen bool
+
+	timeout = time.After(2 * time.Second)
+	for !connClosedSeen || !chanClosedSeen {
+		select {
+		case sc, ok := <-connStateCh:
+			if !ok {
+				connClosedSeen = true
+				continue
+			}
+			t.Logf("Connection state changed post-close: %s", sc)
+			if _, ok := sc.To.(*StateClosed); ok {
+				connClosedSeen = true
+			}
+		case sc, ok := <-chanStateCh:
+			if !ok {
+				chanClosedSeen = true
+				continue
+			}
+			t.Logf("Channel state changed post-close: %s", sc)
+			if _, ok := sc.To.(*StateClosed); ok {
+				chanClosedSeen = true
+			}
+		case <-timeout:
+			t.Fatalf("Timeout waiting for connection and channel state to change to Closed. connClosedSeen=%t, chanClosedSeen=%t", connClosedSeen, chanClosedSeen)
+		}
+	}
+}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -359,3 +359,172 @@ func waitForChannelOpen(t *testing.T, chanStateChanged chan *StateChanged) {
 		}
 	}
 }
+
+func waitForChannelClose(t *testing.T, chanStateChanged chan *StateChanged, chanID int, reason string) {
+	var chanClosedSeen bool
+	var chanReconnectingSeen bool
+	var chanOpenSeen bool
+
+	loopDeadline := time.After(3 * time.Second)
+	for {
+		select {
+		case sc := <-chanStateChanged:
+			t.Logf("Channel %d state changed: %s", chanID, sc)
+			if _, ok := sc.To.(*StateClosed); ok {
+				chanClosedSeen = true
+			}
+			if _, ok := sc.To.(*StateReconnecting); ok {
+				chanReconnectingSeen = true
+			}
+			if _, ok := sc.To.(*StateOpen); ok {
+				chanOpenSeen = true
+			}
+		case <-loopDeadline:
+			if !chanClosedSeen {
+				t.Fatalf("Expected Channel %d to transition to StateClosed", chanID)
+			}
+			if chanReconnectingSeen || chanOpenSeen {
+				t.Fatalf("Channel %d recovery was triggered for %s!", chanID, reason)
+			}
+			return
+		}
+	}
+}
+
+// TestConnectionRecoveryNonRecoverableChannelClose tests that channel recovery is NOT triggered
+// when a channel is closed due to soft exceptions (errors not present in RecoverableExceptionsCodes).
+// It verifies both PRECONDITION_FAILED (406) and RESOURCE_LOCKED (405) leave the connection open,
+// transition the channel to StateClosed, and do not trigger automatic recovery.
+func TestConnectionRecoveryNonRecoverableChannelClose(t *testing.T) {
+	connectionName := "test-non-recoverable-channel-close"
+	properties := NewConnectionProperties()
+	properties.SetClientConnectionName(connectionName)
+	conn, err := DialConfig(amqpURL, Config{
+		Recovery:   &Recovery{},
+		Locale:     defaultLocale,
+		Properties: properties,
+	})
+	if err != nil {
+		t.Fatalf("DialConfig failed: %v", err)
+	}
+	defer conn.Close()
+
+	// --- 1. Test PRECONDITION_FAILED (406) using a durable mismatch on a non-exclusive queue ---
+	ch1, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("First Channel creation failed: %v", err)
+	}
+	defer ch1.Close()
+
+	chanStateChanged1 := make(chan *StateChanged, 10)
+	ch1.NotifyStateChange(chanStateChanged1)
+
+	queueNamePrecondition := "precondition_failed_test_queue"
+	_, _ = ch1.QueueDelete(queueNamePrecondition, false, false, false)
+
+	// Declare non-exclusive queue as durable: true
+	_, err = ch1.QueueDeclare(
+		queueNamePrecondition,
+		true,  // durable
+		false, // auto-delete
+		false, // exclusive
+		false, // no-wait
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("QueueDeclare durable:true failed: %v", err)
+	}
+	defer func() {
+		// Clean up queue using a fresh channel since ch1 will be closed
+		if !conn.IsClosed() {
+			if cleanCh, err := conn.Channel(); err == nil {
+				_, _ = cleanCh.QueueDelete(queueNamePrecondition, false, false, false)
+				cleanCh.Close()
+			}
+		}
+	}()
+
+	// Declare again on SAME channel with durable: false (PreconditionFailed)
+	_, err = ch1.QueueDeclare(
+		queueNamePrecondition,
+		false, // durable (mismatched)
+		false, // auto-delete
+		false, // exclusive
+		false, // no-wait
+		nil,
+	)
+	if err == nil {
+		t.Fatalf("Expected PreconditionFailed error but second QueueDeclare succeeded")
+	}
+
+	amqpErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("Expected amqp.Error, got: %T (%v)", err, err)
+	}
+	if amqpErr.Code != PreconditionFailed {
+		t.Fatalf("Expected PreconditionFailed (406), got code: %d", amqpErr.Code)
+	}
+
+	// Verify ch1 transitioned to StateClosed and did not trigger recovery
+	waitForChannelClose(t, chanStateChanged1, int(ch1.id), "PreconditionFailed")
+
+	if conn.IsClosed() {
+		t.Fatalf("Expected connection to remain open after PRECONDITION_FAILED soft exception")
+	}
+	t.Log("Verified connection remains open after PRECONDITION_FAILED")
+
+	// --- 2. Test RESOURCE_LOCKED (405) using exclusive queue settings ---
+	ch2, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Second Channel creation failed: %v", err)
+	}
+	defer ch2.Close()
+
+	chanStateChanged2 := make(chan *StateChanged, 10)
+	ch2.NotifyStateChange(chanStateChanged2)
+
+	queueNameResource := "resource_locked_test_queue"
+	_, _ = ch2.QueueDelete(queueNameResource, false, false, false)
+
+	// Declare as exclusive: true, auto-delete: true
+	_, err = ch2.QueueDeclare(
+		queueNameResource,
+		false, // durable
+		true,  // auto-delete
+		true,  // exclusive
+		false, // no-wait
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("QueueDeclare exclusive:true failed: %v", err)
+	}
+
+	// Declare again on SAME channel with exclusive: false (ResourceLocked)
+	_, err = ch2.QueueDeclare(
+		queueNameResource,
+		false, // durable
+		true,  // auto-delete
+		false, // exclusive (mismatched)
+		false, // no-wait
+		nil,
+	)
+	if err == nil {
+		t.Fatalf("Expected ResourceLocked error but second QueueDeclare succeeded")
+	}
+
+	amqpErr, ok = err.(*Error)
+	if !ok {
+		t.Fatalf("Expected amqp.Error, got: %T (%v)", err, err)
+	}
+	if amqpErr.Code != ResourceLocked {
+		t.Fatalf("Expected ResourceLocked (405), got code: %d", amqpErr.Code)
+	}
+
+	// Verify ch2 transitioned to StateClosed and did not trigger recovery
+	waitForChannelClose(t, chanStateChanged2, int(ch2.id), "ResourceLocked")
+
+	if conn.IsClosed() {
+		t.Fatalf("Expected connection to remain open after RESOURCE_LOCKED soft exception")
+	}
+	t.Log("Verified connection remains open after RESOURCE_LOCKED")
+}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -328,10 +328,10 @@ func waitForConnectionOpen(t *testing.T, stateChanged chan *StateChanged) {
 		select {
 		case sc := <-stateChanged:
 			t.Logf("Connection state changed: %s", sc)
-			if _, ok := sc.To.(*StateReconnecting); ok {
+			if sc.To == StateReconnecting {
 				connReconnectingSeen = true
 			}
-			if _, ok := sc.To.(*StateOpen); ok {
+			if sc.To == StateOpen {
 				connOpenSeen = true
 			}
 		case <-time.After(10 * time.Second):
@@ -348,10 +348,10 @@ func waitForChannelOpen(t *testing.T, chanStateChanged chan *StateChanged) {
 		select {
 		case sc := <-chanStateChanged:
 			t.Logf("Channel state changed: %s", sc)
-			if _, ok := sc.To.(*StateReconnecting); ok {
+			if sc.To == StateReconnecting {
 				chanReconnectingSeen = true
 			}
-			if _, ok := sc.To.(*StateOpen); ok {
+			if sc.To == StateOpen {
 				chanOpenSeen = true
 			}
 		case <-time.After(10 * time.Second):
@@ -379,13 +379,13 @@ func waitForChannelClose(t *testing.T, chanStateChanged chan *StateChanged, chan
 				return
 			}
 			t.Logf("Channel %d state changed: %s", chanID, sc)
-			if _, ok := sc.To.(*StateClosed); ok {
+			if sc.To == StateClosed {
 				chanClosedSeen = true
 			}
-			if _, ok := sc.To.(*StateReconnecting); ok {
+			if sc.To == StateReconnecting {
 				chanReconnectingSeen = true
 			}
-			if _, ok := sc.To.(*StateOpen); ok {
+			if sc.To == StateOpen {
 				chanOpenSeen = true
 			}
 		case <-loopDeadline:
@@ -808,12 +808,12 @@ func TestConnectionRecoveryCancelInterrupt(t *testing.T) {
 		select {
 		case sc := <-connStateCh:
 			t.Logf("Connection state changed: %s", sc)
-			if _, ok := sc.To.(*StateReconnecting); ok {
+			if sc.To == StateReconnecting {
 				connReconnectingSeen = true
 			}
 		case sc := <-chanStateCh:
 			t.Logf("Channel state changed: %s", sc)
-			if _, ok := sc.To.(*StateReconnecting); ok {
+			if sc.To == StateReconnecting {
 				chanReconnectingSeen = true
 			}
 		case <-timeout:
@@ -861,7 +861,7 @@ func TestConnectionRecoveryCancelInterrupt(t *testing.T) {
 				continue
 			}
 			t.Logf("Connection state changed post-close: %s", sc)
-			if _, ok := sc.To.(*StateClosed); ok {
+			if sc.To == StateClosed {
 				connClosedSeen = true
 			}
 		case sc, ok := <-chanStateCh:
@@ -870,7 +870,7 @@ func TestConnectionRecoveryCancelInterrupt(t *testing.T) {
 				continue
 			}
 			t.Logf("Channel state changed post-close: %s", sc)
-			if _, ok := sc.To.(*StateClosed); ok {
+			if sc.To == StateClosed {
 				chanClosedSeen = true
 			}
 		case <-timeout:

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rabbitmq/amqp091-go/test/utils"
+	"github.com/rabbitmq/amqp091-go/internal/utils"
 )
 
 // TestConnectionRecoveryPublish tests the connection recovery for publish.

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -14,14 +14,6 @@ import (
 	"github.com/rabbitmq/amqp091-go/test/utils"
 )
 
-type testLogger struct {
-	t *testing.T
-}
-
-func (l testLogger) Printf(format string, v ...any) {
-	l.t.Logf("[lib] "+format, v...)
-}
-
 // TestConnectionRecoveryPublish tests the connection recovery for publish.
 func TestConnectionRecoveryPublish(t *testing.T) {
 	connectionName := "test-connection-recovery-publish"

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -7,9 +7,7 @@ package amqp091
 
 import (
 	"context"
-	"net"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -26,13 +24,17 @@ func (l testLogger) Printf(format string, v ...any) {
 
 // TestConnectionRecoveryPublish tests the connection recovery for publish.
 func TestConnectionRecoveryPublish(t *testing.T) {
-	SetLogger(testLogger{t: t})
-	defer SetLogger(NullLogger{})
-
-	// Create a connection with DialRecovery(url, nil)
-	conn, err := DialRecovery(amqpURL, nil)
+	connectionName := "test-connection-recovery-publish"
+	// Create a connection with Recovery
+	properties := NewConnectionProperties()
+	properties.SetClientConnectionName(connectionName)
+	conn, err := DialConfig(amqpURL, Config{
+		Recovery:   &Recovery{},
+		Locale:     defaultLocale,
+		Properties: properties,
+	})
 	if err != nil {
-		t.Fatalf("DialRecovery failed: %v", err)
+		t.Fatalf("DialConfig failed: %v", err)
 	}
 	defer conn.Close()
 
@@ -59,7 +61,7 @@ func TestConnectionRecoveryPublish(t *testing.T) {
 		_ = ch.ExchangeDelete(exchangeName, false, false)
 	}()
 
-	queueName := "recovery_queue"
+	queueName := "recovery_publish_queue"
 	_, err = ch.QueueDeclare(
 		queueName, // name
 		true,      // durable
@@ -88,6 +90,7 @@ func TestConnectionRecoveryPublish(t *testing.T) {
 	}
 
 	// Publish message on the given channel
+	preRecoveryMessage := "hello recovery 1"
 	err = ch.PublishWithContext(
 		context.Background(),
 		exchangeName,
@@ -96,22 +99,23 @@ func TestConnectionRecoveryPublish(t *testing.T) {
 		false,
 		Publishing{
 			ContentType: "text/plain",
-			Body:        []byte("hello recovery 1"),
+			Body:        []byte(preRecoveryMessage),
 		},
 	)
 	if err != nil {
-		t.Fatalf("Publish 1 failed: %v", err)
+		t.Fatalf("Publish pre-recovery message failed: %v", err)
 	}
+	t.Logf("Published message pre-recovery: %s", preRecoveryMessage)
 
 	// Consume message on the given channel
 	msgs, err := ch.Consume(
 		queueName,
-		"",    // consumer tag
-		true,  // autoAck
-		false, // exclusive
-		false, // noLocal
-		false, // noWait
-		nil,   // args
+		"recovery_publish_consumer", // consumer tag
+		true,                        // autoAck
+		false,                       // exclusive
+		false,                       // noLocal
+		false,                       // noWait
+		nil,                         // args
 	)
 	if err != nil {
 		t.Fatalf("Consume failed: %v", err)
@@ -122,11 +126,12 @@ func TestConnectionRecoveryPublish(t *testing.T) {
 		if !ok {
 			t.Fatalf("Consume channel closed prematurely")
 		}
-		if string(d.Body) != "hello recovery 1" {
-			t.Fatalf("Expected message 'hello recovery 1', got: %s", string(d.Body))
+		if string(d.Body) != preRecoveryMessage {
+			t.Fatalf("Expected message '%s', got: %s", preRecoveryMessage, string(d.Body))
 		}
+		t.Logf("Received message pre-recovery: %s", string(d.Body))
 	case <-time.After(5 * time.Second):
-		t.Fatalf("Timeout waiting for message 1")
+		t.Fatalf("Timeout waiting for receive message pre-recovery: %s", preRecoveryMessage)
 	}
 
 	// Register with connection for NotifyStateChange
@@ -138,7 +143,7 @@ func TestConnectionRecoveryPublish(t *testing.T) {
 	ch.NotifyStateChange(chanStateChanged)
 
 	// Call Http API to close the current connection
-	dropConnection(t, conn)
+	dropConnection(t, connectionName)
 
 	// Wait for connection to be open
 	waitForConnectionOpen(t, stateChanged)
@@ -147,6 +152,7 @@ func TestConnectionRecoveryPublish(t *testing.T) {
 	waitForChannelOpen(t, chanStateChanged)
 
 	// Verify Publish message on the given channel post-recovery.
+	postRecoveryMessage := "hello recovery 2"
 	err = ch.PublishWithContext(
 		context.Background(),
 		exchangeName,
@@ -155,12 +161,13 @@ func TestConnectionRecoveryPublish(t *testing.T) {
 		false,
 		Publishing{
 			ContentType: "text/plain",
-			Body:        []byte("hello recovery 2"),
+			Body:        []byte(postRecoveryMessage),
 		},
 	)
 	if err != nil {
-		t.Fatalf("Publish 2 failed: %v", err)
+		t.Fatalf("Publish post-recovery message failed: %v", err)
 	}
+	t.Logf("Published message post-recovery: %s", postRecoveryMessage)
 
 	// Verify message is received on the given channel post-recovery.
 	select {
@@ -168,22 +175,28 @@ func TestConnectionRecoveryPublish(t *testing.T) {
 		if !ok {
 			t.Fatalf("Consume channel closed after recovery")
 		}
-		if string(d.Body) != "hello recovery 2" {
-			t.Fatalf("Expected message 'hello recovery 2', got: %s", string(d.Body))
+		if string(d.Body) != postRecoveryMessage {
+			t.Fatalf("Expected message '%s', got: %s", postRecoveryMessage, string(d.Body))
 		}
+		t.Logf("Received message post-recovery: %s", string(d.Body))
 	case <-time.After(10 * time.Second):
-		t.Fatalf("Timeout waiting for message 2 post-recovery")
+		t.Fatalf("Timeout waiting for receive message post-recovery: %s", postRecoveryMessage)
 	}
 }
 
 // TestConnectionRecoveryConsume tests the connection recovery for consume.
 func TestConnectionRecoveryConsume(t *testing.T) {
-	SetLogger(testLogger{t: t})
-	defer SetLogger(NullLogger{})
-
-	conn, err := DialRecovery(amqpURL, nil)
+	connectionName := "test-connection-recovery-consume"
+	// Create a connection with Recovery
+	properties := NewConnectionProperties()
+	properties.SetClientConnectionName(connectionName)
+	conn, err := DialConfig(amqpURL, Config{
+		Recovery:   &Recovery{},
+		Locale:     defaultLocale,
+		Properties: properties,
+	})
 	if err != nil {
-		t.Fatalf("DialRecovery failed: %v", err)
+		t.Fatalf("DialConfig failed: %v", err)
 	}
 	defer conn.Close()
 
@@ -262,7 +275,7 @@ func TestConnectionRecoveryConsume(t *testing.T) {
 	ch.NotifyStateChange(chanStateChanged)
 
 	// Drop the connection
-	dropConnection(t, conn)
+	dropConnection(t, connectionName)
 
 	// Wait for connection to recover using connection.NotifyStateChange like before
 	waitForConnectionOpen(t, stateChanged)
@@ -290,43 +303,27 @@ func TestConnectionRecoveryConsume(t *testing.T) {
 	}
 }
 
-func dropConnection(t *testing.T, conn *Connection) {
-	localAddr := conn.LocalAddr().String()
-	_, localPortStr, err := net.SplitHostPort(localAddr)
-	if err != nil {
-		t.Fatalf("SplitHostPort failed for localAddr %s: %v", localAddr, err)
-	}
-
+func dropConnection(t *testing.T, name string) {
 	var targetConnName string
 	loopDeadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(loopDeadline) {
-		conns, err := utils.Connections()
+		connection, err := utils.GetConnectionByName(name)
 		if err != nil {
-			t.Logf("Failure listing connections (will retry): %v", err)
-			time.Sleep(time.Second)
+			t.Logf("Failure getting connection by name (will retry): %v", err)
+			time.Sleep(2 * time.Second)
 			continue
 		}
-
-		for _, c := range conns {
-			if strings.Contains(c.Name, ":"+localPortStr+" ->") {
-				targetConnName = c.Name
-				break
-			}
-		}
-
-		if targetConnName != "" {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
+		targetConnName = connection.Name
+		break
 	}
 
 	if targetConnName == "" {
 		conns, _ := utils.Connections()
-		t.Fatalf("Could not find connection name for local address: %s (port: %s) in connections: %+v", localAddr, localPortStr, conns)
+		t.Fatalf("Could not find connection by name: %s in connections: %+v", name, conns)
 	}
 
 	t.Logf("Dropping connection: %s", targetConnName)
-	err = utils.DropConnection(url.PathEscape(targetConnName), "15672")
+	err := utils.DropConnection(url.PathEscape(targetConnName), "15672")
 	if err != nil {
 		t.Fatalf("DropConnection failed: %v", err)
 	}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -528,3 +528,122 @@ func TestConnectionRecoveryNonRecoverableChannelClose(t *testing.T) {
 	}
 	t.Log("Verified connection remains open after RESOURCE_LOCKED")
 }
+
+// TestConnectionRecoveryChannelIDReservation verifies that after connection recovery,
+// the allocator correctly reserves the IDs of recovered channels, and subsequently
+// opened channels do not conflict with the recovered channel's ID.
+func TestConnectionRecoveryChannelIDReservation(t *testing.T) {
+	connectionName := "test-channel-id-reservation-recovery"
+	properties := NewConnectionProperties()
+	properties.SetClientConnectionName(connectionName)
+	conn, err := DialConfig(amqpURL, Config{
+		Recovery:   &Recovery{},
+		Locale:     defaultLocale,
+		Properties: properties,
+	})
+	if err != nil {
+		t.Fatalf("DialConfig failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Open channels 1, 2, 3, 4
+	ch1, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel 1 creation failed: %v", err)
+	}
+	defer ch1.Close()
+
+	ch2, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel 2 creation failed: %v", err)
+	}
+	defer ch2.Close()
+
+	ch3, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel 3 creation failed: %v", err)
+	}
+	defer ch3.Close()
+
+	ch4, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel 4 creation failed: %v", err)
+	}
+	defer ch4.Close()
+
+	id1, id2, id3, id4 := ch1.id, ch2.id, ch3.id, ch4.id
+	t.Logf("Opened channels with IDs: %d, %d, %d, %d", id1, id2, id3, id4)
+
+	// Close channels 2 and 4
+	if err := ch2.Close(); err != nil {
+		t.Fatalf("Failed to close channel 2: %v", err)
+	}
+	if err := ch4.Close(); err != nil {
+		t.Fatalf("Failed to close channel 4: %v", err)
+	}
+	t.Logf("Closed channels with IDs: %d, %d", id2, id4)
+
+	// Register for NotifyStateChange
+	stateChanged := make(chan *StateChanged, 10)
+	conn.NotifyStateChange(stateChanged)
+
+	chanStateChanged1 := make(chan *StateChanged, 10)
+	ch1.NotifyStateChange(chanStateChanged1)
+
+	chanStateChanged3 := make(chan *StateChanged, 10)
+	ch3.NotifyStateChange(chanStateChanged3)
+
+	// Drop connection
+	dropConnection(t, connectionName)
+
+	// Wait for connection and channel recovery
+	waitForConnectionOpen(t, stateChanged)
+	waitForChannelOpen(t, chanStateChanged1)
+	waitForChannelOpen(t, chanStateChanged3)
+
+	// Verify channel IDs are reserved in the connection allocator
+	conn.m.Lock()
+	if conn.allocator == nil {
+		conn.m.Unlock()
+		t.Fatalf("Expected allocator to be initialized post-recovery")
+	}
+	isReserved1 := conn.allocator.reserved(int(id1))
+	isReserved3 := conn.allocator.reserved(int(id3))
+	isReserved2 := conn.allocator.reserved(int(id2))
+	isReserved4 := conn.allocator.reserved(int(id4))
+	conn.m.Unlock()
+
+	if !isReserved1 {
+		t.Fatalf("Expected recovered channel ID %d to be reserved in the allocator", id1)
+	}
+	if !isReserved3 {
+		t.Fatalf("Expected recovered channel ID %d to be reserved in the allocator", id3)
+	}
+	if isReserved2 {
+		t.Fatalf("Expected closed channel ID %d to NOT be reserved in the allocator", id2)
+	}
+	if isReserved4 {
+		t.Fatalf("Expected closed channel ID %d to NOT be reserved in the allocator", id4)
+	}
+	t.Logf("Verified channel IDs %d and %d are correctly reserved, and %d and %d are free in the allocator", id1, id3, id2, id4)
+
+	// Churn open channels post-recovery and verify they don't conflict with the recovered channel IDs
+	var activeChannels []*Channel
+	for i := 0; i < 5; i++ {
+		ch, err := conn.Channel()
+		if err != nil {
+			t.Fatalf("Failed to create channel during churn at iteration %d: %v", i, err)
+		}
+		activeChannels = append(activeChannels, ch)
+		t.Logf("Opened new channel with ID: %d", ch.id)
+
+		if ch.id == id1 || ch.id == id3 {
+			t.Fatalf("Conflict detected! New channel allocated with recovered channel ID: %d", ch.id)
+		}
+	}
+
+	// Close the churned channels
+	for _, ch := range activeChannels {
+		ch.Close()
+	}
+}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -1,0 +1,372 @@
+// Copyright (c) 2026 Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+//go:build integration
+
+package amqp091
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rabbitmq/amqp091-go/test/utils"
+)
+
+type testLogger struct {
+	t *testing.T
+}
+
+func (l testLogger) Printf(format string, v ...any) {
+	l.t.Logf("[lib] "+format, v...)
+}
+
+// TestConnectionRecoveryPublish tests the connection recovery for publish.
+func TestConnectionRecoveryPublish(t *testing.T) {
+	SetLogger(testLogger{t: t})
+	defer SetLogger(NullLogger{})
+
+	// Create a connection with DialRecovery(url, nil)
+	conn, err := DialRecovery(amqpURL, nil)
+	if err != nil {
+		t.Fatalf("DialRecovery failed: %v", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel creation failed: %v", err)
+	}
+	defer ch.Close()
+
+	exchangeName := "recovery_exchange"
+	err = ch.ExchangeDeclare(
+		exchangeName, // name
+		"direct",     // type
+		false,        // durable
+		true,         // auto-delete
+		false,        // internal
+		false,        // no-wait
+		nil,          // arguments
+	)
+	if err != nil {
+		t.Fatalf("ExchangeDeclare failed: %v", err)
+	}
+	defer func() {
+		_ = ch.ExchangeDelete(exchangeName, false, false)
+	}()
+
+	queueName := "recovery_queue"
+	_, err = ch.QueueDeclare(
+		queueName, // name
+		true,      // durable
+		false,     // auto-delete
+		false,     // exclusive
+		false,     // no-wait
+		nil,       // arguments
+	)
+	if err != nil {
+		t.Fatalf("QueueDeclare failed: %v", err)
+	}
+	defer func() {
+		_, _ = ch.QueueDelete(queueName, false, false, false)
+	}()
+
+	routingKey := "recovery_routing_key"
+	err = ch.QueueBind(
+		queueName,
+		routingKey,
+		exchangeName,
+		false,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("QueueBind failed: %v", err)
+	}
+
+	// Publish message on the given channel
+	err = ch.PublishWithContext(
+		context.Background(),
+		exchangeName,
+		routingKey,
+		false,
+		false,
+		Publishing{
+			ContentType: "text/plain",
+			Body:        []byte("hello recovery 1"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Publish 1 failed: %v", err)
+	}
+
+	// Consume message on the given channel
+	msgs, err := ch.Consume(
+		queueName,
+		"",    // consumer tag
+		true,  // autoAck
+		false, // exclusive
+		false, // noLocal
+		false, // noWait
+		nil,   // args
+	)
+	if err != nil {
+		t.Fatalf("Consume failed: %v", err)
+	}
+
+	select {
+	case d, ok := <-msgs:
+		if !ok {
+			t.Fatalf("Consume channel closed prematurely")
+		}
+		if string(d.Body) != "hello recovery 1" {
+			t.Fatalf("Expected message 'hello recovery 1', got: %s", string(d.Body))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Timeout waiting for message 1")
+	}
+
+	// Register with connection for NotifyStateChange
+	stateChanged := make(chan *StateChanged, 10)
+	conn.NotifyStateChange(stateChanged)
+
+	// Register with channel for NotifyStateChange
+	chanStateChanged := make(chan *StateChanged, 10)
+	ch.NotifyStateChange(chanStateChanged)
+
+	// Call Http API to close the current connection
+	dropConnection(t, conn)
+
+	// Wait for connection to be open
+	waitForConnectionOpen(t, stateChanged)
+
+	// Verify channel state change notification is received and is reconnecting, followed by open
+	waitForChannelOpen(t, chanStateChanged)
+
+	// Verify Publish message on the given channel post-recovery.
+	err = ch.PublishWithContext(
+		context.Background(),
+		exchangeName,
+		routingKey,
+		false,
+		false,
+		Publishing{
+			ContentType: "text/plain",
+			Body:        []byte("hello recovery 2"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Publish 2 failed: %v", err)
+	}
+
+	// Verify message is received on the given channel post-recovery.
+	select {
+	case d, ok := <-msgs:
+		if !ok {
+			t.Fatalf("Consume channel closed after recovery")
+		}
+		if string(d.Body) != "hello recovery 2" {
+			t.Fatalf("Expected message 'hello recovery 2', got: %s", string(d.Body))
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Timeout waiting for message 2 post-recovery")
+	}
+}
+
+// TestConnectionRecoveryConsume tests the connection recovery for consume.
+func TestConnectionRecoveryConsume(t *testing.T) {
+	SetLogger(testLogger{t: t})
+	defer SetLogger(NullLogger{})
+
+	conn, err := DialRecovery(amqpURL, nil)
+	if err != nil {
+		t.Fatalf("DialRecovery failed: %v", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel creation failed: %v", err)
+	}
+	defer ch.Close()
+
+	queueName := "recovery_consume_test_queue"
+	_, err = ch.QueueDeclare(
+		queueName, // name
+		true,      // durable
+		false,     // auto-delete
+		false,     // exclusive
+		false,     // no-wait
+		nil,       // arguments
+	)
+	if err != nil {
+		t.Fatalf("QueueDeclare failed: %v", err)
+	}
+	defer func() {
+		_, _ = ch.QueueDelete(queueName, false, false, false)
+	}()
+
+	// Create Consumer with auto-ack false
+	msgs, err := ch.Consume(
+		queueName,
+		"consume-recovery-test",
+		false, // autoAck = false
+		false, // exclusive
+		false, // noLocal
+		false, // noWait
+		nil,   // args
+	)
+	if err != nil {
+		t.Fatalf("Consume failed: %v", err)
+	}
+
+	// Publish a message on the channel.
+	err = ch.PublishWithContext(
+		context.Background(),
+		"",        // exchange
+		queueName, // routing key = queue name
+		false,
+		false,
+		Publishing{
+			ContentType: "text/plain",
+			Body:        []byte("hello recovery consume"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Publish failed: %v", err)
+	}
+
+	// Consume message and do not send ack.
+	select {
+	case msg, ok := <-msgs:
+		if !ok {
+			t.Fatalf("Consume channel closed prematurely")
+		}
+		if string(msg.Body) != "hello recovery consume" {
+			t.Fatalf("Expected message 'hello recovery consume', got: %s", string(msg.Body))
+		}
+		t.Logf("Received message pre-recovery: %s (Redelivered: %t). Intentional no ACK.", string(msg.Body), msg.Redelivered)
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Timeout waiting for message delivery pre-recovery")
+	}
+
+	// Register with connection for NotifyStateChange
+	stateChanged := make(chan *StateChanged, 10)
+	conn.NotifyStateChange(stateChanged)
+
+	// Register with channel for NotifyStateChange
+	chanStateChanged := make(chan *StateChanged, 10)
+	ch.NotifyStateChange(chanStateChanged)
+
+	// Drop the connection
+	dropConnection(t, conn)
+
+	// Wait for connection to recover using connection.NotifyStateChange like before
+	waitForConnectionOpen(t, stateChanged)
+
+	// Wait for channel to recover using channel.NotifyStateChange like before
+	waitForChannelOpen(t, chanStateChanged)
+
+	// Confirm original message is received by the consumer and ack true.
+	select {
+	case msg, ok := <-msgs:
+		if !ok {
+			t.Fatalf("Consume channel closed after recovery")
+		}
+		if string(msg.Body) != "hello recovery consume" {
+			t.Fatalf("Expected message 'hello recovery consume', got: %s", string(msg.Body))
+		}
+		t.Logf("Received message post-recovery: %s (Redelivered: %t). Sending ACK.", string(msg.Body), msg.Redelivered)
+
+		err = msg.Ack(false)
+		if err != nil {
+			t.Fatalf("Acking redelivered message post-recovery failed: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Timeout waiting for message redelivery post-recovery")
+	}
+}
+
+func dropConnection(t *testing.T, conn *Connection) {
+	localAddr := conn.LocalAddr().String()
+	_, localPortStr, err := net.SplitHostPort(localAddr)
+	if err != nil {
+		t.Fatalf("SplitHostPort failed for localAddr %s: %v", localAddr, err)
+	}
+
+	var targetConnName string
+	loopDeadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(loopDeadline) {
+		conns, err := utils.Connections()
+		if err != nil {
+			t.Logf("Failure listing connections (will retry): %v", err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		for _, c := range conns {
+			if strings.Contains(c.Name, ":"+localPortStr+" ->") {
+				targetConnName = c.Name
+				break
+			}
+		}
+
+		if targetConnName != "" {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if targetConnName == "" {
+		conns, _ := utils.Connections()
+		t.Fatalf("Could not find connection name for local address: %s (port: %s) in connections: %+v", localAddr, localPortStr, conns)
+	}
+
+	t.Logf("Dropping connection: %s", targetConnName)
+	err = utils.DropConnection(url.PathEscape(targetConnName), "15672")
+	if err != nil {
+		t.Fatalf("DropConnection failed: %v", err)
+	}
+}
+
+func waitForConnectionOpen(t *testing.T, stateChanged chan *StateChanged) {
+	var connReconnectingSeen bool
+	var connOpenSeen bool
+	for !connOpenSeen {
+		select {
+		case sc := <-stateChanged:
+			t.Logf("Connection state changed: %s", sc)
+			if _, ok := sc.To.(*StateReconnecting); ok {
+				connReconnectingSeen = true
+			}
+			if _, ok := sc.To.(*StateOpen); ok {
+				connOpenSeen = true
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("Timeout waiting for connection recovery state changes. Reconnecting seen: %t, Open seen: %t", connReconnectingSeen, connOpenSeen)
+		}
+	}
+}
+
+func waitForChannelOpen(t *testing.T, chanStateChanged chan *StateChanged) {
+	var chanReconnectingSeen bool
+	var chanOpenSeen bool
+
+	for !chanOpenSeen {
+		select {
+		case sc := <-chanStateChanged:
+			t.Logf("Channel state changed: %s", sc)
+			if _, ok := sc.To.(*StateReconnecting); ok {
+				chanReconnectingSeen = true
+			}
+			if _, ok := sc.To.(*StateOpen); ok {
+				chanOpenSeen = true
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("Timeout waiting for channel recovery state changes. Reconnecting seen: %t, Open seen: %t", chanReconnectingSeen, chanOpenSeen)
+		}
+	}
+}

--- a/test/utils/http.go
+++ b/test/utils/http.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries. All rights reserved.
+
+//go:build integration
+
+package utils
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+type Connection struct {
+	Name        string `json:"name"`
+	ContainerId string `json:"container_id"`
+}
+
+func Connections() ([]Connection, error) {
+	bodyString, err := httpGet("http://localhost:15672/api/connections/", "guest", "guest")
+	if err != nil {
+		return nil, err
+	}
+
+	var data []Connection
+	err = json.Unmarshal([]byte(bodyString), &data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func GetConnectionByContainerID(Id string) (*Connection, error) {
+	connections, err := Connections()
+	if err != nil {
+		return nil, err
+	}
+	for _, conn := range connections {
+		if conn.ContainerId == Id {
+			return &conn, nil
+		}
+	}
+
+	return nil, errors.New("connection not found")
+}
+
+func DropConnectionContainerID(Id string) error {
+	connections, err := Connections()
+	if err != nil {
+		return err
+	}
+	connectionToDrop := ""
+	for _, conn := range connections {
+		if conn.ContainerId == Id {
+			connectionToDrop = conn.Name
+			break
+		}
+	}
+
+	if connectionToDrop == "" {
+		return errors.New("connection not found")
+	}
+
+	err = DropConnection(connectionToDrop, "15672")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func DropConnection(name string, port string) error {
+	_, err := httpDelete("http://localhost:"+port+"/api/connections/"+name, "guest", "guest")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func httpGet(url, username, password string) (string, error) {
+	return baseCall(url, username, password, "GET")
+}
+
+func httpDelete(url, username, password string) (string, error) {
+	return baseCall(url, username, password, "DELETE")
+}
+
+func baseCall(url, username, password string, method string) (string, error) {
+	var client http.Client
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.SetBasicAuth(username, password)
+
+	resp, err3 := client.Do(req)
+
+	if err3 != nil {
+		return "", err3
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 { // OK
+		bodyBytes, err2 := io.ReadAll(resp.Body)
+		if err2 != nil {
+			return "", err2
+		}
+		return string(bodyBytes), nil
+	}
+
+	if resp.StatusCode == 201 {
+		// Created! it is ok
+		return "", nil
+	}
+
+	if resp.StatusCode == 204 { // No Content
+		return "", nil
+	}
+
+	return "", errors.New(strconv.Itoa(resp.StatusCode))
+
+}

--- a/test/utils/http.go
+++ b/test/utils/http.go
@@ -13,9 +13,13 @@ import (
 	"strconv"
 )
 
+type ClientProperties struct {
+	ConnectionName string `json:"connection_name"`
+}
+
 type Connection struct {
-	Name        string `json:"name"`
-	ContainerId string `json:"container_id"`
+	Name             string           `json:"name"`
+	ClientProperties ClientProperties `json:"client_properties"`
 }
 
 func Connections() ([]Connection, error) {
@@ -32,42 +36,18 @@ func Connections() ([]Connection, error) {
 	return data, nil
 }
 
-func GetConnectionByContainerID(Id string) (*Connection, error) {
+func GetConnectionByName(name string) (*Connection, error) {
 	connections, err := Connections()
 	if err != nil {
 		return nil, err
 	}
 	for _, conn := range connections {
-		if conn.ContainerId == Id {
+		if conn.ClientProperties.ConnectionName == name {
 			return &conn, nil
 		}
 	}
 
 	return nil, errors.New("connection not found")
-}
-
-func DropConnectionContainerID(Id string) error {
-	connections, err := Connections()
-	if err != nil {
-		return err
-	}
-	connectionToDrop := ""
-	for _, conn := range connections {
-		if conn.ContainerId == Id {
-			connectionToDrop = conn.Name
-			break
-		}
-	}
-
-	if connectionToDrop == "" {
-		return errors.New("connection not found")
-	}
-
-	err = DropConnection(connectionToDrop, "15672")
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func DropConnection(name string, port string) error {

--- a/types.go
+++ b/types.go
@@ -78,6 +78,9 @@ var (
 
 	// ErrFieldType is returned when writing a message containing a Go type unsupported by AMQP.
 	ErrFieldType = &Error{Code: SyntaxError, Reason: "unsupported table field type"}
+
+	// ErrRecoveryNotEnabled is returned when recovery operations are attempted but recovery is not enabled.
+	ErrRecoveryNotEnabled = &Error{Code: ChannelError, Reason: "recovery is not enabled on this connection"}
 )
 
 // internal errors used inside the library


### PR DESCRIPTION
## Proposed Changes

Introduces automatic reconnection and channel recovery capabilities, allowing client
applications to transparently recover from connection and channel closures caused by 
network failures.
Key Features:
- **Auto-Recovery**: Automatic connection re-dial and re-establishment of all channels,
  publisher confirmation settings, and active consumer subscriptions. The recovery configuration/interface  
  can be provided by the consuming application, otherwise, the default configuration/interface implementation will be considered.
- **NotifyStateChange**: Added a lifecycle state machine to both `Connection` and `Channel` 
  broadcasting transitions (`open`, `reconnecting`, `closing`, `closed`) to registered 
  listeners. This allows applications to cleanly block activity during recovery. The states and Lifecycle type
  definition is used as is from [rabbitmq-amqp-go-client](https://github.com/rabbitmq/rabbitmq-amqp-go-client/blob/main/pkg/rabbitmqamqp/life_cycle.go)
- **Integration Test (`recovery_test.go`)**: Included integration tests 
  that use the RabbitMQ management plugin HTTP API to forcefully drop connections
  (HTTP utils is used as is from [rabbitmq-amqp-go-client](https://github.com/rabbitmq/rabbitmq-amqp-go-client/blob/main/pkg/test-helper/http_utils.go)) and verify:
  - Clean state transitions flow through `NotifyStateChange`
  - Active consumer subscriptions are restored, and unacknowledged messages are safely 
    redelivered (with `Redelivered: true`) and successfully acknowledged post-recovery
- **Example Usage (`_examples/recovery/recovery.go`)**: Added the recovery example to
  demonstrate how applications can listen to `NotifyStateChange` events and use synchronizing
  primitives (like `sync.Cond`) to gracefully block publishers while the connection is 
  reconnecting and unblock them once the state returns to open.

## Types of Changes

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [x] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further Comments

Topology Recovery will be implemented as a follow-up change. With this commit alone, the producer and consumer will work with auto-recovery as long as queues are durable.
