### PR TITLE
fix: redact and zero out plaintext SASL credentials after handshake

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -23,6 +23,11 @@ type PlainAuth struct {
 	Password string
 }
 
+// String returns a redacted representation of PlainAuth.
+func (auth PlainAuth) String() string {
+	return fmt.Sprintf("PlainAuth{Username: %q, Password: [REDACTED]}", auth.Username)
+}
+
 // Mechanism returns "PLAIN"
 func (auth *PlainAuth) Mechanism() string {
 	return "PLAIN"
@@ -37,6 +42,11 @@ func (auth *PlainAuth) Response() string {
 type AMQPlainAuth struct {
 	Username string
 	Password string
+}
+
+// String returns a redacted representation of AMQPlainAuth.
+func (auth AMQPlainAuth) String() string {
+	return fmt.Sprintf("AMQPlainAuth{Username: %q, Password: [REDACTED]}", auth.Username)
 }
 
 // Mechanism returns "AMQPLAIN"

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,6 +1,10 @@
 package amqp091
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 func TestPlainAuth(t *testing.T) {
 	auth := &PlainAuth{
@@ -27,5 +31,21 @@ func TestExternalAuth(t *testing.T) {
 
 	if auth.Response() != "\000*\000*" {
 		t.Errorf("Expected \000*\000*, got %s", auth.Response())
+	}
+}
+
+func TestPlainAuthStringRedactsPassword(t *testing.T) {
+	auth := PlainAuth{Username: "admin", Password: "s3cr3t"}
+	s := fmt.Sprintf("%+v", auth)
+	if strings.Contains(s, "s3cr3t") {
+		t.Fatal("PlainAuth default formatting exposes password")
+	}
+}
+
+func TestAMQPlainAuthStringRedactsPassword(t *testing.T) {
+	auth := AMQPlainAuth{Username: "admin", Password: "s3cr3t"}
+	s := fmt.Sprintf("%+v", auth)
+	if strings.Contains(s, "s3cr3t") {
+		t.Fatal("AMQPlainAuth default formatting exposes password")
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -29,10 +29,8 @@ type server struct {
 }
 
 var (
-	defaultLogin        = "guest"
-	defaultPassword     = "guest"
-	defaultPlainAuth    = &PlainAuth{defaultLogin, defaultPassword}
-	defaultAMQPlainAuth = &AMQPlainAuth{defaultLogin, defaultPassword}
+	defaultLogin    = "guest"
+	defaultPassword = "guest"
 )
 
 func defaultConfigWithAuth(auth Authentication) Config {
@@ -44,11 +42,13 @@ func defaultConfigWithAuth(auth Authentication) Config {
 }
 
 func defaultConfig() Config {
-	return defaultConfigWithAuth(defaultPlainAuth)
+	// Use new instance of PlainAuth as password is zeroed out after successful open-ok
+	return defaultConfigWithAuth(&PlainAuth{Username: defaultLogin, Password: defaultPassword})
 }
 
 func amqplainConfig() Config {
-	return defaultConfigWithAuth(defaultAMQPlainAuth)
+	// Use new instance of AMQPlainAuth as password is zeroed out after successful open-ok
+	return defaultConfigWithAuth(&AMQPlainAuth{Username: defaultLogin, Password: defaultPassword})
 }
 
 func newServer(t *testing.T, serverIO, clientIO io.ReadWriteCloser) *server {

--- a/connection.go
+++ b/connection.go
@@ -105,6 +105,29 @@ func NewConnectionProperties() Table {
 	}
 }
 
+// setSASL populates the SASL configuration from URI if it's not already set.
+func (config *Config) setSASL(uri URI) error {
+	if config.SASL == nil {
+		if uri.AuthMechanism != nil {
+			for _, identifier := range uri.AuthMechanism {
+				switch strings.ToUpper(identifier) {
+				case "PLAIN":
+					config.SASL = append(config.SASL, uri.PlainAuth())
+				case "AMQPLAIN":
+					config.SASL = append(config.SASL, uri.AMQPlainAuth())
+				case "EXTERNAL":
+					config.SASL = append(config.SASL, &ExternalAuth{})
+				default:
+					return fmt.Errorf("unsupported auth_mechanism: %v", identifier)
+				}
+			}
+		} else {
+			config.SASL = []Authentication{uri.PlainAuth()}
+		}
+	}
+	return nil
+}
+
 // Connection manages the serialization and deserialization of frames from IO
 // and dispatches the frames to the appropriate channel.  All RPC methods and
 // asynchronous Publishing, Delivery, Ack, Nack and Return messages are
@@ -237,23 +260,8 @@ func DialConfig(url string, config Config) (*Connection, error) {
 		config.Locale = defaultLocale
 	}
 
-	if config.SASL == nil {
-		if uri.AuthMechanism != nil {
-			for _, identifier := range uri.AuthMechanism {
-				switch strings.ToUpper(identifier) {
-				case "PLAIN":
-					config.SASL = append(config.SASL, uri.PlainAuth())
-				case "AMQPLAIN":
-					config.SASL = append(config.SASL, uri.AMQPlainAuth())
-				case "EXTERNAL":
-					config.SASL = append(config.SASL, &ExternalAuth{})
-				default:
-					return nil, fmt.Errorf("unsupported auth_mechanism: %v", identifier)
-				}
-			}
-		} else {
-			config.SASL = []Authentication{uri.PlainAuth()}
-		}
+	if err := config.setSASL(uri); err != nil {
+		return nil, err
 	}
 
 	if config.Vhost == "" {
@@ -1279,6 +1287,15 @@ func (c *Connection) openComplete() error {
 		_ = deadliner.SetDeadline(time.Time{})
 	}
 
+	// Zero out credentials after successful open-ok
+	for i := range c.Config.SASL {
+		if pa, ok := c.Config.SASL[i].(*PlainAuth); ok {
+			pa.Password = ""
+		} else if apa, ok := c.Config.SASL[i].(*AMQPlainAuth); ok {
+			apa.Password = ""
+		}
+	}
+
 	return nil
 }
 
@@ -1453,6 +1470,14 @@ func (c *Connection) Reconnect() error {
 			Logger.Printf("Connection recovery failed to parse URI: %v", err)
 			return err
 		}
+
+		// Reset SASL to recover from zeroed out credentials
+		c.Config.SASL = nil
+		if err = c.Config.setSASL(uri); err != nil {
+			Logger.Printf("Connection recovery failed to set SASL: %v", err)
+			return err
+		}
+
 		addr := net.JoinHostPort(uri.Host, strconv.FormatInt(int64(uri.Port), 10))
 
 		conn, err = dialer("tcp", addr)

--- a/connection_unit_test.go
+++ b/connection_unit_test.go
@@ -5,6 +5,8 @@
 package amqp091
 
 import (
+	"errors"
+	"net"
 	"testing"
 	"time"
 )
@@ -56,5 +58,93 @@ func TestConnectionUnblockedDispatchDropsNotificationOnFullListener(t *testing.T
 		}
 	case <-time.After(6 * time.Second):
 		t.Fatal("connectionUnblocked dispatch blocked on full listener for more than 6 seconds")
+	}
+}
+
+func TestConnectionOpenCompleteZerosSASLCredentials(t *testing.T) {
+	pa := &PlainAuth{Username: "user", Password: "secretpassword"}
+	apa := &AMQPlainAuth{Username: "user", Password: "secretpassword"}
+
+	c := &Connection{
+		Config: Config{
+			SASL: []Authentication{pa, apa},
+		},
+	}
+
+	err := c.openComplete()
+	if err != nil {
+		t.Fatalf("unexpected error from openComplete: %v", err)
+	}
+
+	if pa.Password != "" {
+		t.Errorf("expected PlainAuth password to be zeroed out, got %q", pa.Password)
+	}
+
+	if apa.Password != "" {
+		t.Errorf("expected AMQPlainAuth password to be zeroed out, got %q", apa.Password)
+	}
+}
+
+func TestConfigSetSASL(t *testing.T) {
+	uri, err := ParseURI("amqp://guest:secret@localhost:5672/")
+	if err != nil {
+		t.Fatalf("failed to parse URI: %v", err)
+	}
+
+	config := Config{}
+	err = config.setSASL(uri)
+	if err != nil {
+		t.Fatalf("unexpected error from setSASL: %v", err)
+	}
+
+	if len(config.SASL) != 1 {
+		t.Fatalf("expected 1 SASL mechanism, got %d", len(config.SASL))
+	}
+
+	pa, ok := config.SASL[0].(*PlainAuth)
+	if !ok {
+		t.Fatalf("expected PlainAuth, got %T", config.SASL[0])
+	}
+
+	if pa.Username != "guest" || pa.Password != "secret" {
+		t.Errorf("expected guest:secret, got %s:%s", pa.Username, pa.Password)
+	}
+}
+
+func TestReconnectRestoresSASLCredentials(t *testing.T) {
+	pa := &PlainAuth{Username: "user", Password: ""} // zeroed out
+	c := &Connection{
+		url:       "amqp://user:mysecretpassword@localhost:5672/",
+		lifeCycle: newLifeCycle(),
+		Config: Config{
+			SASL: []Authentication{pa},
+			Recovery: &Recovery{
+				ReconnectionConfig: &ReconnectionConfig{
+					MaxRetryCount:         1,
+					RetryInterval:         1 * time.Millisecond,
+					RecoverableErrorCodes: []int{320}, // some recoverable code
+				},
+			},
+			Dial: func(network, addr string) (net.Conn, error) {
+				return nil, errors.New("mock dial error")
+			},
+		},
+	}
+	c.closed.Store(true)
+
+	// Trigger Reconnect. It will fail due to the mock dialer, but should restore SASL first
+	_ = c.Reconnect()
+
+	if len(c.Config.SASL) != 1 {
+		t.Fatalf("expected 1 SASL mechanism after Reconnect, got %d", len(c.Config.SASL))
+	}
+
+	restoredPa, ok := c.Config.SASL[0].(*PlainAuth)
+	if !ok {
+		t.Fatalf("expected PlainAuth after Reconnect, got %T", c.Config.SASL[0])
+	}
+
+	if restoredPa.Username != "user" || restoredPa.Password != "mysecretpassword" {
+		t.Errorf("expected restored credentials to be user:mysecretpassword, got %s:%s", restoredPa.Username, restoredPa.Password)
 	}
 }


### PR DESCRIPTION
## Proposed Changes

- Implement `fmt.Stringer` on `PlainAuth` and `AMQPlainAuth` to redact passwords from logs, reflection, or APM dumps.
- Zero out credentials in `Connection.Config.SASL` after a successful handshake in `openComplete()`.
- Extract SASL setup from connection URIs into a new helper method `Config.setSASL(uri URI)`.
- Reset and reinitialize SASL credentials from the connection recovery URL (`c.url`) in `Reconnect()` to ensure automatic reconnection succeeds after the previous connection's credentials were zeroed out.
- Add comprehensive unit tests in `auth_test.go` and `connection_unit_test.go` verifying redacting, zeroing, and recovery restoration of credentials.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
