### PR TITLE
fix: return error when shortstr exceeds 255 bytes

### DIFF
--- a/write.go
+++ b/write.go
@@ -242,6 +242,9 @@ func writeFrame(w io.Writer, typ uint8, channel uint16, payload []byte) (err err
 
 func writeShortstr(w io.Writer, s string) (err error) {
 	b := []byte(s)
+	if len(b) > 255 {
+		return fmt.Errorf("amqp: shortstr %q exceeds 255 bytes", s)
+	}
 
 	length := uint8(len(b))
 

--- a/write_test.go
+++ b/write_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Broadcom, Inc. All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package amqp091
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestWriteShortstrTruncationReturnsError(t *testing.T) {
+	longStr := strings.Repeat("a", 256) // 256 bytes > 255 max
+	var buf bytes.Buffer
+	err := writeShortstr(&buf, longStr)
+	if err == nil {
+		t.Fatal("expected error for shortstr > 255 bytes, got nil")
+	}
+}
+
+func TestWriteShortstrExact255Succeeds(t *testing.T) {
+	s := strings.Repeat("a", 255)
+	var buf bytes.Buffer
+	if err := writeShortstr(&buf, s); err != nil {
+		t.Fatalf("unexpected error for 255-byte shortstr: %v", err)
+	}
+	if buf.Len() != 256 { // 1-byte length prefix + 255 bytes
+		t.Fatalf("wrong output length: %d", buf.Len())
+	}
+}


### PR DESCRIPTION
## Proposed Changes

- Validate the length of short strings in `writeShortstr` and return an error if they exceed the 255-byte limit.
- This prevents silent data truncation and integer wrapping (e.g., a 300-byte string wrapping to a length of 44).
- Add unit tests in `write_test.go` to verify error handling for oversized short strings and successful serialization for strings at the 255-byte limit.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
