### PR TITLE
fix: explicitly enforce TLS 1.2 minimum version in tlsConfigFromURI

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -218,6 +218,9 @@ func Dial(url string) (*Connection, error) {
 // seconds and sets the initial read deadline to 30 seconds.
 //
 // DialTLS uses the provided tls.Config when encountering an amqps:// scheme.
+// Note: If you provide a custom tls.Config, you should explicitly set a secure
+// MinVersion (such as tls.VersionTLS12 or tls.VersionTLS13) as the library
+// does not override it.
 func DialTLS(url string, amqps *tls.Config) (*Connection, error) {
 	return DialConfig(url, Config{
 		TLSClientConfig: amqps,
@@ -234,6 +237,9 @@ func DialTLS(url string, amqps *tls.Config) (*Connection, error) {
 //
 // DialTLS_ExternalAuth uses the provided tls.Config when encountering an
 // amqps:// scheme.
+// Note: If you provide a custom tls.Config, you should explicitly set a secure
+// MinVersion (such as tls.VersionTLS12 or tls.VersionTLS13) as the library
+// does not override it.
 func DialTLS_ExternalAuth(url string, amqps *tls.Config) (*Connection, error) {
 	return DialConfig(url, Config{
 		TLSClientConfig: amqps,
@@ -1323,6 +1329,7 @@ func tlsConfigFromURI(uri URI) (*tls.Config, error) {
 		return &tls.Config{
 			RootCAs:    certPool,
 			ServerName: uri.ServerName,
+			MinVersion: tls.VersionTLS12,
 		}, nil
 	}
 
@@ -1335,6 +1342,7 @@ func tlsConfigFromURI(uri URI) (*tls.Config, error) {
 		Certificates: []tls.Certificate{certificate},
 		RootCAs:      certPool,
 		ServerName:   uri.ServerName,
+		MinVersion:   tls.VersionTLS12,
 	}, nil
 }
 

--- a/connection_unit_test.go
+++ b/connection_unit_test.go
@@ -5,8 +5,11 @@
 package amqp091
 
 import (
+	"crypto/tls"
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -201,5 +204,75 @@ func TestNegotiationEnforcesFrameMinSize(t *testing.T) {
 				t.Errorf("negotiateFrameSize(%d, %d) = %d; want %d", tc.clientFrameSize, tc.serverFrameMax, got, tc.expectedFrameMin)
 			}
 		})
+	}
+}
+
+func TestTLSConfigFromURIEnforcesMinVersion(t *testing.T) {
+	cfg, err := tlsConfigFromURI(URI{
+		ServerName: "localhost",
+	})
+	if err != nil {
+		t.Fatalf("failed to create TLS config from URI: %v", err)
+	}
+
+	if cfg == nil {
+		t.Fatal("expected tls.Config, got nil")
+	}
+
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS 1.2 (%d), got %d", tls.VersionTLS12, cfg.MinVersion)
+	}
+}
+
+func TestTLSConfigFromURIWithCACertAndClientCerts(t *testing.T) {
+	tempDir := t.TempDir()
+
+	caPath := filepath.Join(tempDir, "ca.pem")
+	certPath := filepath.Join(tempDir, "client.pem")
+	keyPath := filepath.Join(tempDir, "client-key.pem")
+
+	if err := os.WriteFile(caPath, []byte(caCert), 0600); err != nil {
+		t.Fatalf("failed to write CA cert: %v", err)
+	}
+	defer func() { _ = os.Remove(caPath) }()
+
+	if err := os.WriteFile(certPath, []byte(clientCert), 0600); err != nil {
+		t.Fatalf("failed to write client cert: %v", err)
+	}
+	defer func() { _ = os.Remove(certPath) }()
+
+	if err := os.WriteFile(keyPath, []byte(clientKey), 0600); err != nil {
+		t.Fatalf("failed to write client key: %v", err)
+	}
+	defer func() { _ = os.Remove(keyPath) }()
+
+	cfg, err := tlsConfigFromURI(URI{
+		CACertFile: caPath,
+		CertFile:   certPath,
+		KeyFile:    keyPath,
+		ServerName: "localhost",
+	})
+	if err != nil {
+		t.Fatalf("failed to create TLS config from URI with CA and client certs: %v", err)
+	}
+
+	if cfg == nil {
+		t.Fatal("expected tls.Config, got nil")
+	}
+
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected MinVersion TLS 1.2 (%d), got %d", tls.VersionTLS12, cfg.MinVersion)
+	}
+
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("expected 1 certificate, got %d", len(cfg.Certificates))
+	}
+
+	if cfg.RootCAs == nil {
+		t.Fatal("expected RootCAs to be set, got nil")
+	}
+
+	if cfg.ServerName != "localhost" {
+		t.Fatalf("expected ServerName localhost, got %q", cfg.ServerName)
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Enforces a minimum TLS version of TLS 1.2 within tlsConfigFromURI to prevent negotiation of insecure TLS 1.0/1.1 protocols when compiled with older Go compiler versions (pre-1.18).

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
