### PR TITLE
Fix Client example to work with RabbitMQ 4.3

### DIFF
--- a/_examples/client/client.go
+++ b/_examples/client/client.go
@@ -257,7 +257,7 @@ func (client *Client) init(conn *amqp.Connection) error {
 	}
 	_, err = ch.QueueDeclare(
 		client.queueName,
-		false, // Durable
+		true,  // Durable
 		false, // Delete when unused
 		false, // Exclusive
 		false, // No-wait


### PR DESCRIPTION
## Proposed Changes

Currently Client example declares transient non-exclusive queue that is not allowed in RabbitMQ 4.3. Fix it by declaring durable queue.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

