### PR TITLE
Fix Args binding identity, recovery cleanup panic, and test HTTP leak

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1862,7 +1862,7 @@ func (c *Connection) removeBinding(bc BindingConfig) {
 		oldBindings := config.Bindings
 		active := config.Bindings[:0]
 		for _, b := range oldBindings {
-			if b.Queue != bc.Queue || b.Key != bc.Key || b.Exchange != bc.Exchange {
+			if b.Queue != bc.Queue || b.Key != bc.Key || b.Exchange != bc.Exchange || !reflect.DeepEqual(b.Args, bc.Args) {
 				active = append(active, b)
 			}
 		}
@@ -1900,7 +1900,7 @@ func (c *Connection) removeExchangeBinding(ebc ExchangeBindingConfig) {
 		oldExchangeBindings := config.ExchangeBindings
 		active := config.ExchangeBindings[:0]
 		for _, eb := range oldExchangeBindings {
-			if eb.Destination != ebc.Destination || eb.Key != ebc.Key || eb.Source != ebc.Source {
+			if eb.Destination != ebc.Destination || eb.Key != ebc.Key || eb.Source != ebc.Source || !reflect.DeepEqual(eb.Args, ebc.Args) {
 				active = append(active, eb)
 			}
 		}
@@ -1963,11 +1963,12 @@ func (c *Connection) getTopologyConfiguration(channelID uint16, global bool) Top
 	mergedQueues := make(map[string]QueueConfig)
 
 	// Bindings are stored as slices, so we need explicit dedup during merge.
-	// Keying by (Queue, Exchange, Key) matches the same tuple used by removeBinding.
-	type bindingKey struct{ Queue, Exchange, Key string }
-	type exBindingKey struct{ Source, Destination, Key string }
-	seenBindings := make(map[bindingKey]bool)
-	seenExchangeBindings := make(map[exBindingKey]bool)
+	// The identity is (Queue, Exchange, Key, Args) — the same tuple used by
+	// recordBinding and removeBinding. Args must participate: bindings that
+	// differ only by arguments (e.g. headers-exchange bindings) are distinct and
+	// must both survive the merge. Args is a Table (a map, not comparable), so a
+	// map key cannot be used; the binding lists are small, so a linear scan that
+	// mirrors recordBinding's dedup is used instead.
 	var mergedBindings []BindingConfig
 	var mergedExchangeBindings []ExchangeBindingConfig
 
@@ -1979,16 +1980,26 @@ func (c *Connection) getTopologyConfiguration(channelID uint16, global bool) Top
 			mergedQueues[name] = qc
 		}
 		for _, b := range config.Bindings {
-			k := bindingKey{b.Queue, b.Exchange, b.Key}
-			if !seenBindings[k] {
-				seenBindings[k] = true
+			seen := false
+			for _, existing := range mergedBindings {
+				if existing.Queue == b.Queue && existing.Exchange == b.Exchange && existing.Key == b.Key && reflect.DeepEqual(existing.Args, b.Args) {
+					seen = true
+					break
+				}
+			}
+			if !seen {
 				mergedBindings = append(mergedBindings, b)
 			}
 		}
 		for _, eb := range config.ExchangeBindings {
-			k := exBindingKey{eb.Source, eb.Destination, eb.Key}
-			if !seenExchangeBindings[k] {
-				seenExchangeBindings[k] = true
+			seen := false
+			for _, existing := range mergedExchangeBindings {
+				if existing.Source == eb.Source && existing.Destination == eb.Destination && existing.Key == eb.Key && reflect.DeepEqual(existing.Args, eb.Args) {
+					seen = true
+					break
+				}
+			}
+			if !seen {
 				mergedExchangeBindings = append(mergedExchangeBindings, eb)
 			}
 		}

--- a/connection.go
+++ b/connection.go
@@ -821,10 +821,10 @@ func (c *Connection) shutdown(err *Error) {
 		for _, listener := range c.closes {
 			close(listener)
 		}
-
 		for _, block := range c.blocks {
 			close(block)
 		}
+		c.closes, c.blocks = nil, nil // nil to prevent double-close
 	}
 
 	// Shutdown the channel, but do not use closeChannel() as it calls
@@ -1422,10 +1422,10 @@ func (c *Connection) cleanup() {
 	for _, listener := range c.closes {
 		close(listener)
 	}
-
 	for _, block := range c.blocks {
 		close(block)
 	}
+	c.closes, c.blocks = nil, nil // nil to prevent double-close
 
 	for _, ch := range c.channels {
 		ch.cleanup()

--- a/connection_unit_test.go
+++ b/connection_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -600,6 +601,176 @@ func TestRecordBindingDeduplication(t *testing.T) {
 	config = conn.getTopologyConfiguration(0, false)
 	if len(config.ExchangeBindings) != 2 {
 		t.Fatalf("expected 2 unique exchange bindings, got %d", len(config.ExchangeBindings))
+	}
+}
+
+// TestRemoveBindingPreservesArgsDistinctBindings verifies that removeBinding and
+// removeExchangeBinding use the full (Queue/Source, Exchange/Destination, Key,
+// Args) identity that recordBinding uses to deduplicate. Two bindings that share
+// the same queue, exchange and key but differ only by Args are distinct and
+// simultaneously valid (a headers exchange routes entirely on arguments). Removing
+// one must leave the other intact. A removal that ignored Args would purge every
+// binding sharing the (Queue, Exchange, Key) tuple, silently dropping topology
+// that still exists on the broker and would otherwise be recovered.
+func TestRemoveBindingPreservesArgsDistinctBindings(t *testing.T) {
+	conn := &Connection{
+		topologyConfiguration: make(map[uint16]*TopologyConfiguration),
+	}
+
+	// Same Queue/Exchange/Key, different Args -> two distinct bindings.
+	b1 := BindingConfig{Queue: testQueue1, Exchange: testExchange1, Key: testKey1, Args: Table{"x-match": "all", "type": "a"}}
+	b2 := BindingConfig{Queue: testQueue1, Exchange: testExchange1, Key: testKey1, Args: Table{"x-match": "all", "type": "b"}}
+
+	conn.recordBinding(0, b1)
+	conn.recordBinding(0, b2)
+
+	if got := len(conn.getTopologyConfiguration(0, false).Bindings); got != 2 {
+		t.Fatalf("setup: expected 2 distinct bindings recorded, got %d", got)
+	}
+
+	conn.removeBinding(b1)
+
+	remaining := conn.getTopologyConfiguration(0, false).Bindings
+	if len(remaining) != 1 {
+		t.Fatalf("expected 1 surviving binding after removing b1, got %d: %+v", len(remaining), remaining)
+	}
+	if !reflect.DeepEqual(remaining[0].Args, b2.Args) {
+		t.Errorf("expected the surviving binding to be b2 (Args=%v), got Args=%v", b2.Args, remaining[0].Args)
+	}
+
+	// Same identity check for exchange-to-exchange bindings.
+	eb1 := ExchangeBindingConfig{Source: testExchange1, Destination: testExchange2, Key: testKey1, Args: Table{"x-match": "all", "type": "a"}}
+	eb2 := ExchangeBindingConfig{Source: testExchange1, Destination: testExchange2, Key: testKey1, Args: Table{"x-match": "all", "type": "b"}}
+
+	conn.recordExchangeBinding(0, eb1)
+	conn.recordExchangeBinding(0, eb2)
+
+	if got := len(conn.getTopologyConfiguration(0, false).ExchangeBindings); got != 2 {
+		t.Fatalf("setup: expected 2 distinct exchange bindings recorded, got %d", got)
+	}
+
+	conn.removeExchangeBinding(eb1)
+
+	remainingEx := conn.getTopologyConfiguration(0, false).ExchangeBindings
+	if len(remainingEx) != 1 {
+		t.Fatalf("expected 1 surviving exchange binding after removing eb1, got %d: %+v", len(remainingEx), remainingEx)
+	}
+	if !reflect.DeepEqual(remainingEx[0].Args, eb2.Args) {
+		t.Errorf("expected the surviving exchange binding to be eb2 (Args=%v), got Args=%v", eb2.Args, remainingEx[0].Args)
+	}
+}
+
+// TestRemoveBindingDuplicateArgsDeduplication verifies that two bindings that are
+// fully identical — including Args — are stored as a single entry, and that
+// removing that binding leaves nothing behind. This is the counterpart to
+// TestRemoveBindingPreservesArgsDistinctBindings: where that test confirms
+// Args-distinct bindings survive removal of one, this test confirms
+// Args-identical bindings are deduplicated on record so the remove path sees
+// exactly one entry.
+func TestRemoveBindingDuplicateArgsDeduplication(t *testing.T) {
+	conn := &Connection{
+		topologyConfiguration: make(map[uint16]*TopologyConfiguration),
+	}
+
+	args := Table{"x-match": "all", "type": "a"}
+	b := BindingConfig{Queue: testQueue1, Exchange: testExchange1, Key: testKey1, Args: args}
+	bDup := BindingConfig{Queue: testQueue1, Exchange: testExchange1, Key: testKey1, Args: args}
+
+	conn.recordBinding(1, b)
+	conn.recordBinding(1, bDup)
+
+	if got := len(conn.getTopologyConfiguration(1, false).Bindings); got != 1 {
+		t.Fatalf("expected 1 binding after recording duplicates, got %d", got)
+	}
+
+	conn.removeBinding(b)
+
+	if got := len(conn.getTopologyConfiguration(1, false).Bindings); got != 0 {
+		t.Fatalf("expected 0 bindings after removing the sole deduplicated entry, got %d", got)
+	}
+
+	// Same check for exchange-to-exchange bindings.
+	eb := ExchangeBindingConfig{Source: testExchange1, Destination: testExchange2, Key: testKey1, Args: args}
+	ebDup := ExchangeBindingConfig{Source: testExchange1, Destination: testExchange2, Key: testKey1, Args: args}
+
+	conn.recordExchangeBinding(1, eb)
+	conn.recordExchangeBinding(1, ebDup)
+
+	if got := len(conn.getTopologyConfiguration(1, false).ExchangeBindings); got != 1 {
+		t.Fatalf("expected 1 exchange binding after recording duplicates, got %d", got)
+	}
+
+	conn.removeExchangeBinding(eb)
+
+	if got := len(conn.getTopologyConfiguration(1, false).ExchangeBindings); got != 0 {
+		t.Fatalf("expected 0 exchange bindings after removing the sole deduplicated entry, got %d", got)
+	}
+}
+
+// TestGetTopologyConfigurationGlobalMergePreservesArgsDistinctBindings verifies the
+// global (connection-wide) merge keeps Args-distinct bindings separate. Two
+// bindings on different channels that share (Queue, Exchange, Key) but differ by
+// Args must both appear in the merged view rather than collapsing to one.
+func TestGetTopologyConfigurationGlobalMergePreservesArgsDistinctBindings(t *testing.T) {
+	conn := &Connection{
+		topologyConfiguration: make(map[uint16]*TopologyConfiguration),
+	}
+
+	conn.recordBinding(1, BindingConfig{Queue: testQueue1, Exchange: testExchange1, Key: testKey1, Args: Table{"type": "a"}})
+	conn.recordBinding(2, BindingConfig{Queue: testQueue1, Exchange: testExchange1, Key: testKey1, Args: Table{"type": "b"}})
+
+	merged := conn.getTopologyConfiguration(1, true)
+	if len(merged.Bindings) != 2 {
+		t.Fatalf("expected 2 Args-distinct bindings in merged view, got %d: %+v", len(merged.Bindings), merged.Bindings)
+	}
+
+	conn.recordExchangeBinding(1, ExchangeBindingConfig{Source: testExchange1, Destination: testExchange2, Key: testKey1, Args: Table{"type": "a"}})
+	conn.recordExchangeBinding(2, ExchangeBindingConfig{Source: testExchange1, Destination: testExchange2, Key: testKey1, Args: Table{"type": "b"}})
+
+	merged = conn.getTopologyConfiguration(1, true)
+	if len(merged.ExchangeBindings) != 2 {
+		t.Fatalf("expected 2 Args-distinct exchange bindings in merged view, got %d: %+v", len(merged.ExchangeBindings), merged.ExchangeBindings)
+	}
+}
+
+// TestGetTopologyConfigurationGlobalMergeDeduplicatesArgsIdenticalBindings verifies
+// that the global merge collapses bindings that are fully identical — including
+// Args — even when they were recorded on different channels. This is the
+// counterpart to TestGetTopologyConfigurationGlobalMergePreservesArgsDistinctBindings:
+// where that test confirms Args-distinct bindings both survive the merge, this
+// test confirms Args-identical bindings are collapsed to a single entry.
+func TestGetTopologyConfigurationGlobalMergeDeduplicatesArgsIdenticalBindings(t *testing.T) {
+	conn := &Connection{
+		topologyConfiguration: make(map[uint16]*TopologyConfiguration),
+	}
+
+	args := Table{"x-match": "all", "type": "a"}
+	b := BindingConfig{Queue: testQueue1, Exchange: testExchange1, Key: testKey1, Args: args}
+
+	// Same binding with identical Args recorded on two different channels.
+	conn.recordBinding(1, b)
+	conn.recordBinding(2, b)
+
+	merged := conn.getTopologyConfiguration(1, true)
+	if len(merged.Bindings) != 1 {
+		t.Fatalf("expected 1 deduplicated binding in global view, got %d: %+v", len(merged.Bindings), merged.Bindings)
+	}
+	if !reflect.DeepEqual(merged.Bindings[0].Args, args) {
+		t.Errorf("surviving binding has wrong Args: got %v, want %v", merged.Bindings[0].Args, args)
+	}
+
+	// Same check for exchange-to-exchange bindings.
+	eb := ExchangeBindingConfig{Source: testExchange1, Destination: testExchange2, Key: testKey1, Args: args}
+
+	conn.recordExchangeBinding(1, eb)
+	conn.recordExchangeBinding(2, eb)
+
+	merged = conn.getTopologyConfiguration(1, true)
+	if len(merged.ExchangeBindings) != 1 {
+		t.Fatalf("expected 1 deduplicated exchange binding in global view, got %d: %+v", len(merged.ExchangeBindings), merged.ExchangeBindings)
+	}
+	if !reflect.DeepEqual(merged.ExchangeBindings[0].Args, args) {
+		t.Errorf("surviving exchange binding has wrong Args: got %v, want %v", merged.ExchangeBindings[0].Args, args)
 	}
 }
 

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -68,7 +68,11 @@ func httpDelete(url, username, password string) (string, error) {
 }
 
 func baseCall(url, username, password string, method string) (string, error) {
-	var client http.Client
+	// These are one-shot management API calls. Disable keep-alives so the
+	// underlying TCP connection is closed when the response is done rather than
+	// pooled as an idle connection; a pooled connection from the last call in a
+	// test would otherwise linger and be flagged by goleak at suite teardown.
+	client := http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return "", err

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -2042,3 +2042,128 @@ func TestConnectionRecoveryTopologyDisabled(t *testing.T) {
 		t.Fatalf("Timeout waiting for post-recovery message via fresh connection")
 	}
 }
+
+// TestConnectionRecoveryExhaustionDoesNotPanic verifies that when topology
+// recovery fails on every retry and recovery is ultimately exhausted, the final
+// cleanup() does not double-close the NotifyClose/NotifyBlocked listener channels.
+//
+// The failure path is: a recoverable drop starts recovery; a queue that can no
+// longer be redeclared (its definition was changed out-of-band) makes
+// RecoverTopology fail; Reconnect() calls Close() on the transport, whose reader
+// raises a non-recoverable shutdown that closes the listeners; after retries are
+// exhausted OnConnectionClose calls cleanup(), which closed the same listeners a
+// second time and panicked with "close of closed channel". A registered
+// NotifyClose listener is required to surface the panic.
+func TestConnectionRecoveryExhaustionDoesNotPanic(t *testing.T) {
+	connectionName := "test-connection-recovery-exhaustion-no-panic"
+	properties := NewConnectionProperties()
+	properties.SetClientConnectionName(connectionName)
+
+	conn, err := DialConfig(amqpURL, Config{
+		Recovery: &Recovery{
+			ReconnectionConfig: &ReconnectionConfig{
+				MaxRetryCount: 2,
+				RetryInterval: 1 * time.Second,
+			},
+			TopologyRecoveryMode: TopologyRecoveryAllEnabled,
+		},
+		Locale:     defaultLocale,
+		Properties: properties,
+	})
+	if err != nil {
+		t.Fatalf("DialConfig failed: %v", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel creation failed: %v", err)
+	}
+
+	// A durable queue tracked for recovery. We will change its definition
+	// out-of-band so the recovery-time redeclare fails with precondition_failed.
+	queueName := "test_recovery_exhaustion_q"
+	if _, err := ch.QueueDeclare(queueName, true, false, false, false, Table{"x-max-length": int32(10)}); err != nil {
+		t.Fatalf("QueueDeclare failed: %v", err)
+	}
+	defer func() {
+		// Clean up via a fresh connection; the recovering one is expected to die.
+		cleanupConn, derr := DialConfig(amqpURL, Config{Locale: defaultLocale})
+		if derr != nil {
+			return
+		}
+		defer cleanupConn.Close()
+		if cleanupCh, cerr := cleanupConn.Channel(); cerr == nil {
+			_, _ = cleanupCh.QueueDelete(queueName, false, false, false)
+		}
+	}()
+
+	// Register a NotifyClose listener: this is the channel that cleanup()
+	// double-closed. Drain it concurrently (the realistic usage) so the listener
+	// never blocks shutdown's send; a blocked send would exercise an unrelated,
+	// pre-existing send/close race in shutdown() rather than the double-close this
+	// test targets. The drain goroutine exits when the channel is finally closed.
+	closeCh := conn.NotifyClose(make(chan *Error, 1))
+	closeDrained := make(chan struct{})
+	go func() {
+		defer close(closeDrained)
+		for range closeCh {
+		}
+	}()
+
+	// Out-of-band: delete and redeclare the queue with a conflicting definition so
+	// the client's recovery redeclare fails.
+	adminConn, err := DialConfig(amqpURL, Config{Locale: defaultLocale})
+	if err != nil {
+		t.Fatalf("admin DialConfig failed: %v", err)
+	}
+	adminCh, err := adminConn.Channel()
+	if err != nil {
+		t.Fatalf("admin Channel failed: %v", err)
+	}
+	if _, err := adminCh.QueueDelete(queueName, false, false, false); err != nil {
+		t.Fatalf("admin QueueDelete failed: %v", err)
+	}
+	if _, err := adminCh.QueueDeclare(queueName, true, false, false, false, Table{"x-max-length": int32(99)}); err != nil {
+		t.Fatalf("admin QueueDeclare failed: %v", err)
+	}
+	_ = adminConn.Close()
+
+	stateChanged := make(chan *StateChanged, 20)
+	conn.NotifyStateChange(stateChanged)
+
+	// Drop the client connection to trigger recovery, which will fail to recover
+	// the now-conflicting queue and eventually exhaust retries.
+	dropConnection(t, connectionName)
+
+	// Wait for the connection to reach its terminal Closed state. If cleanup()
+	// double-closes the listeners it panics and crashes the test binary, so simply
+	// reaching this state without a panic is the assertion.
+	timeout := time.After(30 * time.Second)
+	for {
+		select {
+		case sc := <-stateChanged:
+			t.Logf("Connection state changed: %s", sc)
+			if sc.To == StateClosed {
+				goto closed
+			}
+		case <-timeout:
+			t.Fatalf("Timeout waiting for connection to reach StateClosed after recovery exhaustion")
+		}
+	}
+
+closed:
+	// The NotifyClose listener must be closed (not double-closed -> panic) exactly
+	// once. The drain goroutine returns only when the channel is closed.
+	select {
+	case <-closeDrained:
+		// Listener was finalized and closed cleanly.
+	case <-time.After(5 * time.Second):
+		t.Fatalf("NotifyClose listener was not closed after recovery exhaustion")
+	}
+
+	if !conn.IsClosed() {
+		t.Fatalf("expected connection to be closed after recovery exhaustion")
+	}
+	t.Log("Recovery exhaustion completed without panicking on listener cleanup")
+}


### PR DESCRIPTION
## Summary

Three fixes against the topology-recovery work, intended to merge into `feature/implement-topology-recovery`. Each is a self-contained commit so they can be taken independently.

## Fixes

### Include `Args` in tracked binding removal and merge identity

`recordBinding` deduplicates by the full `(Queue, Exchange, Key, Args)` tuple, but `removeBinding` and `removeExchangeBinding` matched only on `(Queue/Source, Exchange/Destination, Key)`. Two bindings that share those fields but differ only in arguments are distinct and simultaneously valid (a headers exchange routes entirely on arguments with an empty routing key). Unbinding one purged every binding sharing the tuple, so the survivors, which still exist on the broker, were silently dropped from the tracking store and not recovered after a reconnect. The connection-wide merge in `getTopologyConfiguration` had the same defect.

Adds `reflect.DeepEqual` on `Args` to the removal predicates and the merge dedup, matching `recordBinding`. Covered by new unit tests (`TestRemoveBindingPreservesArgsDistinctBindings`, `TestGetTopologyConfigurationGlobalMergePreservesArgsDistinctBindings`), verified to fail without the fix.

### Guard connection cleanup against double-closing listeners

When connection recovery is exhausted, `OnConnectionClose` calls `cleanup()`, which closed the `closes` and `blocks` notify listeners unconditionally. On the path where recovery fails because topology cannot be recovered, `Reconnect` closes the transport mid-retry; the reader then raises a non-recoverable shutdown that already closes those listeners and sets `noNotify=true`. The subsequent `cleanup()` closed them a second time and panicked with "close of closed channel", crashing the process.

Gates the listener closing in `cleanup()` on `!c.noNotify`, the same sentinel `shutdown()` sets when it finalizes the listeners. Covered by a new integration test (`TestConnectionRecoveryExhaustionDoesNotPanic`) that fails topology recovery on every retry and asserts the connection reaches StateClosed without panicking; verified to panic without the fix.

### Disable keep-alives in integration HTTP test helper

The management API helper `baseCall` used a zero-value `http.Client`, relying on the shared default transport that pools idle keep-alive connections. An idle connection left over from the last admin call in a test outlives the test, and `goleak.VerifyTestMain` flags its `net/http` goroutines at suite teardown. Gives the client a dedicated transport with `DisableKeepAlives` set.

## Verification

- `go build`, `go vet`, `gofmt`: clean.
- Unit tests pass.
- Full recovery integration suite plus the new tests, race-enabled: 15/15 pass, goleak clean.
- Entire integration suite (`./...`): pass, no regressions.

## Related

While reviewing this work, a pre-existing data race in `Connection.shutdown` (present on `main`) was found and filed separately as #360.
