### PR TITLE
fix: enforce AMQP minimum frame size during negotiation

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1233,10 +1233,10 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 
 	c.m.Unlock()
 
-	// Frame size includes headers and end byte (len(payload)+8), even if
-	// this is less than FrameMinSize, use what the server sends because the
-	// alternative is to stop the handshake here.
-	c.Config.FrameSize = pick(config.FrameSize, int(tune.FrameMax))
+	// Frame size includes headers and end byte (len(payload)+8). Enforce the spec
+	// minimum floor of frameMinSize (4096 bytes) to prevent malicious servers
+	// from forcing extreme fragmentation and CPU overhead.
+	c.Config.FrameSize = negotiateFrameSize(config.FrameSize, int(tune.FrameMax))
 
 	// Save this off for resetDeadline()
 	c.Config.Heartbeat = time.Second * time.Duration(pick(
@@ -1379,6 +1379,14 @@ func pick(client, server int) int {
 		return max(client, server)
 	}
 	return min(client, server)
+}
+
+func negotiateFrameSize(client, server int) int {
+	size := pick(client, server)
+	if size > 0 && size < frameMinSize {
+		return frameMinSize
+	}
+	return size
 }
 
 // cleanup releases registered resources and performs final teardown of the connection.

--- a/connection_unit_test.go
+++ b/connection_unit_test.go
@@ -148,3 +148,58 @@ func TestReconnectRestoresSASLCredentials(t *testing.T) {
 		t.Errorf("expected restored credentials to be user:mysecretpassword, got %s:%s", restoredPa.Username, restoredPa.Password)
 	}
 }
+
+func TestNegotiationEnforcesFrameMinSize(t *testing.T) {
+	tests := []struct {
+		name             string
+		clientFrameSize  int
+		serverFrameMax   int
+		expectedFrameMin int
+	}{
+		{
+			name:             "client unlimited, server below min",
+			clientFrameSize:  0,
+			serverFrameMax:   1,
+			expectedFrameMin: frameMinSize,
+		},
+		{
+			name:             "client below min, server unlimited",
+			clientFrameSize:  2048,
+			serverFrameMax:   0,
+			expectedFrameMin: frameMinSize,
+		},
+		{
+			name:             "client unlimited, server unlimited",
+			clientFrameSize:  0,
+			serverFrameMax:   0,
+			expectedFrameMin: 0,
+		},
+		{
+			name:             "client and server above min (client smaller)",
+			clientFrameSize:  8192,
+			serverFrameMax:   16384,
+			expectedFrameMin: 8192,
+		},
+		{
+			name:             "client and server above min (server smaller)",
+			clientFrameSize:  16384,
+			serverFrameMax:   8192,
+			expectedFrameMin: 8192,
+		},
+		{
+			name:             "client and server below min",
+			clientFrameSize:  1,
+			serverFrameMax:   1,
+			expectedFrameMin: frameMinSize,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := negotiateFrameSize(tc.clientFrameSize, tc.serverFrameMax)
+			if got != tc.expectedFrameMin {
+				t.Errorf("negotiateFrameSize(%d, %d) = %d; want %d", tc.clientFrameSize, tc.serverFrameMax, got, tc.expectedFrameMin)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed Changes

- Extract frame size negotiation logic into a dedicated helper function `negotiateFrameSize`.
- Enforce the AMQP spec minimum floor of 4096 bytes (`frameMinSize`) to prevent malicious servers from advertising small values to cause excessive CPU overhead and frame fragmentation.
- Added unit test in `connection_unit_test.go` verifying that various client and server negotiation parameters are resolved correctly.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

