### PR TITLE
Write notifications asynchronously.

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -367,7 +367,14 @@ func (ch *Channel) dispatch(msg message) {
 	case *channelFlow:
 		ch.notifyM.RLock()
 		for _, c := range ch.flows {
-			c <- m.Active
+			select {
+			case c <- m.Active:
+			default:
+				go func(c chan bool, v bool) {
+					defer func() { recover() }()
+					c <- v
+				}(c, m.Active)
+			}
 		}
 		ch.notifyM.RUnlock()
 		if err := ch.send(&channelFlowOk{Active: m.Active}); err != nil {
@@ -377,7 +384,14 @@ func (ch *Channel) dispatch(msg message) {
 	case *basicCancel:
 		ch.notifyM.RLock()
 		for _, c := range ch.cancels {
-			c <- m.ConsumerTag
+			select {
+			case c <- m.ConsumerTag:
+			default:
+				go func(c chan string, v string) {
+					defer func() { recover() }()
+					c <- v
+				}(c, m.ConsumerTag)
+			}
 		}
 		ch.notifyM.RUnlock()
 		ch.consumers.cancel(m.ConsumerTag)
@@ -386,7 +400,14 @@ func (ch *Channel) dispatch(msg message) {
 		ret := newReturn(*m)
 		ch.notifyM.RLock()
 		for _, c := range ch.returns {
-			c <- *ret
+			select {
+			case c <- *ret:
+			default:
+				go func(c chan Return, v Return) {
+					defer func() { recover() }()
+					c <- v
+				}(c, *ret)
+			}
 		}
 		ch.notifyM.RUnlock()
 

--- a/channel_test.go
+++ b/channel_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Broadcom, Inc. All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package amqp091
+
+import (
+	"testing"
+	"time"
+)
+
+// The following tests verify that synchronous sends to full notification
+// channels do not block the reader goroutine.  Each test pre-fills the
+// listener channel to capacity so that a bare `c <- value` would deadlock,
+// then calls the dispatch handler in a goroutine and asserts it returns
+// within a short timeout.
+
+func TestChannelFlowDispatchDoesNotBlockOnFullListener(t *testing.T) {
+	flowCh := make(chan bool, 1)
+	flowCh <- true // pre-fill to capacity
+
+	ch := &Channel{flows: []chan bool{flowCh}}
+	ch.closed.Store(true) // ch.send() returns ErrClosed without accessing connection
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ch.dispatch(&channelFlow{Active: false})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("channelFlow dispatch blocked on full notification channel — reader goroutine would stall")
+	}
+}
+
+func TestBasicCancelDispatchDoesNotBlockOnFullListener(t *testing.T) {
+	cancelCh := make(chan string, 1)
+	cancelCh <- "old-tag" // pre-fill to capacity
+
+	ch := &Channel{
+		cancels:   []chan string{cancelCh},
+		consumers: makeConsumers(),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ch.dispatch(&basicCancel{ConsumerTag: "my-tag"})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("basicCancel dispatch blocked on full notification channel — reader goroutine would stall")
+	}
+}
+
+func TestBasicReturnDispatchDoesNotBlockOnFullListener(t *testing.T) {
+	returnCh := make(chan Return, 1)
+	returnCh <- Return{} // pre-fill to capacity
+
+	ch := &Channel{returns: []chan Return{returnCh}}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ch.dispatch(&basicReturn{})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("basicReturn dispatch blocked on full notification channel — reader goroutine would stall")
+	}
+}

--- a/confirms.go
+++ b/confirms.go
@@ -62,7 +62,14 @@ func (c *confirms) confirm(confirmation Confirmation) {
 	delete(c.sequencer, c.expecting)
 	c.expecting++
 	for _, l := range c.listeners {
-		l <- confirmation
+		select {
+		case l <- confirmation:
+		default:
+			go func(l chan Confirmation, c Confirmation) {
+				defer func() { recover() }()
+				l <- c
+			}(l, confirmation)
+		}
 	}
 }
 

--- a/confirms_test.go
+++ b/confirms_test.go
@@ -306,3 +306,24 @@ func TestDeferredConfirmationsConcurrency(t *testing.T) {
 		t.Fatal("expected to receive true for concurrent confirmations, received false")
 	}
 }
+
+func TestConfirmDispatchDoesNotBlockOnFullListener(t *testing.T) {
+	c := newConfirms()
+
+	// Pre-fill the listener to capacity so the next send would block without the fix.
+	listener := make(chan Confirmation, 1)
+	listener <- Confirmation{DeliveryTag: 0, Ack: true}
+	c.listeners = append(c.listeners, listener)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.confirm(Confirmation{DeliveryTag: 1, Ack: true})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("confirms.confirm() blocked on full listener channel — reader goroutine would stall")
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -846,11 +846,27 @@ func (c *Connection) dispatch0(f frame) {
 			c.shutdown(newError(m.ReplyCode, m.ReplyText))
 		case *connectionBlocked:
 			for _, c := range c.blocks {
-				c <- Blocking{Active: true, Reason: m.Reason}
+				b := Blocking{Active: true, Reason: m.Reason}
+				select {
+				case c <- b:
+				default:
+					go func(c chan Blocking, b Blocking) {
+						defer func() { recover() }()
+						c <- b
+					}(c, b)
+				}
 			}
 		case *connectionUnblocked:
 			for _, c := range c.blocks {
-				c <- Blocking{Active: false}
+				b := Blocking{Active: false}
+				select {
+				case c <- b:
+				default:
+					go func(c chan Blocking, b Blocking) {
+						defer func() { recover() }()
+						c <- b
+					}(c, b)
+				}
 			}
 		default:
 			select {

--- a/connection_test.go
+++ b/connection_test.go
@@ -392,3 +392,41 @@ func rabbitmqctl(t *testing.T, args ...string) error {
 
 	return cmd.Run()
 }
+
+func TestConnectionBlockedDispatchDoesNotBlockOnFullListener(t *testing.T) {
+	blockCh := make(chan Blocking, 1)
+	blockCh <- Blocking{Active: true, Reason: "existing"} // pre-fill to capacity
+
+	conn := &Connection{blocks: []chan Blocking{blockCh}}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn.dispatch0(&methodFrame{Method: &connectionBlocked{Reason: "memory"}})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("connectionBlocked dispatch blocked on full notification channel — reader goroutine would stall")
+	}
+}
+
+func TestConnectionUnblockedDispatchDoesNotBlockOnFullListener(t *testing.T) {
+	blockCh := make(chan Blocking, 1)
+	blockCh <- Blocking{Active: false} // pre-fill to capacity
+
+	conn := &Connection{blocks: []chan Blocking{blockCh}}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn.dispatch0(&methodFrame{Method: &connectionUnblocked{}})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("connectionUnblocked dispatch blocked on full notification channel — reader goroutine would stall")
+	}
+}


### PR DESCRIPTION
Prevents blocked notifications from blocking the reader. Allows heartbeats, ACKs, and deliveries even when the notification send blocks.

[ai-assisted=yes]