### PR TITLE
feat: skip-and-continue topology recovery with per-entity error surfacing

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -253,6 +253,8 @@ func (ch *Channel) shutdown(e *Error) {
 	ch.notifyM.Lock()
 	defer ch.notifyM.Unlock()
 
+	isRecoveryInProgress := ch.connection.inTopologyRecovery.Load()
+	Logger.Printf("Channel isRecoveryInProgress: %v", isRecoveryInProgress)
 	// Broadcast abnormal shutdown
 	if e != nil {
 		for _, c := range ch.closes {
@@ -281,7 +283,8 @@ func (ch *Channel) shutdown(e *Error) {
 		}
 	}
 
-	if e == nil || !ch.connection.IsRecoveryEnabled() || !ch.connection.isRecoverable(e) {
+	if e == nil || !ch.connection.IsRecoveryEnabled() || (!ch.connection.isRecoverable(e) && !isRecoveryInProgress) {
+		Logger.Printf("Channel: Removing consumers")
 		ch.consumers.close()
 
 		for _, c := range ch.closes {
@@ -2203,6 +2206,8 @@ func (ch *Channel) cleanup() {
 	ch.notifyM.Lock()
 	defer ch.notifyM.Unlock()
 
+	Logger.Printf("Cleanup channel")
+
 	ch.consumers.close()
 
 	for _, c := range ch.closes {
@@ -2276,6 +2281,31 @@ func (ch *Channel) Reconnect() error {
 	return nil
 }
 
+// openChannelSession resets client-side state, opens a fresh broker channel,
+// and restores QoS/Confirm configuration. It is the shared single-attempt core
+// used by both reconnectChannel (retry loop) and reopenChannelIfClosed (topology
+// recovery). The caller must hold ch.reconnecting and manage lifecycle transitions.
+//
+// openSucceeded is true when ch.open() completed — the caller needs this to decide
+// whether to send a channel.close courtesy frame to the broker before the next
+// retry (meaningful only when open succeeded but setup then failed).
+func (ch *Channel) openChannelSession() (openSucceeded bool, err error) {
+	// 1. Reset client-side state
+	ch.destructorM.Lock()
+	ch.m.Lock()
+	ch.resetState()
+	ch.m.Unlock()
+	ch.destructorM.Unlock()
+
+	// 2. Open a fresh channel on the broker
+	if err = ch.open(); err != nil {
+		return false, err
+	}
+
+	// 3. Perform QoS and Confirms setup.
+	return true, ch.setupChannelBasic()
+}
+
 // reconnectChannel opens a fresh channel on the broker and performs basic setup (QoS, Confirms).
 // It does NOT recover the channel's topology.
 func (ch *Channel) reconnectChannel() error {
@@ -2294,7 +2324,10 @@ func (ch *Channel) reconnectChannel() error {
 
 	cancelCh := ch.NotifyRecoveryCancel(make(chan struct{}))
 
-	var err error
+	var (
+		err    error
+		opened bool
+	)
 	for i := 0; i < ch.connection.MaxRetryCount(); i++ {
 		// Exit early if Close() was already called
 		select {
@@ -2317,24 +2350,16 @@ func (ch *Channel) reconnectChannel() error {
 			}
 		}
 
-		// 1. Reset client-side state
-		ch.destructorM.Lock()
-		ch.m.Lock()
-		ch.resetState()
-		ch.m.Unlock()
-		ch.destructorM.Unlock()
-
-		// 2. Open a fresh channel on the broker
-		if err = ch.open(); err != nil {
-			Logger.Printf("Channel %d recovery open error: %v", ch.id, err)
-			continue
-		}
-
-		// 3. Perform QoS and Confirms setup.
-		if err = ch.setupChannelBasic(); err != nil {
-			Logger.Printf("Channel %d setup failed: %v, closing and retrying...", ch.id, err)
-			ch.setClosed()
-			_ = ch.call(&channelClose{ReplyCode: replySuccess, ReplyText: "Recovery retry"}, &channelCloseOk{})
+		opened, err = ch.openChannelSession()
+		if err != nil {
+			Logger.Printf("Channel %d recovery attempt %d failed: %v", ch.id, i+1, err)
+			if opened {
+				// open() succeeded but setupChannelBasic() failed:
+				// gracefully close the broker-side session before the next attempt.
+				// channelClose must be sent before setClosed()
+				_ = ch.call(&channelClose{ReplyCode: replySuccess, ReplyText: "Recovery retry"}, &channelCloseOk{})
+				ch.setClosed()
+			}
 			continue
 		}
 

--- a/channel.go
+++ b/channel.go
@@ -114,6 +114,14 @@ type Channel struct {
 	reconnecting sync.Mutex // Mutex for reconnecting channel.
 	lifeCycle    *lifeCycle // The current state of the channel.
 
+	// recoveringTopology is true while a recoverConnectionTopology pass owns
+	// this channel's reopen/redeclare sequence. watchChannel's NotifyClose
+	// listener checks this to avoid starting a redundant, competing
+	// Reconnect+RecoverTopology pass when a broker soft error (e.g. a
+	// PRECONDITION_FAILED from an entity the in-flight pass is already
+	// handling) closes the channel out from under it.
+	recoveringTopology atomic.Bool
+
 	recoveryCancels []chan struct{} // listeners for channel recovery cancellation
 }
 
@@ -254,25 +262,38 @@ func (ch *Channel) shutdown(e *Error) {
 	ch.notifyM.Lock()
 	defer ch.notifyM.Unlock()
 
-	// Broadcast abnormal shutdown
+	// Broadcast abnormal shutdown.
 	if e != nil {
-		for _, c := range ch.closes {
-			select {
-			case c <- e:
-			default:
-				// Channel is full; deliver in a background goroutine so we never deadlock
-				// the shutdown sequence. The goroutine holds notifyM.RLock() for the
-				// duration of the send, which is mutually exclusive with cleanup()'s
-				// notifyM.Lock(), preventing a concurrent send+close data race.
-				go func(c chan *Error, e *Error) {
-					defer func() { _ = recover() }()
-					ch.notifyM.RLock()
-					defer ch.notifyM.RUnlock()
-					select {
-					case c <- e:
-					case <-time.After(5 * time.Second):
-					}
-				}(c, e)
+		// While an in-flight topology-recovery pass owns this channel
+		// (ch.recoveringTopology), skip notifying external NotifyClose
+		// listeners (including watchChannel's): reopenChannelIfClosed is
+		// already reopening the channel in-band for this exact soft error,
+		// so a listener would otherwise start a redundant, competing
+		// recovery pass. This must happen here rather than only in the
+		// listener, because a full listener channel defers delivery up to
+		// notifyTimeout in the background goroutine below, by which time
+		// recoveringTopology may have already cleared — suppressing at the
+		// source avoids that race. ch.errors is unaffected: ch.call() (used
+		// by the in-band redeclare itself) depends on it to return promptly.
+		if !ch.recoveringTopology.Load() {
+			for _, c := range ch.closes {
+				select {
+				case c <- e:
+				default:
+					// Channel is full; deliver in a background goroutine so we never deadlock
+					// the shutdown sequence. The goroutine holds notifyM.RLock() for the
+					// duration of the send, which is mutually exclusive with cleanup()'s
+					// notifyM.Lock(), preventing a concurrent send+close data race.
+					go func(c chan *Error, e *Error) {
+						defer func() { _ = recover() }()
+						ch.notifyM.RLock()
+						defer ch.notifyM.RUnlock()
+						select {
+						case c <- e:
+						case <-time.After(5 * time.Second):
+						}
+					}(c, e)
+				}
 			}
 		}
 		// Notify RPC if we're selecting

--- a/channel.go
+++ b/channel.go
@@ -266,7 +266,7 @@ func (ch *Channel) shutdown(e *Error) {
 	if e != nil {
 		// While an in-flight topology-recovery pass owns this channel
 		// (ch.recoveringTopology), skip notifying external NotifyClose
-		// listeners (including watchChannel's): reopenChannelIfClosed is
+		// listeners (including watchChannel's): Channel.reopenIfClosed is
 		// already reopening the channel in-band for this exact soft error,
 		// so a listener would otherwise start a redundant, competing
 		// recovery pass. This must happen here rather than only in the
@@ -344,7 +344,7 @@ func (ch *Channel) shutdown(e *Error) {
 
 		var err error
 		if e != nil {
-			err = fmt.Errorf("%w", e) // preserve the original error type for assertions
+			err = fmt.Errorf("channel shutdown error: %w", e) // errors.As(err, &target) still unwraps to *Error
 		}
 		ch.lifeCycle.SetState(StateClosed, err)
 	} else {
@@ -2218,7 +2218,7 @@ func (ch *Channel) GetNextPublishSeqNo() uint64 {
 }
 
 // cleanup closes all the channels and the confirms.
-func (ch *Channel) cleanup(e *Error) {
+func (ch *Channel) cleanup(e error) {
 	ch.setClosed() // Ensure ch.IsClosed() returns true globally
 
 	// If it returns false, it means cleanedUp was already true (cleanup already ran).
@@ -2272,7 +2272,7 @@ func (ch *Channel) cleanup(e *Error) {
 
 	var err error
 	if e != nil {
-		err = fmt.Errorf("%w", e)
+		err = fmt.Errorf("channel cleanup error: %w", e)
 	}
 
 	ch.lifeCycle.SetState(StateClosed, err)
@@ -2318,7 +2318,7 @@ func (ch *Channel) Reconnect() error {
 
 // openChannelSession resets client-side state, opens a fresh broker channel,
 // and restores QoS/Confirm configuration. It is the shared single-attempt core
-// used by both reconnectChannel (retry loop) and reopenChannelIfClosed (topology
+// used by both reconnectChannel (retry loop) and reopenIfClosed (topology
 // recovery). The caller must hold ch.reconnecting and manage lifecycle transitions.
 //
 // openSucceeded is true when ch.open() completed — the caller needs this to decide
@@ -2339,6 +2339,44 @@ func (ch *Channel) openChannelSession() (openSucceeded bool, err error) {
 
 	// 3. Perform QoS and Confirms setup.
 	return true, ch.setupChannelBasic()
+}
+
+// reopenIfClosed reopens a channel that was closed as a side-effect of a
+// broker soft error (e.g. PRECONDITION_FAILED / 406) during topology recovery.
+func (ch *Channel) reopenIfClosed() {
+	// Fast path: skip the mutex entirely for the common case where the channel
+	// is already open. Avoids blocking on ch.reconnecting for every entity in
+	// a healthy recovery where no reopen is needed.
+	if !ch.IsClosed() {
+		return
+	}
+
+	ch.reconnecting.Lock()
+	defer ch.reconnecting.Unlock()
+
+	// Re-check under lock: a concurrent watchChannel goroutine may have already
+	// reopened the channel via reconnectChannel between the fast-path check above
+	// and acquiring the lock.
+	if !ch.IsClosed() {
+		return
+	}
+
+	Logger.Printf("topology recovery: channel %d closed by broker soft error; reopening for remaining entities", ch.id)
+	ch.lifeCycle.SetState(StateReconnecting, nil)
+
+	// Make sure the channel id is registered before sending channel.open.
+	ch.connection.reregisterChannel(ch)
+
+	if opened, err := ch.openChannelSession(); err != nil {
+		Logger.Printf("topology recovery: failed to reopen channel %d: %v", ch.id, err)
+		if opened {
+			_ = ch.call(&channelClose{ReplyCode: replySuccess, ReplyText: "Topology recovery"}, &channelCloseOk{})
+		}
+		ch.setClosed()
+		return
+	}
+
+	ch.lifeCycle.SetState(StateOpen, nil)
 }
 
 // reconnectChannel opens a fresh channel on the broker and performs basic setup (QoS, Confirms).

--- a/channel.go
+++ b/channel.go
@@ -2263,9 +2263,13 @@ func (ch *Channel) Reconnect() error {
 
 	// Recover topology for this channel
 	if ch.connection.IsTopologyRecoveryEnabled() {
-		if err := ch.connection.Config.Recovery.TopologyRecovery.RecoverTopology(ch.connection, []*Channel{ch}); err != nil {
+		skippedTopologyEntities, err := ch.connection.Config.Recovery.TopologyRecovery.RecoverTopology(ch.connection, []*Channel{ch})
+		if err != nil {
 			Logger.Printf("Channel %d recovery topology error: %v", ch.id, err)
 			return err
+		}
+		for _, e := range skippedTopologyEntities {
+			Logger.Printf("Channel %d topology recovery skipped entity: %v", ch.id, e)
 		}
 	}
 

--- a/channel.go
+++ b/channel.go
@@ -63,6 +63,7 @@ should be discarded and a new channel established.
 type Channel struct {
 	destructorM sync.Mutex   // Mutex for destroying the channel.
 	destructed  bool         // Will be true if the channel has been destroyed, false otherwise.
+	cleanedUp   atomic.Bool  // Thread-safe atomic boolean to track final cleanup status
 	m           sync.Mutex   // Mutex for the channel.
 	notifyM     sync.RWMutex // Mutex for the notify state.
 
@@ -253,8 +254,6 @@ func (ch *Channel) shutdown(e *Error) {
 	ch.notifyM.Lock()
 	defer ch.notifyM.Unlock()
 
-	isRecoveryInProgress := ch.connection.inTopologyRecovery.Load()
-	Logger.Printf("Channel isRecoveryInProgress: %v", isRecoveryInProgress)
 	// Broadcast abnormal shutdown
 	if e != nil {
 		for _, c := range ch.closes {
@@ -283,8 +282,7 @@ func (ch *Channel) shutdown(e *Error) {
 		}
 	}
 
-	if e == nil || !ch.connection.IsRecoveryEnabled() || (!ch.connection.isRecoverable(e) && !isRecoveryInProgress) {
-		Logger.Printf("Channel: Removing consumers")
+	if e == nil || !ch.connection.IsRecoveryEnabled() {
 		ch.consumers.close()
 
 		for _, c := range ch.closes {
@@ -2199,14 +2197,23 @@ func (ch *Channel) GetNextPublishSeqNo() uint64 {
 }
 
 // cleanup closes all the channels and the confirms.
-func (ch *Channel) cleanup() {
+func (ch *Channel) cleanup(e *Error) {
+	ch.setClosed() // Ensure ch.IsClosed() returns true globally
+
+	// If it returns false, it means cleanedUp was already true (cleanup already ran).
+	if !ch.cleanedUp.CompareAndSwap(false, true) {
+		return
+	}
+
+	ch.destructorM.Lock()
+	ch.destructed = true // Lock out any future transport shutdowns as well
+	ch.destructorM.Unlock()
+
 	ch.m.Lock()
 	defer ch.m.Unlock()
 
 	ch.notifyM.Lock()
 	defer ch.notifyM.Unlock()
-
-	Logger.Printf("Cleanup channel")
 
 	ch.consumers.close()
 
@@ -2241,6 +2248,13 @@ func (ch *Channel) cleanup() {
 	}
 
 	ch.noNotify = true
+
+	var err error
+	if e != nil {
+		err = fmt.Errorf("%w", e)
+	}
+
+	ch.lifeCycle.SetState(StateClosed, err)
 }
 
 // watchChannel watches the channel for close events and triggers recovery if needed.
@@ -2370,7 +2384,6 @@ func (ch *Channel) reconnectChannel() error {
 
 	Logger.Printf("Channel %d recovery exhausted all %d retries", ch.id, ch.connection.MaxRetryCount())
 	ch.setClosed()
-	ch.lifeCycle.SetState(StateClosed, err)
 	return err
 }
 

--- a/connection.go
+++ b/connection.go
@@ -855,7 +855,7 @@ func (c *Connection) shutdown(err *Error) {
 
 		var e error
 		if err != nil {
-			e = fmt.Errorf("%w", err) // preserve the original error type for assertions
+			e = fmt.Errorf("connection shutdown error: %w", err) // errors.As(e, &target) still unwraps to *Error
 		}
 		c.lifeCycle.SetState(StateClosed, e)
 	}
@@ -1095,6 +1095,19 @@ func (c *Connection) releaseChannel(ch *Channel) {
 	}
 }
 
+// reregisterChannel re-adds a channel to the registry if it is missing, without
+// allocating a new id. Used by Channel.reopenIfClosed to restore a channel that
+// topology recovery kept around (see closeChannel) after a broker soft error.
+func (c *Connection) reregisterChannel(ch *Channel) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if _, present := c.channels[ch.id]; !present && c.allocator != nil {
+		c.channels[ch.id] = ch
+		c.allocator.reserve(int(ch.id))
+	}
+}
+
 // openChannel allocates and opens a channel, must be paired with closeChannel
 func (c *Connection) openChannel() (*Channel, error) {
 	ch, err := c.allocateChannel()
@@ -1122,7 +1135,7 @@ func (c *Connection) openChannel() (*Channel, error) {
 func (c *Connection) closeChannel(ch *Channel, e *Error) {
 	// If we are actively recovering topology, do NOT purge the channel from memory yet.
 	// We keep it in c.channels so that:
-	//   1. reopenChannelIfClosed can find and reuse it if we skip-and-continue.
+	//   1. Channel.reopenIfClosed can find and reuse it if we skip-and-continue.
 	//   2. connection.cleanup can access it to force a full shutdown if recovery fails completely.
 	if e == nil || !c.IsRecoveryEnabled() {
 		c.releaseChannel(ch)
@@ -1445,7 +1458,7 @@ func negotiateFrameSize(client, server int) int {
 }
 
 // cleanup releases registered resources and performs final teardown of the connection.
-func (c *Connection) cleanup(err *Error) {
+func (c *Connection) cleanup(err error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
@@ -1479,7 +1492,7 @@ func (c *Connection) cleanup(err *Error) {
 
 	var e error
 	if err != nil {
-		e = fmt.Errorf("%w", err)
+		e = fmt.Errorf("connection cleanup error: %w", err)
 	}
 
 	c.lifeCycle.SetState(StateClosed, e)
@@ -2201,23 +2214,17 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 	c.topologyM.Unlock()
 
 	// Build a channel-ID → Channel map for O(1) lookup during the recovery loops.
+	// Mark each channel as owned by this pass so watchChannel's
+	// NotifyClose listener (registered once, for the channel's lifetime) won't
+	// start a redundant, competing Reconnect+RecoverTopology pass if a broker
+	// soft error closes the channel while this pass is already
+	// reopening/redeclaring it below.
 	channelMap := make(map[uint16]*Channel, len(channels))
 	for _, ch := range channels {
 		channelMap[ch.id] = ch
-	}
-
-	// Mark every channel this pass owns so watchChannel's NotifyClose listener
-	// (registered once, for the channel's lifetime) won't start a redundant,
-	// competing Reconnect+RecoverTopology pass if a broker soft error closes
-	// the channel while this pass is already reopening/redeclaring it below.
-	for _, ch := range channels {
 		ch.recoveringTopology.Store(true)
+		defer ch.recoveringTopology.Store(false)
 	}
-	defer func() {
-		for _, ch := range channels {
-			ch.recoveringTopology.Store(false)
-		}
-	}()
 
 	// When only transient topology should be recovered, filter the snapshot down
 	// to auto-delete exchanges and exclusive/auto-delete queues (and their
@@ -2261,50 +2268,6 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 		return false, fmt.Errorf("%w", e)
 	}
 
-	// reopenChannelIfClosed reopens a channel that was closed as a side-effect of a
-	// broker soft error (e.g. PRECONDITION_FAILED / 406) during topology recovery.
-	reopenChannelIfClosed := func(ch *Channel) {
-		// Fast path: skip the mutex entirely for the common case where the channel
-		// is already open. Avoids blocking on ch.reconnecting for every entity in
-		// a healthy recovery where no reopen is needed.
-		if !ch.IsClosed() {
-			return
-		}
-
-		ch.reconnecting.Lock()
-		defer ch.reconnecting.Unlock()
-
-		// Re-check under lock: a concurrent watchChannel goroutine may have already
-		// reopened the channel via reconnectChannel between the fast-path check above
-		// and acquiring the lock.
-		if !ch.IsClosed() {
-			return
-		}
-
-		Logger.Printf("topology recovery: channel %d closed by broker soft error; reopening for remaining entities", ch.id)
-		ch.lifeCycle.SetState(StateReconnecting, nil)
-
-		// Make sure the channel id is registered in c.channels.
-		// Re-register the channel in c.channels before sending channel.open.
-		c.m.Lock()
-		if _, present := c.channels[ch.id]; !present && c.allocator != nil {
-			c.channels[ch.id] = ch
-			c.allocator.reserve(int(ch.id))
-		}
-		c.m.Unlock()
-
-		if opened, err := ch.openChannelSession(); err != nil {
-			Logger.Printf("topology recovery: failed to reopen channel %d: %v", ch.id, err)
-			if opened {
-				_ = ch.call(&channelClose{ReplyCode: replySuccess, ReplyText: "Topology recovery"}, &channelCloseOk{})
-			}
-			ch.setClosed()
-			return
-		}
-
-		ch.lifeCycle.SetState(StateOpen, nil)
-	}
-
 	// 1. Recover exchanges across all channels.
 	for chID, config := range topologyMap {
 		ch, ok := channelMap[chID]
@@ -2318,7 +2281,7 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 				if cont, fatal := skipOrAbort(e); !cont {
 					return skipped, fatal
 				}
-				reopenChannelIfClosed(ch)
+				ch.reopenIfClosed()
 			}
 		}
 	}
@@ -2356,7 +2319,7 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 				if cont, fatal := skipOrAbort(e); !cont {
 					return skipped, fatal
 				}
-				reopenChannelIfClosed(ch)
+				ch.reopenIfClosed()
 				continue
 			}
 
@@ -2432,7 +2395,7 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 				if cont, fatal := skipOrAbort(e); !cont {
 					return skipped, fatal
 				}
-				reopenChannelIfClosed(ch)
+				ch.reopenIfClosed()
 			}
 		}
 	}
@@ -2450,7 +2413,7 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 				if cont, fatal := skipOrAbort(e); !cont {
 					return skipped, fatal
 				}
-				reopenChannelIfClosed(ch)
+				ch.reopenIfClosed()
 			}
 		}
 	}
@@ -2488,7 +2451,7 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 				if cont, fatal := skipOrAbort(e); !cont {
 					return skipped, fatal
 				}
-				reopenChannelIfClosed(ch)
+				ch.reopenIfClosed()
 			}
 		}
 	}

--- a/connection.go
+++ b/connection.go
@@ -2206,6 +2206,19 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 		channelMap[ch.id] = ch
 	}
 
+	// Mark every channel this pass owns so watchChannel's NotifyClose listener
+	// (registered once, for the channel's lifetime) won't start a redundant,
+	// competing Reconnect+RecoverTopology pass if a broker soft error closes
+	// the channel while this pass is already reopening/redeclaring it below.
+	for _, ch := range channels {
+		ch.recoveringTopology.Store(true)
+	}
+	defer func() {
+		for _, ch := range channels {
+			ch.recoveringTopology.Store(false)
+		}
+	}()
+
 	// When only transient topology should be recovered, filter the snapshot down
 	// to auto-delete exchanges and exclusive/auto-delete queues (and their
 	// bindings). The global transient sets are built by scanning every channel

--- a/connection.go
+++ b/connection.go
@@ -1606,9 +1606,11 @@ func (c *Connection) Reconnect() error {
 			}
 		}
 
+		var skippedTopologyEntities []TopologyRecoveryEntity
 		if err == nil && c.IsTopologyRecoveryEnabled() {
 			// Phase 2: Recover topology across all channels via the configured implementation
-			if err = c.Config.Recovery.TopologyRecovery.RecoverTopology(c, channels); err != nil {
+			skippedTopologyEntities, err = c.Config.Recovery.TopologyRecovery.RecoverTopology(c, channels)
+			if err != nil {
 				Logger.Printf("Connection recovery failed to recover topology: %v", err)
 				conn.Close()
 			}
@@ -1619,8 +1621,12 @@ func (c *Connection) Reconnect() error {
 			continue
 		}
 
-		Logger.Printf("Connection recovery successful")
-		c.lifeCycle.SetState(StateOpen, nil)
+		if len(skippedTopologyEntities) > 0 {
+			Logger.Printf("Connection recovery succeeded with %d skipped topology entities", len(skippedTopologyEntities))
+		} else {
+			Logger.Printf("Connection recovery successful")
+		}
+		c.lifeCycle.setStateOpen(skippedTopologyEntities)
 		return nil
 	}
 
@@ -2230,9 +2236,9 @@ func filterTransientTopology(
 // pipeline (buffer goroutine + outer chan Delivery) that was wired up before the
 // connection dropped. This means the application's delivery channel remains valid
 // across reconnects without any intervention from the caller.
-func (c *Connection) recoverConnectionTopology(channels []*Channel) error {
+func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyRecoveryEntity, error) {
 	if !c.IsTopologyRecoveryEnabled() {
-		return nil
+		return nil, nil
 	}
 
 	// Clone the topology snapshot under lock so network I/O below does not
@@ -2277,6 +2283,21 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) error {
 		}
 	}
 
+	var skipped []TopologyRecoveryEntity
+	cb := c.Config.Recovery.OnTopologyEntityError
+
+	// skipOrAbort calls cb with the connection and entity error. If cb returns true
+	// (or is nil, matching DefaultOnTopologyEntityError behaviour) the entity is
+	// appended to skipped and the caller continues the loop. If cb returns false
+	// the entity error is returned as a fatal error, aborting topology recovery.
+	skipOrAbort := func(e TopologyRecoveryEntity) (skip bool, fatal error) {
+		if cb == nil || cb(c, e) {
+			skipped = append(skipped, e)
+			return true, nil
+		}
+		return false, fmt.Errorf("%w", e)
+	}
+
 	// 1. Recover exchanges across all channels.
 	for chID, config := range topologyMap {
 		ch, ok := channelMap[chID]
@@ -2284,9 +2305,12 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) error {
 			continue
 		}
 		for _, ec := range config.Exchanges {
-			err := ch.ExchangeDeclare(ec.Name, ec.Kind, ec.Durable, ec.AutoDelete, ec.Internal, ec.NoWait, ec.Args)
-			if err != nil {
-				return fmt.Errorf("failed to recover exchange %s on channel %d: %w", ec.Name, chID, err)
+			if err := ch.ExchangeDeclare(ec.Name, ec.Kind, ec.Durable, ec.AutoDelete, ec.Internal, ec.NoWait, ec.Args); err != nil {
+				Logger.Printf("failed to recover exchange %s on channel %d: %v", ec.Name, chID, err)
+				e := TopologyRecoveryEntity{TopologyEntityExchange, ec.Name, chID, err}
+				if cont, fatal := skipOrAbort(e); !cont {
+					return skipped, fatal
+				}
 			}
 		}
 	}
@@ -2319,7 +2343,12 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) error {
 
 			q, err := ch.QueueDeclare(qc.DeclaredName, qc.Durable, qc.AutoDelete, qc.Exclusive, qc.NoWait, qc.Args)
 			if err != nil {
-				return fmt.Errorf("failed to recover queue %s on channel %d: %w", qc.ActualName, chID, err)
+				Logger.Printf("failed to recover queue %s on channel %d: %v", qc.ActualName, chID, err)
+				e := TopologyRecoveryEntity{TopologyEntityQueue, qc.ActualName, chID, err}
+				if cont, fatal := skipOrAbort(e); !cont {
+					return skipped, fatal
+				}
+				continue
 			}
 
 			// Server-generated queues (DeclaredName == "") receive a fresh broker-assigned
@@ -2388,9 +2417,12 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) error {
 			continue
 		}
 		for _, b := range config.Bindings {
-			err := ch.QueueBind(b.Queue, b.Key, b.Exchange, b.NoWait, b.Args)
-			if err != nil {
-				return fmt.Errorf("failed to recover binding of queue %s to exchange %s on channel %d: %w", b.Queue, b.Exchange, chID, err)
+			if err := ch.QueueBind(b.Queue, b.Key, b.Exchange, b.NoWait, b.Args); err != nil {
+				Logger.Printf("failed to recover binding of queue %s to exchange %s on channel %d: %v", b.Queue, b.Exchange, chID, err)
+				e := TopologyRecoveryEntity{TopologyEntityQueueBinding, b.Queue, chID, err}
+				if cont, fatal := skipOrAbort(e); !cont {
+					return skipped, fatal
+				}
 			}
 		}
 	}
@@ -2402,9 +2434,12 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) error {
 			continue
 		}
 		for _, eb := range config.ExchangeBindings {
-			err := ch.ExchangeBind(eb.Destination, eb.Key, eb.Source, eb.NoWait, eb.Args)
-			if err != nil {
-				return fmt.Errorf("failed to recover exchange binding from %s to %s on channel %d: %w", eb.Source, eb.Destination, chID, err)
+			if err := ch.ExchangeBind(eb.Destination, eb.Key, eb.Source, eb.NoWait, eb.Args); err != nil {
+				Logger.Printf("failed to recover exchange binding from %s to %s on channel %d: %v", eb.Source, eb.Destination, chID, err)
+				e := TopologyRecoveryEntity{TopologyEntityExchangeBinding, eb.Source, chID, err}
+				if cont, fatal := skipOrAbort(e); !cont {
+					return skipped, fatal
+				}
 			}
 		}
 	}
@@ -2437,10 +2472,14 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) error {
 			}
 			res := &basicConsumeOk{}
 			if err := ch.call(req, res); err != nil {
-				return fmt.Errorf("failed to recover consumer for tag %s on queue %s on channel %d: %w", tag, config.Queue, ch.id, err)
+				Logger.Printf("failed to recover consumer for tag %s on queue %s on channel %d: %v", tag, config.Queue, ch.id, err)
+				e := TopologyRecoveryEntity{TopologyEntityConsumer, tag, ch.id, err}
+				if cont, fatal := skipOrAbort(e); !cont {
+					return skipped, fatal
+				}
 			}
 		}
 	}
 
-	return nil
+	return skipped, nil
 }

--- a/connection.go
+++ b/connection.go
@@ -143,14 +143,13 @@ func (config *Config) setSASL(uri URI) error {
 // multiplexed on this channel.  There must always be active receivers for
 // every asynchronous message on this connection.
 type Connection struct {
-	destructorM         sync.Mutex   // Mutex for connection teardown: notifying close/block listeners, closing channels, and closing the underlying socket
-	destructed          bool         // true when the connection has been destructed (teardown is initiated or completed)
-	closeM              sync.Mutex   // Mutex for connection close handshake: sending a single connection.close frame to the broker
-	closeInit           bool         // true when a connection close has been initiated (connection.close frame has been or is being sent)
-	sendM               sync.Mutex   // conn writer mutex
-	m                   sync.Mutex   // struct field mutex
-	recoveryErrorCodesM sync.Mutex   // Mutex for protecting RecoverableErrorCodes updates and reads
-	notifyM             sync.RWMutex // Mutex for notifying close/block listeners; mirrors Channel.notifyM
+	destructorM sync.Mutex   // Mutex for connection teardown: notifying close/block listeners, closing channels, and closing the underlying socket
+	destructed  bool         // true when the connection has been destructed (teardown is initiated or completed)
+	closeM      sync.Mutex   // Mutex for connection close handshake: sending a single connection.close frame to the broker
+	closeInit   bool         // true when a connection close has been initiated (connection.close frame has been or is being sent)
+	sendM       sync.Mutex   // conn writer mutex
+	m           sync.Mutex   // struct field mutex
+	notifyM     sync.RWMutex // Mutex for notifying close/block listeners; mirrors Channel.notifyM
 
 	conn io.ReadWriteCloser
 
@@ -182,8 +181,7 @@ type Connection struct {
 	Properties Table    // Server properties
 	Locales    []string // Server locales
 
-	closed             atomic.Bool // Will be true if the connection is closed, false otherwise.
-	inTopologyRecovery atomic.Bool // True while RecoverTopology is running; suppresses full channel teardown on soft broker errors.
+	closed atomic.Bool // Will be true if the connection is closed, false otherwise.
 
 	// maxFrameSize mirrors Config.FrameSize once negotiated via connection.tune,
 	// letting the reader goroutine reject over-sized frames before allocating
@@ -349,8 +347,6 @@ func DialConfig(url string, config Config) (*Connection, error) {
 	if config.Recovery != nil {
 		if config.Recovery.ReconnectionConfig == nil {
 			config.Recovery.ReconnectionConfig = DefaultReconnectionConfig.Clone()
-		} else if config.Recovery.ReconnectionConfig.RecoverableErrorCodes == nil {
-			config.Recovery.ReconnectionConfig.RecoverableErrorCodes = cloneRecoverableErrorCodes(defaultRecoverableErrorCodes)
 		}
 		if config.Recovery.ConnectionRecovery == nil {
 			config.Recovery.ConnectionRecovery = &DefaultConnectionRecovery{}
@@ -799,9 +795,6 @@ func (c *Connection) shutdown(err *Error) {
 	c.notifyM.Lock()
 	defer c.notifyM.Unlock()
 
-	isRecoveryInProgress := c.inTopologyRecovery.Load()
-	Logger.Printf("Connection: isRecoveryInProgress: %v", isRecoveryInProgress)
-
 	if err != nil {
 		for _, listener := range c.closes {
 			select {
@@ -832,8 +825,7 @@ func (c *Connection) shutdown(err *Error) {
 	// Shutdown handler goroutine can still receive the result.
 	close(c.errors)
 
-	if err == nil || !c.IsRecoveryEnabled() || (!c.isRecoverable(err) && !isRecoveryInProgress) {
-		Logger.Printf("Connection: Removing listener, block")
+	if err == nil || !c.IsRecoveryEnabled() {
 		for _, listener := range c.closes {
 			close(listener)
 		}
@@ -856,8 +848,7 @@ func (c *Connection) shutdown(err *Error) {
 	// reader exit
 	close(c.close)
 
-	if err == nil || !c.IsRecoveryEnabled() || (!c.isRecoverable(err) && !isRecoveryInProgress) {
-		Logger.Printf("Connection: Removing channels to nil")
+	if err == nil || !c.IsRecoveryEnabled() {
 		c.channels = nil
 		c.allocator = nil
 		c.noNotify = true
@@ -1097,7 +1088,6 @@ func (c *Connection) releaseChannel(ch *Channel) {
 	if !c.IsClosed() {
 		got, ok := c.channels[ch.id]
 		if ok && got == ch {
-			Logger.Printf("releasing channel %d", ch.id)
 			delete(c.channels, ch.id)
 			c.allocator.release(int(ch.id))
 			c.removeChannelTopology(ch.id)
@@ -1113,7 +1103,6 @@ func (c *Connection) openChannel() (*Channel, error) {
 	}
 
 	if err := ch.open(); err != nil {
-		Logger.Printf("Calling release channel from openChannel")
 		c.releaseChannel(ch)
 		return nil, err
 	}
@@ -1130,49 +1119,15 @@ func (c *Connection) openChannel() (*Channel, error) {
 // closeChannel releases and initiates a shutdown of the channel.  All channel
 // closures should be initiated here for proper channel lifecycle management on
 // this connection.
-//
-// releaseChannel is called first so the channel is removed from c.channels
-// before ch.shutdown sends to ch.errors. This guarantees that when the topology
-// recovery goroutine wakes (via ch.errors) and calls reopenChannelIfClosed, the
-// channel is already absent from c.channels and the re-registration check
-// (!present) correctly fires. Reversing the order creates a TOCTOU window where
-// the recovery goroutine sees the channel as still present, skips re-registration,
-// and then releaseChannel removes it — causing channelOpenOk to go to
-// dispatchClosed and triggering a spurious ErrClosed(504) connection close.
-//
-// Exception: when a non-recoverable soft channel error (e.g. 406 PRECONDITION_FAILED)
-// arrives during topology recovery, releaseChannel is skipped so that ch stays in
-// c.channels. This prevents a goroutine leak: ch.shutdown takes the minimal-cleanup
-// branch (preserving consumers and leaving ch.closes open), so conn.cleanup() must
-// be able to find ch via c.channels to call ch.cleanup() and close ch.closes.
-// The TOCTOU concern above does not apply here because OnChannelClose returns
-// immediately for non-recoverable errors and never calls ch.Reconnect() concurrently.
 func (c *Connection) closeChannel(ch *Channel, e *Error) {
-	// if e == nil || !ch.connection.IsRecoveryEnabled() || !ch.connection.inTopologyRecovery.Load() {
-	// 	c.releaseChannel(ch)
-	// }
-	// Logger.Printf("Skipping release channel from closeChannel, err: %v", e)
-	//c.releaseChannel(ch)
-
 	// If we are actively recovering topology, do NOT purge the channel from memory yet.
 	// We keep it in c.channels so that:
 	//   1. reopenChannelIfClosed can find and reuse it if we skip-and-continue.
 	//   2. connection.cleanup can access it to force a full shutdown if recovery fails completely.
-	if !c.inTopologyRecovery.Load() {
+	if e == nil || !c.IsRecoveryEnabled() {
 		c.releaseChannel(ch)
 	}
 	ch.shutdown(e)
-	// if e != nil && !c.isRecoverable(e) && c.inTopologyRecovery.Load() {
-	// 	c.m.Lock()
-	// 	if c.channels != nil && c.allocator != nil {
-	// 		if _, present := c.channels[ch.id]; !present {
-	// 			Logger.Printf("Adding channel back to connection, %d", ch.id)
-	// 			c.channels[ch.id] = ch
-	// 			c.allocator.reserve(int(ch.id))
-	// 		}
-	// 	}
-	// 	c.m.Unlock()
-	// }
 }
 
 /*
@@ -1490,7 +1445,7 @@ func negotiateFrameSize(client, server int) int {
 }
 
 // cleanup releases registered resources and performs final teardown of the connection.
-func (c *Connection) cleanup() {
+func (c *Connection) cleanup(err *Error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
@@ -1505,10 +1460,8 @@ func (c *Connection) cleanup() {
 	}
 	c.closes, c.blocks = nil, nil // nil to prevent double-close
 
-	Logger.Printf("Total channels: %d", len(c.channels))
 	for _, ch := range c.channels {
-		Logger.Printf("Cleaning up channel %d", ch.id)
-		ch.cleanup()
+		ch.cleanup(err)
 	}
 
 	for _, listener := range c.recoveryCancels {
@@ -1523,6 +1476,13 @@ func (c *Connection) cleanup() {
 	c.topologyM.Lock()
 	c.topologyConfiguration = nil
 	c.topologyM.Unlock()
+
+	var e error
+	if err != nil {
+		e = fmt.Errorf("%w", err)
+	}
+
+	c.lifeCycle.SetState(StateClosed, e)
 }
 
 // watchConnection watches the connection for close events and triggers recovery if needed.
@@ -1569,7 +1529,6 @@ func (c *Connection) Reconnect() error {
 		select {
 		case <-cancelCh:
 			Logger.Printf("Connection recovery aborted: connection closed during backoff.")
-			c.inTopologyRecovery.Store(false)
 			return ErrClosed
 		case <-time.After(c.RetryInterval() + jitter):
 		}
@@ -1686,7 +1645,6 @@ func (c *Connection) Reconnect() error {
 		c.conn.Close()
 	}
 	c.closed.Store(true)
-	c.lifeCycle.SetState(StateClosed, err)
 
 	return err
 }
@@ -1719,8 +1677,7 @@ func (c *Connection) IsRecoveryEnabled() bool {
 	}
 	return c.Config.Recovery != nil &&
 		c.Config.Recovery.ReconnectionConfig != nil &&
-		c.Config.Recovery.ReconnectionConfig.MaxRetryCount > 0 &&
-		len(c.GetRecoverableErrorCodes()) > 0
+		c.Config.Recovery.ReconnectionConfig.MaxRetryCount > 0
 }
 
 // IsTopologyRecoveryEnabled checks if the topology recovery is enabled.
@@ -1755,36 +1712,6 @@ func (c *Connection) IsConnectionRecoveryEnabled() bool {
 	return c.IsRecoveryEnabled() && c.Config.Recovery.ConnectionRecovery != nil
 }
 
-// isRecoverable returns true if the given error is recoverable based on RecoverableErrorCodes.
-func (c *Connection) isRecoverable(err *Error) bool {
-	if !c.IsRecoveryEnabled() {
-		return false
-	}
-	if err == nil {
-		return true
-	}
-	for _, code := range c.GetRecoverableErrorCodes() {
-		if err.Code == code {
-			return true
-		}
-	}
-	return false
-}
-
-// GetRecoverableErrorCodes returns a copy of the recoverable error codes.
-func (c *Connection) GetRecoverableErrorCodes() []int {
-	if c == nil {
-		return nil
-	}
-	c.recoveryErrorCodesM.Lock()
-	defer c.recoveryErrorCodesM.Unlock()
-	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
-		return nil
-	}
-
-	return cloneRecoverableErrorCodes(c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes)
-}
-
 // MaxRetryCount returns the maximum number of retries if recovery is enabled, otherwise returns 0.
 func (c *Connection) MaxRetryCount() int {
 	if c.IsRecoveryEnabled() {
@@ -1799,34 +1726,6 @@ func (c *Connection) RetryInterval() time.Duration {
 		return c.Config.Recovery.ReconnectionConfig.RetryInterval
 	}
 	return 0
-}
-
-// SetRecoverableErrorCodes sets the list of error codes that trigger recovery.
-func (c *Connection) SetRecoverableErrorCodes(codes []int) error {
-	if c == nil {
-		return ErrClosed
-	}
-	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
-		return ErrRecoveryNotEnabled
-	}
-	c.recoveryErrorCodesM.Lock()
-	defer c.recoveryErrorCodesM.Unlock()
-	c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes = codes
-	return nil
-}
-
-// AddRecoverableErrorCodes adds one or more error codes to the list of recoverable error codes.
-func (c *Connection) AddRecoverableErrorCodes(codes ...int) error {
-	if c == nil {
-		return ErrClosed
-	}
-	if c.Config.Recovery == nil || c.Config.Recovery.ReconnectionConfig == nil {
-		return ErrRecoveryNotEnabled
-	}
-	c.recoveryErrorCodesM.Lock()
-	defer c.recoveryErrorCodesM.Unlock()
-	c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes = append(c.Config.Recovery.ReconnectionConfig.RecoverableErrorCodes, codes...)
-	return nil
 }
 
 // channelTopology returns the TopologyConfiguration for the given channel,
@@ -2292,9 +2191,6 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 		return nil, nil
 	}
 
-	c.inTopologyRecovery.Store(true)
-	defer c.inTopologyRecovery.Store(false)
-
 	// Clone the topology snapshot under lock so network I/O below does not
 	// hold topologyM and deadlock with concurrent record* / remove* calls.
 	c.topologyM.Lock()
@@ -2354,9 +2250,6 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 
 	// reopenChannelIfClosed reopens a channel that was closed as a side-effect of a
 	// broker soft error (e.g. PRECONDITION_FAILED / 406) during topology recovery.
-	//
-	// Lifecycle state transitions follow the same pattern as reconnectChannel:
-	// StateClosed → StateReconnecting → StateOpen (success) or StateClosed (failure).
 	reopenChannelIfClosed := func(ch *Channel) {
 		// Fast path: skip the mutex entirely for the common case where the channel
 		// is already open. Avoids blocking on ch.reconnecting for every entity in
@@ -2378,11 +2271,8 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 		Logger.Printf("topology recovery: channel %d closed by broker soft error; reopening for remaining entities", ch.id)
 		ch.lifeCycle.SetState(StateReconnecting, nil)
 
+		// Make sure the channel id is registered in c.channels.
 		// Re-register the channel in c.channels before sending channel.open.
-		// closeChannel→releaseChannel removes the channel from c.channels before
-		// waking this goroutine (via ch.shutdown→ch.errors). Without re-registering,
-		// the reader goroutine cannot route the channelOpenOk frame to ch.rpc, which
-		// permanently stalls call() and leaks the goroutine even after connection shutdown.
 		c.m.Lock()
 		if _, present := c.channels[ch.id]; !present && c.allocator != nil {
 			c.channels[ch.id] = ch
@@ -2396,7 +2286,6 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 				_ = ch.call(&channelClose{ReplyCode: replySuccess, ReplyText: "Topology recovery"}, &channelCloseOk{})
 			}
 			ch.setClosed()
-			ch.lifeCycle.SetState(StateClosed, err)
 			return
 		}
 

--- a/connection.go
+++ b/connection.go
@@ -182,7 +182,8 @@ type Connection struct {
 	Properties Table    // Server properties
 	Locales    []string // Server locales
 
-	closed atomic.Bool // Will be true if the connection is closed, false otherwise.
+	closed             atomic.Bool // Will be true if the connection is closed, false otherwise.
+	inTopologyRecovery atomic.Bool // True while RecoverTopology is running; suppresses full channel teardown on soft broker errors.
 
 	// maxFrameSize mirrors Config.FrameSize once negotiated via connection.tune,
 	// letting the reader goroutine reject over-sized frames before allocating
@@ -798,6 +799,9 @@ func (c *Connection) shutdown(err *Error) {
 	c.notifyM.Lock()
 	defer c.notifyM.Unlock()
 
+	isRecoveryInProgress := c.inTopologyRecovery.Load()
+	Logger.Printf("Connection: isRecoveryInProgress: %v", isRecoveryInProgress)
+
 	if err != nil {
 		for _, listener := range c.closes {
 			select {
@@ -828,7 +832,8 @@ func (c *Connection) shutdown(err *Error) {
 	// Shutdown handler goroutine can still receive the result.
 	close(c.errors)
 
-	if err == nil || !c.IsRecoveryEnabled() || !c.isRecoverable(err) {
+	if err == nil || !c.IsRecoveryEnabled() || (!c.isRecoverable(err) && !isRecoveryInProgress) {
+		Logger.Printf("Connection: Removing listener, block")
 		for _, listener := range c.closes {
 			close(listener)
 		}
@@ -851,7 +856,8 @@ func (c *Connection) shutdown(err *Error) {
 	// reader exit
 	close(c.close)
 
-	if err == nil || !c.IsRecoveryEnabled() || !c.isRecoverable(err) {
+	if err == nil || !c.IsRecoveryEnabled() || (!c.isRecoverable(err) && !isRecoveryInProgress) {
+		Logger.Printf("Connection: Removing channels to nil")
 		c.channels = nil
 		c.allocator = nil
 		c.noNotify = true
@@ -1091,6 +1097,7 @@ func (c *Connection) releaseChannel(ch *Channel) {
 	if !c.IsClosed() {
 		got, ok := c.channels[ch.id]
 		if ok && got == ch {
+			Logger.Printf("releasing channel %d", ch.id)
 			delete(c.channels, ch.id)
 			c.allocator.release(int(ch.id))
 			c.removeChannelTopology(ch.id)
@@ -1106,6 +1113,7 @@ func (c *Connection) openChannel() (*Channel, error) {
 	}
 
 	if err := ch.open(); err != nil {
+		Logger.Printf("Calling release channel from openChannel")
 		c.releaseChannel(ch)
 		return nil, err
 	}
@@ -1122,9 +1130,49 @@ func (c *Connection) openChannel() (*Channel, error) {
 // closeChannel releases and initiates a shutdown of the channel.  All channel
 // closures should be initiated here for proper channel lifecycle management on
 // this connection.
+//
+// releaseChannel is called first so the channel is removed from c.channels
+// before ch.shutdown sends to ch.errors. This guarantees that when the topology
+// recovery goroutine wakes (via ch.errors) and calls reopenChannelIfClosed, the
+// channel is already absent from c.channels and the re-registration check
+// (!present) correctly fires. Reversing the order creates a TOCTOU window where
+// the recovery goroutine sees the channel as still present, skips re-registration,
+// and then releaseChannel removes it — causing channelOpenOk to go to
+// dispatchClosed and triggering a spurious ErrClosed(504) connection close.
+//
+// Exception: when a non-recoverable soft channel error (e.g. 406 PRECONDITION_FAILED)
+// arrives during topology recovery, releaseChannel is skipped so that ch stays in
+// c.channels. This prevents a goroutine leak: ch.shutdown takes the minimal-cleanup
+// branch (preserving consumers and leaving ch.closes open), so conn.cleanup() must
+// be able to find ch via c.channels to call ch.cleanup() and close ch.closes.
+// The TOCTOU concern above does not apply here because OnChannelClose returns
+// immediately for non-recoverable errors and never calls ch.Reconnect() concurrently.
 func (c *Connection) closeChannel(ch *Channel, e *Error) {
+	// if e == nil || !ch.connection.IsRecoveryEnabled() || !ch.connection.inTopologyRecovery.Load() {
+	// 	c.releaseChannel(ch)
+	// }
+	// Logger.Printf("Skipping release channel from closeChannel, err: %v", e)
+	//c.releaseChannel(ch)
+
+	// If we are actively recovering topology, do NOT purge the channel from memory yet.
+	// We keep it in c.channels so that:
+	//   1. reopenChannelIfClosed can find and reuse it if we skip-and-continue.
+	//   2. connection.cleanup can access it to force a full shutdown if recovery fails completely.
+	if !c.inTopologyRecovery.Load() {
+		c.releaseChannel(ch)
+	}
 	ch.shutdown(e)
-	c.releaseChannel(ch)
+	// if e != nil && !c.isRecoverable(e) && c.inTopologyRecovery.Load() {
+	// 	c.m.Lock()
+	// 	if c.channels != nil && c.allocator != nil {
+	// 		if _, present := c.channels[ch.id]; !present {
+	// 			Logger.Printf("Adding channel back to connection, %d", ch.id)
+	// 			c.channels[ch.id] = ch
+	// 			c.allocator.reserve(int(ch.id))
+	// 		}
+	// 	}
+	// 	c.m.Unlock()
+	// }
 }
 
 /*
@@ -1457,7 +1505,9 @@ func (c *Connection) cleanup() {
 	}
 	c.closes, c.blocks = nil, nil // nil to prevent double-close
 
+	Logger.Printf("Total channels: %d", len(c.channels))
 	for _, ch := range c.channels {
+		Logger.Printf("Cleaning up channel %d", ch.id)
 		ch.cleanup()
 	}
 
@@ -1519,6 +1569,7 @@ func (c *Connection) Reconnect() error {
 		select {
 		case <-cancelCh:
 			Logger.Printf("Connection recovery aborted: connection closed during backoff.")
+			c.inTopologyRecovery.Store(false)
 			return ErrClosed
 		case <-time.After(c.RetryInterval() + jitter):
 		}
@@ -2241,6 +2292,9 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 		return nil, nil
 	}
 
+	c.inTopologyRecovery.Store(true)
+	defer c.inTopologyRecovery.Store(false)
+
 	// Clone the topology snapshot under lock so network I/O below does not
 	// hold topologyM and deadlock with concurrent record* / remove* calls.
 	c.topologyM.Lock()
@@ -2298,6 +2352,57 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 		return false, fmt.Errorf("%w", e)
 	}
 
+	// reopenChannelIfClosed reopens a channel that was closed as a side-effect of a
+	// broker soft error (e.g. PRECONDITION_FAILED / 406) during topology recovery.
+	//
+	// Lifecycle state transitions follow the same pattern as reconnectChannel:
+	// StateClosed → StateReconnecting → StateOpen (success) or StateClosed (failure).
+	reopenChannelIfClosed := func(ch *Channel) {
+		// Fast path: skip the mutex entirely for the common case where the channel
+		// is already open. Avoids blocking on ch.reconnecting for every entity in
+		// a healthy recovery where no reopen is needed.
+		if !ch.IsClosed() {
+			return
+		}
+
+		ch.reconnecting.Lock()
+		defer ch.reconnecting.Unlock()
+
+		// Re-check under lock: a concurrent watchChannel goroutine may have already
+		// reopened the channel via reconnectChannel between the fast-path check above
+		// and acquiring the lock.
+		if !ch.IsClosed() {
+			return
+		}
+
+		Logger.Printf("topology recovery: channel %d closed by broker soft error; reopening for remaining entities", ch.id)
+		ch.lifeCycle.SetState(StateReconnecting, nil)
+
+		// Re-register the channel in c.channels before sending channel.open.
+		// closeChannel→releaseChannel removes the channel from c.channels before
+		// waking this goroutine (via ch.shutdown→ch.errors). Without re-registering,
+		// the reader goroutine cannot route the channelOpenOk frame to ch.rpc, which
+		// permanently stalls call() and leaks the goroutine even after connection shutdown.
+		c.m.Lock()
+		if _, present := c.channels[ch.id]; !present && c.allocator != nil {
+			c.channels[ch.id] = ch
+			c.allocator.reserve(int(ch.id))
+		}
+		c.m.Unlock()
+
+		if opened, err := ch.openChannelSession(); err != nil {
+			Logger.Printf("topology recovery: failed to reopen channel %d: %v", ch.id, err)
+			if opened {
+				_ = ch.call(&channelClose{ReplyCode: replySuccess, ReplyText: "Topology recovery"}, &channelCloseOk{})
+			}
+			ch.setClosed()
+			ch.lifeCycle.SetState(StateClosed, err)
+			return
+		}
+
+		ch.lifeCycle.SetState(StateOpen, nil)
+	}
+
 	// 1. Recover exchanges across all channels.
 	for chID, config := range topologyMap {
 		ch, ok := channelMap[chID]
@@ -2307,10 +2412,11 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 		for _, ec := range config.Exchanges {
 			if err := ch.ExchangeDeclare(ec.Name, ec.Kind, ec.Durable, ec.AutoDelete, ec.Internal, ec.NoWait, ec.Args); err != nil {
 				Logger.Printf("failed to recover exchange %s on channel %d: %v", ec.Name, chID, err)
-				e := TopologyRecoveryEntity{TopologyEntityExchange, ec.Name, chID, err}
+				e := TopologyRecoveryEntity{EntityType: TopologyEntityExchange, EntityName: ec.Name, ChannelID: chID, Err: err}
 				if cont, fatal := skipOrAbort(e); !cont {
 					return skipped, fatal
 				}
+				reopenChannelIfClosed(ch)
 			}
 		}
 	}
@@ -2344,10 +2450,11 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 			q, err := ch.QueueDeclare(qc.DeclaredName, qc.Durable, qc.AutoDelete, qc.Exclusive, qc.NoWait, qc.Args)
 			if err != nil {
 				Logger.Printf("failed to recover queue %s on channel %d: %v", qc.ActualName, chID, err)
-				e := TopologyRecoveryEntity{TopologyEntityQueue, qc.ActualName, chID, err}
+				e := TopologyRecoveryEntity{EntityType: TopologyEntityQueue, EntityName: qc.ActualName, ChannelID: chID, Err: err}
 				if cont, fatal := skipOrAbort(e); !cont {
 					return skipped, fatal
 				}
+				reopenChannelIfClosed(ch)
 				continue
 			}
 
@@ -2419,10 +2526,11 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 		for _, b := range config.Bindings {
 			if err := ch.QueueBind(b.Queue, b.Key, b.Exchange, b.NoWait, b.Args); err != nil {
 				Logger.Printf("failed to recover binding of queue %s to exchange %s on channel %d: %v", b.Queue, b.Exchange, chID, err)
-				e := TopologyRecoveryEntity{TopologyEntityQueueBinding, b.Queue, chID, err}
+				e := TopologyRecoveryEntity{EntityType: TopologyEntityQueueBinding, EntityName: b.Queue, SecondaryName: b.Exchange, RoutingKey: b.Key, ChannelID: chID, Err: err}
 				if cont, fatal := skipOrAbort(e); !cont {
 					return skipped, fatal
 				}
+				reopenChannelIfClosed(ch)
 			}
 		}
 	}
@@ -2436,10 +2544,11 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 		for _, eb := range config.ExchangeBindings {
 			if err := ch.ExchangeBind(eb.Destination, eb.Key, eb.Source, eb.NoWait, eb.Args); err != nil {
 				Logger.Printf("failed to recover exchange binding from %s to %s on channel %d: %v", eb.Source, eb.Destination, chID, err)
-				e := TopologyRecoveryEntity{TopologyEntityExchangeBinding, eb.Source, chID, err}
+				e := TopologyRecoveryEntity{EntityType: TopologyEntityExchangeBinding, EntityName: eb.Source, SecondaryName: eb.Destination, RoutingKey: eb.Key, ChannelID: chID, Err: err}
 				if cont, fatal := skipOrAbort(e); !cont {
 					return skipped, fatal
 				}
+				reopenChannelIfClosed(ch)
 			}
 		}
 	}
@@ -2473,10 +2582,11 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 			res := &basicConsumeOk{}
 			if err := ch.call(req, res); err != nil {
 				Logger.Printf("failed to recover consumer for tag %s on queue %s on channel %d: %v", tag, config.Queue, ch.id, err)
-				e := TopologyRecoveryEntity{TopologyEntityConsumer, tag, ch.id, err}
+				e := TopologyRecoveryEntity{EntityType: TopologyEntityConsumer, EntityName: tag, ChannelID: ch.id, Err: err}
 				if cont, fatal := skipOrAbort(e); !cont {
 					return skipped, fatal
 				}
+				reopenChannelIfClosed(ch)
 			}
 		}
 	}

--- a/connection_unit_test.go
+++ b/connection_unit_test.go
@@ -124,9 +124,8 @@ func TestReconnectRestoresSASLCredentials(t *testing.T) {
 			SASL: []Authentication{pa},
 			Recovery: &Recovery{
 				ReconnectionConfig: &ReconnectionConfig{
-					MaxRetryCount:         1,
-					RetryInterval:         1 * time.Millisecond,
-					RecoverableErrorCodes: []int{320}, // some recoverable code
+					MaxRetryCount: 1,
+					RetryInterval: 1 * time.Millisecond,
 				},
 			},
 			Dial: func(network, addr string) (net.Conn, error) {

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -38,7 +38,15 @@ func (s LifeCycleState) String() string {
 type StateChanged struct {
 	From LifeCycleState
 	To   LifeCycleState
-	Err  error // Stores the error when transitioning to StateClosed
+
+	// Err is set only on the →StateClosed transition and carries the fatal error
+	// that ended recovery (exhausted retries, non-recoverable error, etc.).
+	Err error
+
+	// SkippedTopologyEntities is set only on the StateReconnecting→StateOpen transition when
+	// one or more topology entities were skipped via Recovery.OnTopologyEntityError.
+	// Nil on all other transitions and when all entities recovered successfully.
+	SkippedTopologyEntities []TopologyRecoveryEntity
 }
 
 func (s StateChanged) String() string {
@@ -113,6 +121,32 @@ func (l *lifeCycle) SetState(value LifeCycleState, err error) {
 		Err:  err,
 	}
 
+	for _, listener := range l.listeners {
+		listener.enqueue(sc)
+		if !listener.sending {
+			listener.sending = true
+			go l.deliverToListener(listener)
+		}
+	}
+}
+
+// setStateOpen transitions to StateOpen and attaches any topology entities that
+// were skipped during recovery. Called only from Connection.Reconnect.
+func (l *lifeCycle) setStateOpen(skippedTopologyEntities []TopologyRecoveryEntity) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if l.state == StateOpen {
+		return
+	}
+	oldState := l.state
+	l.state = StateOpen
+	sc := &StateChanged{
+		From: oldState,
+		To:   StateOpen,
+	}
+	if len(skippedTopologyEntities) != 0 {
+		sc.SkippedTopologyEntities = skippedTopologyEntities
+	}
 	for _, listener := range l.listeners {
 		listener.enqueue(sc)
 		if !listener.sending {

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -102,6 +103,9 @@ func ExampleConnection_reconnect() {
 				go conn.Close()
 			}
 		}
+		// Give the final connection's background goroutines a moment to
+		// finish winding down asynchronously before the test exits.
+		time.Sleep(100 * time.Millisecond)
 	} else {
 		// pass with expected output when not running in an integration
 		// environment.

--- a/recovery.go
+++ b/recovery.go
@@ -4,9 +4,55 @@
 package amqp091
 
 import (
+	"fmt"
 	"net/url"
 	"time"
 )
+
+// TopologyRecoveryEntityType identifies the topology recovery entity kind.
+type TopologyRecoveryEntityType byte
+
+const (
+	TopologyEntityExchange TopologyRecoveryEntityType = iota
+	TopologyEntityQueue
+	TopologyEntityQueueBinding
+	TopologyEntityExchangeBinding
+	TopologyEntityConsumer
+)
+
+func (t TopologyRecoveryEntityType) String() string {
+	switch t {
+	case TopologyEntityExchange:
+		return "exchange"
+	case TopologyEntityQueue:
+		return "queue"
+	case TopologyEntityQueueBinding:
+		return "queue-binding"
+	case TopologyEntityExchangeBinding:
+		return "exchange-binding"
+	case TopologyEntityConsumer:
+		return "consumer"
+	default:
+		return "unknown"
+	}
+}
+
+// TopologyRecoveryEntity describes a single topology entity during the recovery.
+type TopologyRecoveryEntity struct {
+	EntityType TopologyRecoveryEntityType
+	EntityName string // exchange/queue name, consumer tag, etc.
+	ChannelID  uint16
+	Err        error // the underlying broker or network error during the recovery.
+}
+
+func (e TopologyRecoveryEntity) Error() string {
+	return fmt.Sprintf("topology recovery: %s %q on channel %d: %v",
+		e.EntityType, e.EntityName, e.ChannelID, e.Err)
+}
+
+// Unwrap allows errors.As and errors.Is to inspect the underlying broker error,
+// enabling callers to match on *amqp091.Error reply codes inside OnTopologyEntityError.
+func (e TopologyRecoveryEntity) Unwrap() error { return e.Err }
 
 const (
 	// DefaultMaxRetryCount is the default maximum number of retries for recovery.
@@ -82,8 +128,12 @@ type ConnectionRecovery interface {
 //   - Load and declare topology dynamically from an external config or registry.
 //   - Rate-limit or stagger declarations to avoid overloading the broker after a reconnect.
 //   - Perform pre-recovery checks or customized failover/fallback routines.
+//
+// RecoverTopology returns any entity-level errors that were skipped (via the
+// Recovery.OnTopologyEntityError callback) as the first return value. A non-nil
+// second return value means recovery failed fatally and the retry cycle continues.
 type TopologyRecovery interface {
-	RecoverTopology(conn *Connection, channels []*Channel) error
+	RecoverTopology(conn *Connection, channels []*Channel) ([]TopologyRecoveryEntity, error)
 }
 
 // TopologyRecoveryMode controls which topology entities are recovered after a
@@ -126,6 +176,44 @@ type Recovery struct {
 	// value (TopologyRecoveryAllEnabled) recovers all tracked topology.
 	// Setting it to TopologyRecoveryDisabled disables topology and consumer recovery entirely.
 	TopologyRecoveryMode TopologyRecoveryMode
+
+	// OnTopologyEntityError is called each time a single topology entity fails to
+	// recover. Return true to skip the entity and continue recovering the remaining
+	// entities. Return false to abort topology recovery and trigger the normal retry
+	// cycle.
+	//
+	// The conn parameter is the connection on which recovery is running. Use it to
+	// inspect the full topology of the channel that owns the failed entity:
+	//
+	//	cfg := conn.Channel(e.ChannelID).TopologyConfiguration(true)
+	//
+	// The global flag merges topology from all channels into one connection-scoped
+	// view — appropriate because AMQP exchanges, queues, and bindings are scoped to
+	// the TCP connection, not individual channels. Pass false to limit the view to
+	// entities declared on that channel only.
+	//
+	// From cfg you can retrieve the full declaration arguments of the failed entity:
+	//
+	//	switch e.EntityType {
+	//	case amqp091.TopologyEntityQueue:
+	//	    qc, ok := cfg.Queues[e.EntityName]  // QueueConfig with Durable, AutoDelete, Args, etc.
+	//	case amqp091.TopologyEntityExchange:
+	//	    ec, ok := cfg.Exchanges[e.EntityName] // ExchangeConfig with Kind, Durable, Args, etc.
+	//	case amqp091.TopologyEntityQueueBinding:
+	//	    // cfg.Bindings is a slice; find the entry whose Queue matches e.EntityName
+	//	case amqp091.TopologyEntityExchangeBinding:
+	//	    // cfg.ExchangeBindings is a slice; find the entry whose Source matches e.EntityName
+	//	case amqp091.TopologyEntityConsumer:
+	//	    // Consumer internals are not exposed via TopologyConfiguration.
+	//	    // The consumer tag is available in e.EntityName.
+	//	}
+	//
+	// Skipped-entity errors are collected and delivered to NotifyStateChange listeners
+	// in the SkippedTopologyEntities field of the StateReconnecting→StateOpen transition, so the
+	// application can observe what was not restored even on an otherwise successful reconnect.
+	//
+	// Default: nil — entity is skipped on failure and recovery continues (same as returning true).
+	OnTopologyEntityError func(conn *Connection, e TopologyRecoveryEntity) bool
 }
 
 // DefaultConnectionRecovery is the default implementation of the connection recovery.
@@ -195,6 +283,6 @@ func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
 // DefaultTopologyRecovery is the default implementation of the topology recovery.
 type DefaultTopologyRecovery struct{}
 
-func (d *DefaultTopologyRecovery) RecoverTopology(conn *Connection, channels []*Channel) error {
+func (d *DefaultTopologyRecovery) RecoverTopology(conn *Connection, channels []*Channel) ([]TopologyRecoveryEntity, error) {
 	return conn.recoverConnectionTopology(channels)
 }

--- a/recovery.go
+++ b/recovery.go
@@ -4,7 +4,6 @@
 package amqp091
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -265,9 +264,7 @@ func (d *DefaultConnectionRecovery) OnConnectionClose(conn *Connection, err *Err
 	// Reconnect connection
 	if err := conn.Reconnect(); err != nil {
 		Logger.Printf("Connection %s recovery failed: %v.", parsedURL.Redacted(), err)
-		var amqpErr *Error
-		errors.As(err, &amqpErr)
-		conn.cleanup(amqpErr)
+		conn.cleanup(err)
 	}
 }
 
@@ -287,7 +284,7 @@ func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
 	// Guard against a redundant, competing recovery pass: an in-flight
 	// recoverConnectionTopology call already owns this channel's
 	// reopen/redeclare sequence and will reopen it itself (see
-	// reopenChannelIfClosed) if a broker soft error closes it here.
+	// Channel.reopenIfClosed) if a broker soft error closes it here.
 	if ch.recoveringTopology.Load() {
 		Logger.Printf("Channel %d topology recovery already in progress, skipping redundant reconnect.", ch.id)
 		return
@@ -297,9 +294,8 @@ func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
 	// Reconnect channel
 	if err := ch.Reconnect(); err != nil {
 		Logger.Printf("Channel %d recovery failed: %v.", ch.id, err)
-		var amqpErr *Error
-		errors.As(err, &amqpErr)
-		ch.cleanup(amqpErr)
+		ch.cleanup(err)
+		ch.connection.releaseChannel(ch)
 	}
 }
 

--- a/recovery.go
+++ b/recovery.go
@@ -4,6 +4,7 @@
 package amqp091
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -92,33 +93,17 @@ const (
 )
 
 var (
-	// defaultRecoverableErrorCodes contains the default exception codes that trigger recovery.
-	defaultRecoverableErrorCodes = []int{ConnectionForced, InternalError}
-
 	// DefaultReconnectionConfig is the default reconnection config settings.
 	DefaultReconnectionConfig = &ReconnectionConfig{
-		MaxRetryCount:         DefaultMaxRetryCount,
-		RetryInterval:         DefaultRetryInterval,
-		RecoverableErrorCodes: cloneRecoverableErrorCodes(defaultRecoverableErrorCodes),
+		MaxRetryCount: DefaultMaxRetryCount,
+		RetryInterval: DefaultRetryInterval,
 	}
 )
 
-// cloneRecoverableErrorCodes returns a clone of given RecoverableErrorCodes slice.
-// It is used to avoid modifying the original slice.
-func cloneRecoverableErrorCodes(inRecoverableErrorCodes []int) []int {
-	if inRecoverableErrorCodes == nil {
-		return nil
-	}
-	codes := make([]int, len(inRecoverableErrorCodes))
-	copy(codes, inRecoverableErrorCodes)
-	return codes
-}
-
 // ReconnectionConfig is the configuration for the reconnection.
 type ReconnectionConfig struct {
-	MaxRetryCount         int           // The maximum number of retries.
-	RetryInterval         time.Duration // The interval between retries.
-	RecoverableErrorCodes []int         // The error codes that trigger recovery.
+	MaxRetryCount int           // The maximum number of retries.
+	RetryInterval time.Duration // The interval between retries.
 }
 
 // Clone returns a deep copy of the ReconnectionConfig.
@@ -127,20 +112,16 @@ func (rc *ReconnectionConfig) Clone() *ReconnectionConfig {
 		return nil
 	}
 	return &ReconnectionConfig{
-		MaxRetryCount:         rc.MaxRetryCount,
-		RetryInterval:         rc.RetryInterval,
-		RecoverableErrorCodes: cloneRecoverableErrorCodes(rc.RecoverableErrorCodes),
+		MaxRetryCount: rc.MaxRetryCount,
+		RetryInterval: rc.RetryInterval,
 	}
 }
 
 // ConnectionRecovery is the interface for the connection recovery.
 //
 // The err parameter in OnConnectionClose and OnChannelClose provides the reason
-// why the connection or channel was closed. Under the hood, DefaultConnectionRecovery
-// performs conditional recovery based on RecoverableErrorCodes. You can also customize
-// the list of recoverable errors dynamically using Connection.SetRecoverableErrorCodes and
-// Connection.AddRecoverableErrorCodes, or use custom implementations of this interface to
-// perform more advanced logic, log errors to external monitoring systems (e.g., Prometheus),
+// why the connection or channel was closed. Custom implementations of this interface
+// can perform advanced logic, log errors to external monitoring systems (e.g., Prometheus),
 // or trigger alerts.
 type ConnectionRecovery interface {
 	OnConnectionClose(conn *Connection, err *Error) // Called when the connection is closed.
@@ -280,21 +261,13 @@ func (d *DefaultConnectionRecovery) OnConnectionClose(conn *Connection, err *Err
 		return
 	}
 
-	if !conn.isRecoverable(err) {
-		code := 0
-		if err != nil {
-			code = err.Code
-		}
-		Logger.Printf("Connection %s closed with non-recoverable error code %d, skipping reconnect.", parsedURL.Redacted(), code)
-		return
-	}
-
 	Logger.Printf("Initiating connection recovery for %s.", parsedURL.Redacted())
 	// Reconnect connection
 	if err := conn.Reconnect(); err != nil {
 		Logger.Printf("Connection %s recovery failed: %v.", parsedURL.Redacted(), err)
-		Logger.Printf("Now cleanup channels")
-		conn.cleanup()
+		var amqpErr *Error
+		errors.As(err, &amqpErr)
+		conn.cleanup(amqpErr)
 	}
 }
 
@@ -311,20 +284,13 @@ func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
 		return
 	}
 
-	if !ch.connection.isRecoverable(err) {
-		code := 0
-		if err != nil {
-			code = err.Code
-		}
-		Logger.Printf("Channel %d closed with non-recoverable error code %d, skipping reconnect.", ch.id, code)
-		return
-	}
-
 	Logger.Printf("Initiating channel %d recovery", ch.id)
 	// Reconnect channel
 	if err := ch.Reconnect(); err != nil {
 		Logger.Printf("Channel %d recovery failed: %v.", ch.id, err)
-		ch.cleanup()
+		var amqpErr *Error
+		errors.As(err, &amqpErr)
+		ch.cleanup(amqpErr)
 	}
 }
 

--- a/recovery.go
+++ b/recovery.go
@@ -284,6 +284,15 @@ func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
 		return
 	}
 
+	// Guard against a redundant, competing recovery pass: an in-flight
+	// recoverConnectionTopology call already owns this channel's
+	// reopen/redeclare sequence and will reopen it itself (see
+	// reopenChannelIfClosed) if a broker soft error closes it here.
+	if ch.recoveringTopology.Load() {
+		Logger.Printf("Channel %d topology recovery already in progress, skipping redundant reconnect.", ch.id)
+		return
+	}
+
 	Logger.Printf("Initiating channel %d recovery", ch.id)
 	// Reconnect channel
 	if err := ch.Reconnect(); err != nil {

--- a/recovery.go
+++ b/recovery.go
@@ -37,17 +37,46 @@ func (t TopologyRecoveryEntityType) String() string {
 	}
 }
 
-// TopologyRecoveryEntity describes a single topology entity during the recovery.
+// TopologyRecoveryEntity describes a single topology entity that failed during recovery.
+// It is passed to Recovery.OnTopologyEntityError and collected in StateChanged.SkippedTopologyEntities.
+//
+// For non-binding entity types, EntityName uniquely identifies the entity.
+// For binding types (QueueBinding, ExchangeBinding), use EntityName + SecondaryName + RoutingKey
+// together — the same queue or exchange may appear in multiple bindings with different
+// routing keys or destination exchanges.
 type TopologyRecoveryEntity struct {
 	EntityType TopologyRecoveryEntityType
-	EntityName string // exchange/queue name, consumer tag, etc.
+	// EntityName is the primary name of the entity:
+	//   - Exchange: the exchange name
+	//   - Queue: the queue name
+	//   - QueueBinding: the queue name
+	//   - ExchangeBinding: the source exchange name
+	//   - Consumer: the consumer tag
+	EntityName string
+	// SecondaryName disambiguates binding entities that share the same EntityName:
+	//   - QueueBinding: the exchange the queue is bound to
+	//   - ExchangeBinding: the destination exchange
+	//   - Empty for all other entity types.
+	SecondaryName string
+	// RoutingKey is set for binding entities (QueueBinding, ExchangeBinding).
+	// Empty for all other entity types.
+	RoutingKey string
 	ChannelID  uint16
 	Err        error // the underlying broker or network error during the recovery.
 }
 
 func (e TopologyRecoveryEntity) Error() string {
-	return fmt.Sprintf("topology recovery: %s %q on channel %d: %v",
-		e.EntityType, e.EntityName, e.ChannelID, e.Err)
+	switch e.EntityType {
+	case TopologyEntityQueueBinding:
+		return fmt.Sprintf("topology recovery: queue-binding %q → %q [%s] on channel %d: %v",
+			e.EntityName, e.SecondaryName, e.RoutingKey, e.ChannelID, e.Err)
+	case TopologyEntityExchangeBinding:
+		return fmt.Sprintf("topology recovery: exchange-binding %q → %q [%s] on channel %d: %v",
+			e.EntityName, e.SecondaryName, e.RoutingKey, e.ChannelID, e.Err)
+	default:
+		return fmt.Sprintf("topology recovery: %s %q on channel %d: %v",
+			e.EntityType, e.EntityName, e.ChannelID, e.Err)
+	}
 }
 
 // Unwrap allows errors.As and errors.Is to inspect the underlying broker error,
@@ -182,8 +211,22 @@ type Recovery struct {
 	// entities. Return false to abort topology recovery and trigger the normal retry
 	// cycle.
 	//
+	// The entity e carries enough information to identify the failed entity without
+	// any additional lookup:
+	//
+	//	e.EntityType   — what kind of entity failed (exchange, queue, binding, consumer)
+	//	e.EntityName   — primary name: exchange/queue name, source exchange, consumer tag
+	//	e.SecondaryName — for bindings only: exchange (queue-binding) or destination exchange (exchange-binding)
+	//	e.RoutingKey   — for bindings only: the routing key
+	//	e.ChannelID    — the channel on which the failure occurred
+	//	e.Err          — the underlying broker or network error
+	//
+	// For bindings, EntityName alone is not sufficient to identify the specific
+	// binding — the same queue or exchange may be bound multiple times with different
+	// routing keys. Use EntityName + SecondaryName + RoutingKey together.
+	//
 	// The conn parameter is the connection on which recovery is running. Use it to
-	// inspect the full topology of the channel that owns the failed entity:
+	// retrieve the full declaration arguments of the failed entity when needed:
 	//
 	//	cfg := conn.Channel(e.ChannelID).TopologyConfiguration(true)
 	//
@@ -192,17 +235,21 @@ type Recovery struct {
 	// the TCP connection, not individual channels. Pass false to limit the view to
 	// entities declared on that channel only.
 	//
-	// From cfg you can retrieve the full declaration arguments of the failed entity:
-	//
 	//	switch e.EntityType {
 	//	case amqp091.TopologyEntityQueue:
-	//	    qc, ok := cfg.Queues[e.EntityName]  // QueueConfig with Durable, AutoDelete, Args, etc.
+	//	    qc, ok := cfg.Queues[e.EntityName]    // QueueConfig with Durable, AutoDelete, Args, etc.
 	//	case amqp091.TopologyEntityExchange:
-	//	    ec, ok := cfg.Exchanges[e.EntityName] // ExchangeConfig with Kind, Durable, Args, etc.
+	//	    ec, ok := cfg.Exchanges[e.EntityName]  // ExchangeConfig with Kind, Durable, Args, etc.
 	//	case amqp091.TopologyEntityQueueBinding:
-	//	    // cfg.Bindings is a slice; find the entry whose Queue matches e.EntityName
+	//	    // Match by Queue + Exchange + Key (args may further distinguish headers bindings).
+	//	    for _, b := range cfg.Bindings {
+	//	        if b.Queue == e.EntityName && b.Exchange == e.SecondaryName && b.Key == e.RoutingKey { ... }
+	//	    }
 	//	case amqp091.TopologyEntityExchangeBinding:
-	//	    // cfg.ExchangeBindings is a slice; find the entry whose Source matches e.EntityName
+	//	    // Match by Source + Destination + Key.
+	//	    for _, eb := range cfg.ExchangeBindings {
+	//	        if eb.Source == e.EntityName && eb.Destination == e.SecondaryName && eb.Key == e.RoutingKey { ... }
+	//	    }
 	//	case amqp091.TopologyEntityConsumer:
 	//	    // Consumer internals are not exposed via TopologyConfiguration.
 	//	    // The consumer tag is available in e.EntityName.
@@ -246,6 +293,7 @@ func (d *DefaultConnectionRecovery) OnConnectionClose(conn *Connection, err *Err
 	// Reconnect connection
 	if err := conn.Reconnect(); err != nil {
 		Logger.Printf("Connection %s recovery failed: %v.", parsedURL.Redacted(), err)
+		Logger.Printf("Now cleanup channels")
 		conn.cleanup()
 	}
 }

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -360,46 +360,6 @@ func waitForChannelOpen(t *testing.T, chanStateChanged chan *StateChanged) {
 	}
 }
 
-func waitForChannelClose(t *testing.T, chanStateChanged chan *StateChanged, chanID int, reason string) {
-	var chanClosedSeen bool
-	var chanReconnectingSeen bool
-	var chanOpenSeen bool
-
-	loopDeadline := time.After(3 * time.Second)
-	for {
-		select {
-		case sc, ok := <-chanStateChanged:
-			if !ok {
-				if !chanClosedSeen {
-					t.Fatalf("Expected Channel %d to transition to StateClosed before channel closed", chanID)
-				}
-				if chanReconnectingSeen || chanOpenSeen {
-					t.Fatalf("Channel %d recovery was triggered for %s!", chanID, reason)
-				}
-				return
-			}
-			t.Logf("Channel %d state changed: %s", chanID, sc)
-			if sc.To == StateClosed {
-				chanClosedSeen = true
-			}
-			if sc.To == StateReconnecting {
-				chanReconnectingSeen = true
-			}
-			if sc.To == StateOpen {
-				chanOpenSeen = true
-			}
-		case <-loopDeadline:
-			if !chanClosedSeen {
-				t.Fatalf("Expected Channel %d to transition to StateClosed", chanID)
-			}
-			if chanReconnectingSeen || chanOpenSeen {
-				t.Fatalf("Channel %d recovery was triggered for %s!", chanID, reason)
-			}
-			return
-		}
-	}
-}
-
 func waitForStateChangeClose(t *testing.T, ch chan *StateChanged, name, listenerName string) {
 	done := make(chan struct{})
 	go func() {
@@ -413,144 +373,6 @@ func waitForStateChangeClose(t *testing.T, ch chan *StateChanged, name, listener
 	case <-time.After(5 * time.Second):
 		t.Fatalf("Timeout waiting for state change channel for %s %s to close", name, listenerName)
 	}
-}
-
-// TestConnectionRecoveryNonRecoverableChannelClose tests that channel recovery is NOT triggered
-// when a channel is closed due to soft exceptions (errors not present in RecoverableErrorCodes).
-// It verifies both PRECONDITION_FAILED (406) and RESOURCE_LOCKED (405) leave the connection open,
-// transition the channel to StateClosed, and do not trigger automatic recovery.
-func TestConnectionRecoveryNonRecoverableChannelClose(t *testing.T) {
-	connectionName := "test-non-recoverable-channel-close"
-	properties := NewConnectionProperties()
-	properties.SetClientConnectionName(connectionName)
-	conn, err := DialConfig(amqpURL, Config{
-		Recovery:   &Recovery{},
-		Locale:     defaultLocale,
-		Properties: properties,
-	})
-	if err != nil {
-		t.Fatalf("DialConfig failed: %v", err)
-	}
-	defer conn.Close()
-
-	// --- 1. Test PRECONDITION_FAILED (406) using a durable mismatch on a non-exclusive queue ---
-	ch1, err := conn.Channel()
-	if err != nil {
-		t.Fatalf("First Channel creation failed: %v", err)
-	}
-	defer ch1.Close()
-
-	chanStateChanged1 := make(chan *StateChanged, 10)
-	ch1.NotifyStateChange(chanStateChanged1)
-
-	queueNamePrecondition := "precondition_failed_test_queue"
-	_, _ = ch1.QueueDelete(queueNamePrecondition, false, false, false)
-
-	// Declare non-exclusive queue as durable: true
-	_, err = ch1.QueueDeclare(
-		queueNamePrecondition,
-		true,  // durable
-		false, // auto-delete
-		false, // exclusive
-		false, // no-wait
-		nil,
-	)
-	if err != nil {
-		t.Fatalf("QueueDeclare durable:true failed: %v", err)
-	}
-	defer func() {
-		// Clean up queue using a fresh channel since ch1 will be closed
-		if !conn.IsClosed() {
-			if cleanCh, err := conn.Channel(); err == nil {
-				_, _ = cleanCh.QueueDelete(queueNamePrecondition, false, false, false)
-				cleanCh.Close()
-			}
-		}
-	}()
-
-	// Declare again on SAME channel with durable: false (PreconditionFailed)
-	_, err = ch1.QueueDeclare(
-		queueNamePrecondition,
-		false, // durable (mismatched)
-		false, // auto-delete
-		false, // exclusive
-		false, // no-wait
-		nil,
-	)
-	if err == nil {
-		t.Fatalf("Expected PreconditionFailed error but second QueueDeclare succeeded")
-	}
-
-	amqpErr, ok := err.(*Error)
-	if !ok {
-		t.Fatalf("Expected amqp.Error, got: %T (%v)", err, err)
-	}
-	if amqpErr.Code != PreconditionFailed {
-		t.Fatalf("Expected PreconditionFailed (406), got code: %d", amqpErr.Code)
-	}
-
-	// Verify ch1 transitioned to StateClosed and did not trigger recovery
-	waitForChannelClose(t, chanStateChanged1, int(ch1.id), "PreconditionFailed")
-
-	if conn.IsClosed() {
-		t.Fatalf("Expected connection to remain open after PRECONDITION_FAILED soft exception")
-	}
-	t.Log("Verified connection remains open after PRECONDITION_FAILED")
-
-	// --- 2. Test RESOURCE_LOCKED (405) using exclusive queue settings ---
-	ch2, err := conn.Channel()
-	if err != nil {
-		t.Fatalf("Second Channel creation failed: %v", err)
-	}
-	defer ch2.Close()
-
-	chanStateChanged2 := make(chan *StateChanged, 10)
-	ch2.NotifyStateChange(chanStateChanged2)
-
-	queueNameResource := "resource_locked_test_queue"
-	_, _ = ch2.QueueDelete(queueNameResource, false, false, false)
-
-	// Declare as exclusive: true, auto-delete: true
-	_, err = ch2.QueueDeclare(
-		queueNameResource,
-		false, // durable
-		true,  // auto-delete
-		true,  // exclusive
-		false, // no-wait
-		nil,
-	)
-	if err != nil {
-		t.Fatalf("QueueDeclare exclusive:true failed: %v", err)
-	}
-
-	// Declare again on SAME channel with exclusive: false (ResourceLocked)
-	_, err = ch2.QueueDeclare(
-		queueNameResource,
-		false, // durable
-		true,  // auto-delete
-		false, // exclusive (mismatched)
-		false, // no-wait
-		nil,
-	)
-	if err == nil {
-		t.Fatalf("Expected ResourceLocked error but second QueueDeclare succeeded")
-	}
-
-	amqpErr, ok = err.(*Error)
-	if !ok {
-		t.Fatalf("Expected amqp.Error, got: %T (%v)", err, err)
-	}
-	if amqpErr.Code != ResourceLocked {
-		t.Fatalf("Expected ResourceLocked (405), got code: %d", amqpErr.Code)
-	}
-
-	// Verify ch2 transitioned to StateClosed and did not trigger recovery
-	waitForChannelClose(t, chanStateChanged2, int(ch2.id), "ResourceLocked")
-
-	if conn.IsClosed() {
-		t.Fatalf("Expected connection to remain open after RESOURCE_LOCKED soft exception")
-	}
-	t.Log("Verified connection remains open after RESOURCE_LOCKED")
 }
 
 // TestConnectionRecoveryChannelIDReservation verifies that after connection recovery,
@@ -2623,8 +2445,19 @@ func TestConnectionRecoveryAutoDeleteExchangeCascade(t *testing.T) {
 			},
 		},
 	}
+	// Use a plain, non-recovering connection for these checks: each is expected
+	// to close its channel with a 404, and running them on the recovering
+	// `conn` would trigger the library's own per-channel auto-recovery
+	// (Connection.watchChannel -> OnChannelClose -> Channel.Reconnect) for a
+	// channel we're intentionally breaking, racing with the next check.
+	verifyConn, err := DialConfig(amqpURL, Config{Locale: defaultLocale})
+	if err != nil {
+		t.Fatalf("s3 verification connection failed: %v", err)
+	}
+	defer verifyConn.Close()
+
 	for _, ck := range checks {
-		verifyCh, err := conn.Channel()
+		verifyCh, err := verifyConn.Channel()
 		if err != nil {
 			t.Fatalf("s3 verification channel failed: %v", err)
 		}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -2049,11 +2049,12 @@ func TestConnectionRecoveryTopologyDisabled(t *testing.T) {
 //
 // The failure path is: a recoverable drop starts recovery; a queue that can no
 // longer be redeclared (its definition was changed out-of-band) makes
-// RecoverTopology fail; Reconnect() calls Close() on the transport, whose reader
-// raises a non-recoverable shutdown that closes the listeners; after retries are
-// exhausted OnConnectionClose calls cleanup(), which closed the same listeners a
-// second time and panicked with "close of closed channel". A registered
-// NotifyClose listener is required to surface the panic.
+// RecoverTopology fail (OnTopologyEntityError returns false to abort, not skip);
+// Reconnect() calls Close() on the transport, whose reader raises a
+// non-recoverable shutdown that closes the listeners; after retries are exhausted
+// OnConnectionClose calls cleanup(), which closed the same listeners a second time
+// and panicked with "close of closed channel". A registered NotifyClose listener
+// is required to surface the panic.
 func TestConnectionRecoveryExhaustionDoesNotPanic(t *testing.T) {
 	connectionName := "test-connection-recovery-exhaustion-no-panic"
 	properties := NewConnectionProperties()
@@ -2066,6 +2067,12 @@ func TestConnectionRecoveryExhaustionDoesNotPanic(t *testing.T) {
 				RetryInterval: 1 * time.Second,
 			},
 			TopologyRecoveryMode: TopologyRecoveryAllEnabled,
+			// Return false to abort topology recovery on any entity error.
+			// Without this, the default behavior skips the failed entity and
+			// recovery succeeds — the connection never reaches StateClosed.
+			OnTopologyEntityError: func(_ *Connection, _ TopologyRecoveryEntity) bool {
+				return false
+			},
 		},
 		Locale:     defaultLocale,
 		Properties: properties,
@@ -2674,4 +2681,135 @@ func TestConnectionRecoveryAutoDeleteExchangeCascade(t *testing.T) {
 		t.Fatalf("s4: auto-delete source exchange %q must be forgotten after ExchangeDelete removed its only e2e binding, but it is still tracked", s4Source)
 	}
 	t.Logf("Scenario 4 OK: source exchange %q cascade-forgotten after ExchangeDelete of destination %q", s4Source, s4Dest)
+}
+
+// TestConnectionRecoverySkipAndContinue tests that when a topology entity fails to
+// recover, OnTopologyEntityError can skip it and recovery still completes successfully.
+// The StateReconnecting→StateOpen transition must carry the skipped entities in
+// SkippedTopologyEntities so the caller can observe what was not restored.
+func TestConnectionRecoverySkipAndContinue(t *testing.T) {
+	connectionName := "test-connection-recovery-skip-and-continue"
+	properties := NewConnectionProperties()
+	properties.SetClientConnectionName(connectionName)
+
+	// 1. Declare topology: auto-delete exchange, durable queue (with x-max-length),
+	//    a binding, and a consumer.
+	conn, err := DialConfig(amqpURL, Config{
+		Recovery: &Recovery{
+			// Explicitly return true to skip the failed entity and continue recovery.
+			OnTopologyEntityError: func(_ *Connection, e TopologyRecoveryEntity) bool {
+				return true
+			},
+		},
+		Locale:     defaultLocale,
+		Properties: properties,
+	})
+	if err != nil {
+		t.Fatalf("DialConfig failed: %v", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel creation failed: %v", err)
+	}
+	defer ch.Close()
+
+	exchangeName := "test_skip_continue_ex"
+	if err := ch.ExchangeDeclare(exchangeName, "direct", false, true, false, false, nil); err != nil {
+		t.Fatalf("ExchangeDeclare failed: %v", err)
+	}
+	defer func() {
+		if !conn.IsClosed() {
+			_ = ch.ExchangeDelete(exchangeName, false, false)
+		}
+	}()
+
+	queueName := "test_skip_continue_q"
+	if _, err := ch.QueueDeclare(queueName, true, false, false, false, Table{"x-max-length": int32(10)}); err != nil {
+		t.Fatalf("QueueDeclare failed: %v", err)
+	}
+	defer func() {
+		// ch may be closed after the conflicting-queue error during recovery; use a
+		// fresh channel for cleanup so the queue is always removed.
+		if conn.IsClosed() {
+			return
+		}
+		cleanupCh, cerr := conn.Channel()
+		if cerr != nil {
+			return
+		}
+		defer cleanupCh.Close()
+		_, _ = cleanupCh.QueueDelete(queueName, false, false, false)
+	}()
+
+	routingKey := "skip-continue-key"
+	if err := ch.QueueBind(queueName, routingKey, exchangeName, false, nil); err != nil {
+		t.Fatalf("QueueBind failed: %v", err)
+	}
+
+	msgs, err := ch.Consume(queueName, "skip-continue-consumer", true, false, false, false, nil)
+	if err != nil {
+		t.Fatalf("Consume failed: %v", err)
+	}
+	_ = msgs
+
+	// 2. Out-of-band: delete and redeclare the queue with a conflicting definition
+	//    so that the client's recovery-time redeclare fails with PRECONDITION_FAILED.
+	adminConn, err := DialConfig(amqpURL, Config{Locale: defaultLocale})
+	if err != nil {
+		t.Fatalf("admin DialConfig failed: %v", err)
+	}
+	adminCh, err := adminConn.Channel()
+	if err != nil {
+		t.Fatalf("admin Channel failed: %v", err)
+	}
+	if _, err := adminCh.QueueDelete(queueName, false, false, false); err != nil {
+		t.Fatalf("admin QueueDelete failed: %v", err)
+	}
+	if _, err := adminCh.QueueDeclare(queueName, true, false, false, false, Table{"x-max-length": int32(99)}); err != nil {
+		t.Fatalf("admin QueueDeclare (conflicting) failed: %v", err)
+	}
+	_ = adminCh.Close()
+	_ = adminConn.Close()
+
+	// 3. Register state change listener.
+	stateChanged := make(chan *StateChanged, 10)
+	conn.NotifyStateChange(stateChanged)
+
+	// 4. Drop the connection.
+	dropConnection(t, connectionName)
+
+	// 5. Wait for recovery; 6. Assert the open transition carries skipped entities.
+	timeout := time.After(30 * time.Second)
+	for {
+		select {
+		case sc := <-stateChanged:
+			t.Logf("Connection state changed: %s", sc)
+			if sc.To != StateOpen {
+				continue
+			}
+			if len(sc.SkippedTopologyEntities) == 0 {
+				t.Fatalf("Expected SkippedTopologyEntities to be non-empty on StateOpen after skip-and-continue, but it was nil/empty")
+			}
+			t.Logf("Recovery succeeded with %d skipped topology entity/entities:", len(sc.SkippedTopologyEntities))
+			for _, e := range sc.SkippedTopologyEntities {
+				t.Logf("  - %s %q on channel %d: %v", e.EntityType, e.EntityName, e.ChannelID, e.Err)
+			}
+			// Verify at least one skipped entity is the conflicting queue.
+			foundQueue := false
+			for _, e := range sc.SkippedTopologyEntities {
+				if e.EntityType == TopologyEntityQueue && e.EntityName == queueName {
+					foundQueue = true
+				}
+			}
+			if !foundQueue {
+				t.Fatalf("Expected a skipped entity for queue %q but it was not found in SkippedTopologyEntities: %+v",
+					queueName, sc.SkippedTopologyEntities)
+			}
+			return
+		case <-timeout:
+			t.Fatalf("Timeout waiting for connection to recover to StateOpen with skipped topology entities")
+		}
+	}
 }

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -8,6 +8,7 @@ package amqp091
 import (
 	"context"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2645,4 +2646,147 @@ func TestConnectionRecoverySkipAndContinue(t *testing.T) {
 			t.Fatalf("Timeout waiting for connection to recover to StateOpen with skipped topology entities")
 		}
 	}
+}
+
+// countingTopologyRecovery wraps DefaultTopologyRecovery and counts how many
+// times RecoverTopology is invoked, so a test can detect a self-sustaining
+// recovery loop (a growing count) versus a single settled pass.
+type countingTopologyRecovery struct {
+	calls int32
+}
+
+func (c *countingTopologyRecovery) RecoverTopology(conn *Connection, channels []*Channel) ([]TopologyRecoveryEntity, error) {
+	atomic.AddInt32(&c.calls, 1)
+	return (&DefaultTopologyRecovery{}).RecoverTopology(conn, channels)
+}
+
+// TestConnectionRecoverySkipAndContinueNoInfiniteLoop verifies that skipping a
+// permanently-failing topology entity settles the channel instead of looping
+// forever.
+//
+// Regression for: a channel-level soft error (e.g. PRECONDITION_FAILED)
+// raised while recoverConnectionTopology is already reopening/redeclaring a
+// channel used to be re-delivered to watchChannel's long-lived NotifyClose
+// listener, which started a second, independent Reconnect+RecoverTopology
+// pass over the same still-conflicting entities. That pass hit the same
+// broker error again, re-triggering the cycle roughly every notifyTimeout
+// (5s) forever. Channel.recoveringTopology now suppresses that redundant
+// trigger while an in-flight pass owns the channel.
+func TestConnectionRecoverySkipAndContinueNoInfiniteLoop(t *testing.T) {
+	counter := &countingTopologyRecovery{}
+
+	conn, err := DialConfig(amqpURL, Config{
+		Recovery: &Recovery{
+			TopologyRecoveryMode: TopologyRecoveryAllEnabled,
+			TopologyRecovery:     counter,
+			OnTopologyEntityError: func(_ *Connection, _ TopologyRecoveryEntity) bool {
+				return true // skip-and-continue
+			},
+		},
+		Locale: defaultLocale,
+	})
+	if err != nil {
+		t.Fatalf("DialConfig failed: %v", err)
+	}
+	defer conn.Close()
+
+	ch1, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("conn.Channel failed: %v", err)
+	}
+	defer ch1.Close()
+
+	// Two queues on the same channel, both durable with an arg, so redeclaring
+	// either during recovery can be made to fail with PRECONDITION_FAILED.
+	q1, q2 := "test_no_infinite_loop_q1", "test_no_infinite_loop_q2"
+	_, _ = ch1.QueueDelete(q1, false, false, false)
+	_, _ = ch1.QueueDelete(q2, false, false, false)
+
+	if _, err := ch1.QueueDeclare(q1, true, false, false, false, Table{"x-max-length": int32(10)}); err != nil {
+		t.Fatalf("QueueDeclare q1 failed: %v", err)
+	}
+	if _, err := ch1.QueueDeclare(q2, true, false, false, false, Table{"x-max-length": int32(10)}); err != nil {
+		t.Fatalf("QueueDeclare q2 failed: %v", err)
+	}
+
+	adminConn, err := DialConfig(amqpURL, Config{Locale: defaultLocale})
+	if err != nil {
+		t.Fatalf("admin DialConfig failed: %v", err)
+	}
+	defer adminConn.Close()
+	adminCh, err := adminConn.Channel()
+	if err != nil {
+		t.Fatalf("admin Channel failed: %v", err)
+	}
+	defer func() {
+		_, _ = adminCh.QueueDelete(q1, false, false, false)
+		_, _ = adminCh.QueueDelete(q2, false, false, false)
+	}()
+
+	// Corrupt q1 and q2 out-of-band so that when ch1's own recovery pass
+	// redeclares them (durable=true), the broker responds with
+	// PRECONDITION_FAILED for both — a permanent, realistic conflict.
+	for _, q := range []string{q1, q2} {
+		if _, err := adminCh.QueueDelete(q, false, false, false); err != nil {
+			t.Fatalf("admin QueueDelete %s failed: %v", q, err)
+		}
+		if _, err := adminCh.QueueDeclare(q, true, false, false, false, Table{"x-max-length": int32(99)}); err != nil {
+			t.Fatalf("admin QueueDeclare(conflicting) %s failed: %v", q, err)
+		}
+	}
+
+	stateChanged := make(chan *StateChanged, 20)
+	ch1.NotifyStateChange(stateChanged)
+
+	// Trigger a channel-level soft error UNRELATED to q1/q2 to close ch1 and
+	// drive it through watchChannel -> Reconnect -> RecoverTopology, which
+	// will hit the q1/q2 conflicts just planted.
+	q3 := "test_no_infinite_loop_q3_trigger"
+	_, _ = adminCh.QueueDelete(q3, false, false, false)
+	if _, err := adminCh.QueueDeclare(q3, true, false, false, false, nil); err != nil {
+		t.Fatalf("admin QueueDeclare q3 failed: %v", err)
+	}
+	defer func() { _, _ = adminCh.QueueDelete(q3, false, false, false) }()
+
+	if _, err := ch1.QueueDeclare(q3, true, true /* mismatched auto-delete -> 406 */, false, false, nil); err == nil {
+		t.Fatalf("expected ch1.QueueDeclare(q3) to fail with PRECONDITION_FAILED, got no error")
+	}
+
+	// Wait for the first recovery pass to settle back to StateOpen.
+	timeout := time.After(15 * time.Second)
+waitOpen:
+	for {
+		select {
+		case sc := <-stateChanged:
+			t.Logf("Channel state changed: %s", sc)
+			if sc.To == StateOpen {
+				break waitOpen
+			}
+		case <-timeout:
+			t.Fatalf("Timeout waiting for channel to settle to StateOpen after skip-and-continue recovery")
+		}
+	}
+
+	// Give any in-flight goroutines (e.g. shutdown's background fallback
+	// delivery) a moment to finish before taking the first snapshot.
+	time.Sleep(1 * time.Second)
+	firstCount := atomic.LoadInt32(&counter.calls)
+	if firstCount == 0 {
+		t.Fatalf("expected at least one RecoverTopology call, got 0")
+	}
+
+	// If watchChannel's listener were still re-triggering a redundant pass,
+	// it would recur roughly every notifyTimeout (5s) since q1/q2 remain
+	// permanently conflicting. Wait several multiples of that period and
+	// confirm the call count does not grow.
+	time.Sleep(3 * notifyTimeout)
+	secondCount := atomic.LoadInt32(&counter.calls)
+	if secondCount != firstCount {
+		t.Fatalf("RecoverTopology call count grew from %d to %d after settling — self-sustaining recovery loop detected", firstCount, secondCount)
+	}
+
+	if ch1.IsClosed() {
+		t.Fatalf("expected ch1 to be open after settling, but it is closed")
+	}
+	t.Logf("Channel settled after %d RecoverTopology call(s), no further calls over %v", firstCount, 3*notifyTimeout)
 }

--- a/types.go
+++ b/types.go
@@ -83,9 +83,6 @@ var (
 
 	// ErrFieldType is returned when writing a message containing a Go type unsupported by AMQP.
 	ErrFieldType = &Error{Code: SyntaxError, Reason: "unsupported table field type"}
-
-	// ErrRecoveryNotEnabled is returned when recovery operations are attempted but recovery is not enabled.
-	ErrRecoveryNotEnabled = &Error{Code: ChannelError, Reason: "recovery is not enabled on this connection"}
 )
 
 // internal errors used inside the library


### PR DESCRIPTION
## Proposed Changes

Topology recovery previously aborted on the first entity failure, causing
the entire retry cycle to restart even when a single exchange or queue
was missing or mis-configured. This change introduces a skip-and-continue
model with fine-grained error visibility.

**Structural Removal of `isRecoverable`:**
To implement a resilient "Skip and Continue" topology recovery architecture, 
channels must not be completely torn down on soft broker exceptions 
(such as a 406 PRECONDITION_FAILED due to argument mismatches). Maintaining 
a hardcoded list of recoverable error codes is incredibly fragile, complex, 
and prone to hidden regressions if a specific broker or network error frame 
is missed.

To establish a clean separation of concerns, the `isRecoverable(err)` error 
classification layer has been completely removed from the connection and 
channel shutdown phases. 

Instead of forcing a single method to handle mixed-mode teardowns based on 
volatile error codes, responsibilities are cleanly bifurcated based on 
whether recovery is globally enabled:

1. **When Recovery is Enabled**: Unexpected connection-level drops (`err.Code >= 500`, 
   `320`, or `FrameError`) trigger minimal transport-only closures (`close(ch.errors)`, 
   `close(ch.close)`). This safely unblocks any blocking network RPC threads while 
   preserving the client-side consumer layouts and channel registry maps (`c.channels`) 
   perfectly in memory.
2. **When Recovery is Not Enabled / Graceful Close**: User-initiated closures 
   (where `err == nil`) or localized channel exceptions (`406` / `405`) bypass the 
   recovery shunts and immediately execute full, destructive teardowns.
3. **Recovery Lifecycle Ownership**: If automatic recovery fails permanently 
   and exhausts all retries, the recovery framework assumes total responsibility 
   for terminal destruction by invoking `Connection.cleanup()`. It leverages the 
   safely preserved maps to forcefully wipe remaining consumers, close notification 
   pipes, broadcast the final terminal `StateClosed` state, and eliminate any 
   lingering `goleak` goroutine failures.

## Types of Changes

<!-- What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply -->

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [x] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further Comments

Connection and Topology recovery feature is in Experimental phase and changes are expected to make it more resilient.
