### PR TITLE
Reject negative prefetch values in Qos

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -820,6 +820,11 @@ greater as described by benchmarks on RabbitMQ.
 http://www.rabbitmq.com/blog/2012/04/25/rabbitmq-performance-measurements-part-2/
 */
 func (ch *Channel) Qos(prefetchCount, prefetchSize int, global bool) error {
+	// TODO: Change prefetchCount and prefetchSize types from int to uint16 and uint32 respectively.
+	// This will be a breaking change and should be done in a future major release.
+	if err := ch.validateQos(prefetchCount, prefetchSize); err != nil {
+		return err
+	}
 	return ch.call(
 		&basicQos{
 			PrefetchCount: uint16(prefetchCount),
@@ -828,6 +833,13 @@ func (ch *Channel) Qos(prefetchCount, prefetchSize int, global bool) error {
 		},
 		&basicQosOk{},
 	)
+}
+
+func (ch *Channel) validateQos(prefetchCount, prefetchSize int) error {
+	if prefetchCount < 0 || prefetchSize < 0 {
+		return fmt.Errorf("amqp: Qos values must be non-negative (got prefetchCount=%d, prefetchSize=%d)", prefetchCount, prefetchSize)
+	}
+	return nil
 }
 
 /*

--- a/channel_test.go
+++ b/channel_test.go
@@ -143,3 +143,22 @@ func TestRecvContentBodyPreallocationIsCappedToFrameSize(t *testing.T) {
 		})
 	}
 }
+
+func TestQosNegativeReturnsError(t *testing.T) {
+	ch := &Channel{}
+	if err := ch.validateQos(-1, 0); err == nil {
+		t.Fatal("expected error for negative prefetchCount")
+	}
+	if err := ch.validateQos(0, -1); err == nil {
+		t.Fatal("expected error for negative prefetchSize")
+	}
+	if err := ch.validateQos(-1, -1); err == nil {
+		t.Fatal("expected error for negative prefetchCount and prefetchSize")
+	}
+	if err := ch.validateQos(0, 0); err != nil {
+		t.Fatalf("unexpected error for zero values: %v", err)
+	}
+	if err := ch.validateQos(10, 100); err != nil {
+		t.Fatalf("unexpected error for positive values: %v", err)
+	}
+}


### PR DESCRIPTION
## Proposed Changes

Validate and reject negative prefetchCount and prefetchSize values in Channel.Qos to prevent integer wrapping to unlimited prefetch. 
Added a TODO to change the parameter types to unsigned integers in a future major release.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

I'll create a issue on GH and mark it for 2.0.0
