### PR TITLE
doc: remove auto-reconnect from non-goals in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,6 @@ interact the semantics of the protocol.
 
 Things not intended to be supported.
 
-  * Auto reconnect and re-synchronization of client and server topologies.
-    * Reconnection would require understanding the error paths when the
-      topology cannot be declared on reconnect.  This would require a new set
-      of types and code paths that are best suited at the call-site of this
-      package.  AMQP has a dynamic topology that needs all peers to agree. If
-      this doesn't happen, the behavior is undefined.  Instead of producing a
-      possible interface with undefined behavior, this package is designed to
-      be simple for the caller to implement the necessary connection-time
-      topology declaration so that reconnection is trivial and encapsulated in
-      the caller's application code.
   * AMQP Protocol negotiation for forward or backward compatibility.
     * 0.9.1 is stable and widely deployed.  AMQP 1.0 is a divergent
       specification (a different protocol) and belongs to a different library.


### PR DESCRIPTION
## Proposed Changes

Remove the "Auto reconnect and re-synchronization of client and server topologies" section from the list of non-goals in README.md. This is no longer a non-goal because:
- Automatic connection and channel recovery was recently implemented in #339.
- Topology recovery is planned to be implemented soon as a follow-up.

## Types of Changes

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

