### PR TITLE
Make TopologyRecoveryAllEnabled the default topology recovery mode

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -91,10 +91,10 @@ type Config struct {
 	// If Recovery.TopologyRecovery is nil, a default topology recovery implementation (DefaultTopologyRecovery) is used.
 	//
 	// Topology recovery scope is controlled by Recovery.TopologyRecoveryMode:
-	//   - TopologyRecoveryOnlyTransient (default): recovers only transient entities
-	//     (exclusive/auto-delete queues, auto-delete exchanges, and bindings to them).
-	//   - TopologyRecoveryAllEnabled: recovers all tracked topology (exchanges, queues,
+	//   - TopologyRecoveryAllEnabled (default): recovers all tracked topology (exchanges, queues,
 	//     bindings, exchange-to-exchange bindings, and consumers).
+	//   - TopologyRecoveryOnlyTransient: recovers only transient entities
+	//     (exclusive/auto-delete queues, auto-delete exchanges, and bindings to them).
 	//   - TopologyRecoveryDisabled: skips topology and consumer recovery entirely.
 	//
 	// During the recovery process, applications can monitor state changes (such as reconnecting
@@ -1652,10 +1652,10 @@ func (c *Connection) IsTopologyRecoveryEnabled() bool {
 }
 
 // topologyRecoveryMode returns the configured topology recovery mode, defaulting
-// to TopologyRecoveryOnlyTransient when recovery is not configured.
+// to TopologyRecoveryAllEnabled when recovery is not configured.
 func (c *Connection) topologyRecoveryMode() TopologyRecoveryMode {
 	if c == nil || c.Config.Recovery == nil {
-		return TopologyRecoveryOnlyTransient
+		return TopologyRecoveryAllEnabled
 	}
 	return c.Config.Recovery.TopologyRecoveryMode
 }

--- a/recovery.go
+++ b/recovery.go
@@ -91,6 +91,12 @@ type TopologyRecovery interface {
 type TopologyRecoveryMode byte
 
 const (
+	// TopologyRecoveryAllEnabled recovers all tracked topology: exchanges, queues,
+	// bindings, exchange-to-exchange bindings, and active consumers.
+	//
+	// This is the default (the zero value of TopologyRecoveryMode).
+	TopologyRecoveryAllEnabled TopologyRecoveryMode = iota
+
 	// TopologyRecoveryOnlyTransient recovers only connection-scoped (transient)
 	// entities: queues declared as exclusive and/or auto-delete (which includes
 	// server-named queues), auto-delete exchanges, and any bindings that reference
@@ -102,14 +108,7 @@ const (
 	// skipped because the broker retains them across a network interruption. Use
 	// this mode when durable topology is managed declaratively or out-of-band and
 	// only the connection-scoped entities need to be restored by the client.
-	//
-	// This is the default (the zero value of TopologyRecoveryMode), preserving the
-	// behavior of recovering only transient topology when the field is left unset.
-	TopologyRecoveryOnlyTransient TopologyRecoveryMode = iota
-
-	// TopologyRecoveryAllEnabled recovers all tracked topology: exchanges, queues,
-	// bindings, exchange-to-exchange bindings, and active consumers.
-	TopologyRecoveryAllEnabled
+	TopologyRecoveryOnlyTransient
 
 	// TopologyRecoveryDisabled disables topology recovery completely. Neither
 	// entities nor consumers are recovered. Connection and channel recovery still
@@ -124,7 +123,7 @@ type Recovery struct {
 	TopologyRecovery   TopologyRecovery    // The implementation of the topology recovery.
 
 	// TopologyRecoveryMode controls which topology entities are recovered. The zero
-	// value (TopologyRecoveryOnlyTransient) recovers only transient tracked topology.
+	// value (TopologyRecoveryAllEnabled) recovers all tracked topology.
 	// Setting it to TopologyRecoveryDisabled disables topology and consumer recovery entirely.
 	TopologyRecoveryMode TopologyRecoveryMode
 }


### PR DESCRIPTION
## Proposed Changes

Previously, TopologyRecoveryOnlyTransient was the zero value of TopologyRecoveryMode, so callers that left the field unset would only recover transient (exclusive/auto-delete) topology on reconnection.

This commit reorders the iota so that TopologyRecoveryAllEnabled is the zero value, making full topology recovery—exchanges, queues, bindings, exchange-to-exchange bindings, and active consumers—the default behavior when Recovery is configured but TopologyRecoveryMode is not explicitly set.

## Types of Changes

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [x] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further Comments

This is a follow-up PR of https://github.com/rabbitmq/amqp091-go/pull/357
