### PR TITLE
Avoid notifications blocking reader.

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -367,7 +367,10 @@ func (ch *Channel) dispatch(msg message) {
 	case *channelFlow:
 		ch.notifyM.RLock()
 		for _, c := range ch.flows {
-			c <- m.Active
+			select {
+			case c <- m.Active:
+			case <-time.After(5 * time.Second):
+			}
 		}
 		ch.notifyM.RUnlock()
 		if err := ch.send(&channelFlowOk{Active: m.Active}); err != nil {
@@ -377,7 +380,10 @@ func (ch *Channel) dispatch(msg message) {
 	case *basicCancel:
 		ch.notifyM.RLock()
 		for _, c := range ch.cancels {
-			c <- m.ConsumerTag
+			select {
+			case c <- m.ConsumerTag:
+			case <-time.After(5 * time.Second):
+			}
 		}
 		ch.notifyM.RUnlock()
 		ch.consumers.cancel(m.ConsumerTag)
@@ -386,7 +392,10 @@ func (ch *Channel) dispatch(msg message) {
 		ret := newReturn(*m)
 		ch.notifyM.RLock()
 		for _, c := range ch.returns {
-			c <- *ret
+			select {
+			case c <- *ret:
+			case <-time.After(5 * time.Second):
+			}
 		}
 		ch.notifyM.RUnlock()
 

--- a/channel.go
+++ b/channel.go
@@ -23,6 +23,38 @@ import (
 //	octet   short         long         size octets       octet
 const frameHeaderSize = 1 + 2 + 4 + 1
 
+// notifyTimeout bounds how long a notification send may block the reader
+// goroutine when a listener's channel is full.
+const notifyTimeout = 5 * time.Second
+
+// notifyAll broadcasts v to every listener, abandoning any individual send
+// that blocks for longer than notifyTimeout so a slow or full listener can
+// never wedge the reader goroutine. A single timer is reused across the whole
+// broadcast: this avoids allocating—and, on Go < 1.23, leaking for the full
+// timeout—a timer per send, which matters on hot paths such as publisher
+// confirms. No timer is allocated when there are no listeners.
+func notifyAll[T any](listeners []chan T, v T) {
+	if len(listeners) == 0 {
+		return
+	}
+	t := time.NewTimer(notifyTimeout)
+	defer t.Stop()
+	for _, c := range listeners {
+		if !t.Stop() {
+			// Drain the channel if the timer already fired so Reset is safe.
+			select {
+			case <-t.C:
+			default:
+			}
+		}
+		t.Reset(notifyTimeout)
+		select {
+		case c <- v:
+		case <-t.C:
+		}
+	}
+}
+
 /*
 Channel represents an AMQP channel. Used as a context for valid message
 exchange.  Errors on methods with this Channel as a receiver means this channel
@@ -366,12 +398,7 @@ func (ch *Channel) dispatch(msg message) {
 
 	case *channelFlow:
 		ch.notifyM.RLock()
-		for _, c := range ch.flows {
-			select {
-			case c <- m.Active:
-			case <-time.After(5 * time.Second):
-			}
-		}
+		notifyAll(ch.flows, m.Active)
 		ch.notifyM.RUnlock()
 		if err := ch.send(&channelFlowOk{Active: m.Active}); err != nil {
 			Logger.Printf("error sending channelFlowOk, channel id: %d error: %+v", ch.id, err)
@@ -379,24 +406,14 @@ func (ch *Channel) dispatch(msg message) {
 
 	case *basicCancel:
 		ch.notifyM.RLock()
-		for _, c := range ch.cancels {
-			select {
-			case c <- m.ConsumerTag:
-			case <-time.After(5 * time.Second):
-			}
-		}
+		notifyAll(ch.cancels, m.ConsumerTag)
 		ch.notifyM.RUnlock()
 		ch.consumers.cancel(m.ConsumerTag)
 
 	case *basicReturn:
 		ret := newReturn(*m)
 		ch.notifyM.RLock()
-		for _, c := range ch.returns {
-			select {
-			case c <- *ret:
-			case <-time.After(5 * time.Second):
-			}
-		}
+		notifyAll(ch.returns, *ret)
 		ch.notifyM.RUnlock()
 
 	case *basicAck:

--- a/channel_test.go
+++ b/channel_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Broadcom, Inc. All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package amqp091
+
+import (
+	"testing"
+	"time"
+)
+
+func TestChannelFlowDispatchDropsNotificationOnFullListener(t *testing.T) {
+	t.Parallel()
+
+	listener := make(chan bool, 1)
+	listener <- false // pre-fill to capacity
+
+	ch := &Channel{consumers: makeConsumers()}
+	ch.flows = append(ch.flows, listener)
+	ch.closed.Store(true) // prevent send() from accessing nil connection
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ch.dispatch(&channelFlow{Active: true})
+	}()
+
+	select {
+	case <-done:
+		if len(listener) != 1 {
+			t.Fatalf("expected listener to retain 1 item (notification dropped), got %d", len(listener))
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("channelFlow dispatch blocked on full listener for more than 6 seconds")
+	}
+}
+
+func TestBasicCancelDispatchDropsNotificationOnFullListener(t *testing.T) {
+	t.Parallel()
+
+	listener := make(chan string, 1)
+	listener <- "existing-tag" // pre-fill to capacity
+
+	ch := &Channel{consumers: makeConsumers()}
+	ch.cancels = append(ch.cancels, listener)
+	ch.closed.Store(true)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ch.dispatch(&basicCancel{ConsumerTag: "new-tag"})
+	}()
+
+	select {
+	case <-done:
+		if len(listener) != 1 {
+			t.Fatalf("expected listener to retain 1 item (notification dropped), got %d", len(listener))
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("basicCancel dispatch blocked on full listener for more than 6 seconds")
+	}
+}
+
+func TestBasicReturnDispatchDropsNotificationOnFullListener(t *testing.T) {
+	t.Parallel()
+
+	listener := make(chan Return, 1)
+	listener <- Return{} // pre-fill to capacity
+
+	ch := &Channel{consumers: makeConsumers()}
+	ch.returns = append(ch.returns, listener)
+	ch.closed.Store(true)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ch.dispatch(&basicReturn{})
+	}()
+
+	select {
+	case <-done:
+		if len(listener) != 1 {
+			t.Fatalf("expected listener to retain 1 item (notification dropped), got %d", len(listener))
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("basicReturn dispatch blocked on full listener for more than 6 seconds")
+	}
+}

--- a/confirms.go
+++ b/confirms.go
@@ -8,6 +8,7 @@ package amqp091
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // confirms resequences and notifies one or multiple publisher confirmation listeners
@@ -62,7 +63,10 @@ func (c *confirms) confirm(confirmation Confirmation) {
 	delete(c.sequencer, c.expecting)
 	c.expecting++
 	for _, l := range c.listeners {
-		l <- confirmation
+		select {
+		case l <- confirmation:
+		case <-time.After(5 * time.Second):
+		}
 	}
 }
 

--- a/confirms.go
+++ b/confirms.go
@@ -8,7 +8,6 @@ package amqp091
 import (
 	"context"
 	"sync"
-	"time"
 )
 
 // confirms resequences and notifies one or multiple publisher confirmation listeners
@@ -62,12 +61,7 @@ func (c *confirms) unpublish() {
 func (c *confirms) confirm(confirmation Confirmation) {
 	delete(c.sequencer, c.expecting)
 	c.expecting++
-	for _, l := range c.listeners {
-		select {
-		case l <- confirmation:
-		case <-time.After(5 * time.Second):
-		}
-	}
+	notifyAll(c.listeners, confirmation)
 }
 
 // resequence confirms any out of order delivered confirmations

--- a/confirms_test.go
+++ b/confirms_test.go
@@ -306,3 +306,27 @@ func TestDeferredConfirmationsConcurrency(t *testing.T) {
 		t.Fatal("expected to receive true for concurrent confirmations, received false")
 	}
 }
+
+func TestConfirmDispatchDropsNotificationOnFullListener(t *testing.T) {
+	t.Parallel()
+
+	c := newConfirms()
+	listener := make(chan Confirmation, 1)
+	listener <- Confirmation{0, false} // pre-fill to capacity
+	c.Listen(listener)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.confirm(Confirmation{1, true})
+	}()
+
+	select {
+	case <-done:
+		if len(listener) != 1 {
+			t.Fatalf("expected listener to retain 1 item (notification dropped), got %d", len(listener))
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("confirm blocked on full listener for more than 6 seconds")
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -845,19 +845,9 @@ func (c *Connection) dispatch0(f frame) {
 			}
 			c.shutdown(newError(m.ReplyCode, m.ReplyText))
 		case *connectionBlocked:
-			for _, c := range c.blocks {
-				select {
-				case c <- Blocking{Active: true, Reason: m.Reason}:
-				case <-time.After(5 * time.Second):
-				}
-			}
+			notifyAll(c.blocks, Blocking{Active: true, Reason: m.Reason})
 		case *connectionUnblocked:
-			for _, c := range c.blocks {
-				select {
-				case c <- Blocking{Active: false}:
-				case <-time.After(5 * time.Second):
-				}
-			}
+			notifyAll(c.blocks, Blocking{Active: false})
 		default:
 			select {
 			case <-c.close:

--- a/connection.go
+++ b/connection.go
@@ -846,11 +846,17 @@ func (c *Connection) dispatch0(f frame) {
 			c.shutdown(newError(m.ReplyCode, m.ReplyText))
 		case *connectionBlocked:
 			for _, c := range c.blocks {
-				c <- Blocking{Active: true, Reason: m.Reason}
+				select {
+				case c <- Blocking{Active: true, Reason: m.Reason}:
+				case <-time.After(5 * time.Second):
+				}
 			}
 		case *connectionUnblocked:
 			for _, c := range c.blocks {
-				c <- Blocking{Active: false}
+				select {
+				case c <- Blocking{Active: false}:
+				case <-time.After(5 * time.Second):
+				}
 			}
 		default:
 			select {

--- a/connection_unit_test.go
+++ b/connection_unit_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Broadcom, Inc. All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package amqp091
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConnectionBlockedDispatchDropsNotificationOnFullListener(t *testing.T) {
+	t.Parallel()
+
+	listener := make(chan Blocking, 1)
+	listener <- Blocking{} // pre-fill to capacity
+
+	c := &Connection{}
+	c.blocks = append(c.blocks, listener)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.dispatch0(&methodFrame{Method: &connectionBlocked{Reason: "memory"}})
+	}()
+
+	select {
+	case <-done:
+		if len(listener) != 1 {
+			t.Fatalf("expected listener to retain 1 item (notification dropped), got %d", len(listener))
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("connectionBlocked dispatch blocked on full listener for more than 6 seconds")
+	}
+}
+
+func TestConnectionUnblockedDispatchDropsNotificationOnFullListener(t *testing.T) {
+	t.Parallel()
+
+	listener := make(chan Blocking, 1)
+	listener <- Blocking{} // pre-fill to capacity
+
+	c := &Connection{}
+	c.blocks = append(c.blocks, listener)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.dispatch0(&methodFrame{Method: &connectionUnblocked{}})
+	}()
+
+	select {
+	case <-done:
+		if len(listener) != 1 {
+			t.Fatalf("expected listener to retain 1 item (notification dropped), got %d", len(listener))
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("connectionUnblocked dispatch blocked on full listener for more than 6 seconds")
+	}
+}


### PR DESCRIPTION
Add 5s timeout to notifications to avoid blocking reader when notification channel is full.

[ai-assisted=yes]