### PR TITLE
ci: upgrade RabbitMQ image to management variant

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,10 @@ jobs:
         go-version: ['oldstable', 'stable']
     services:
       rabbitmq:
-        image: rabbitmq
+        image: rabbitmq:4-management
         ports:
           - 5672:5672
+          - 15672:15672
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6


### PR DESCRIPTION
## Proposed Changes

Switch the RabbitMQ service image in the GitHub Actions workflow from the base version to `rabbitmq:4-management` and expose the management port (15672).

This change is required to support upcoming features that rely on the RabbitMQ Management API for integration testing.

## Types of Changes

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->
- [x] CI Changes

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

