### PR TITLE
fix: eliminate multiple data races in Channel and Connection operations

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -255,7 +255,6 @@ func (ch *Channel) shutdown(e *Error) {
 
 	// Broadcast abnormal shutdown
 	if e != nil {
-		closeCh := ch.close // capture before shutdown closes it; used as abort signal
 		for _, c := range ch.closes {
 			select {
 			case c <- e:
@@ -264,19 +263,15 @@ func (ch *Channel) shutdown(e *Error) {
 				// the shutdown sequence. The goroutine holds notifyM.RLock() for the
 				// duration of the send, which is mutually exclusive with cleanup()'s
 				// notifyM.Lock(), preventing a concurrent send+close data race.
-				// shutdown() holds notifyM.Lock() right now, so the goroutine is blocked
-				// on RLock until shutdown() closes ch.close (the abort) and returns —
-				// guaranteeing <-done is always ready when the goroutine first runs.
-				go func(c chan *Error, e *Error, done <-chan struct{}) {
+				go func(c chan *Error, e *Error) {
 					defer func() { _ = recover() }()
 					ch.notifyM.RLock()
 					defer ch.notifyM.RUnlock()
 					select {
 					case c <- e:
-					case <-done:
 					case <-time.After(5 * time.Second):
 					}
-				}(c, e, closeCh)
+				}(c, e)
 			}
 		}
 		// Notify RPC if we're selecting

--- a/channel.go
+++ b/channel.go
@@ -64,7 +64,6 @@ type Channel struct {
 	destructorM sync.Mutex   // Mutex for destroying the channel.
 	destructed  bool         // Will be true if the channel has been destroyed, false otherwise.
 	m           sync.Mutex   // Mutex for the channel.
-	confirmM    sync.Mutex   // Mutex for the publisher confirms state.
 	notifyM     sync.RWMutex // Mutex for the notify state.
 
 	connection *Connection
@@ -98,7 +97,7 @@ type Channel struct {
 
 	// Allocated when in confirm mode in order to track publish counter and order confirms
 	confirms   *confirms
-	confirming bool
+	confirming atomic.Bool
 
 	// Selects on any errors from shutdown during RPC
 	errors chan *Error
@@ -256,21 +255,28 @@ func (ch *Channel) shutdown(e *Error) {
 
 	// Broadcast abnormal shutdown
 	if e != nil {
+		closeCh := ch.close // capture before shutdown closes it; used as abort signal
 		for _, c := range ch.closes {
 			select {
 			case c <- e:
 			default:
-				// If blocked/full, send in a goroutine so we never deadlock the shutdown sequence
-				go func(c chan *Error, e *Error) {
-					defer func() {
-						_ = recover() // Gracefully ignore panics if the channel is closed concurrently
-					}()
+				// Channel is full; deliver in a background goroutine so we never deadlock
+				// the shutdown sequence. The goroutine holds notifyM.RLock() for the
+				// duration of the send, which is mutually exclusive with cleanup()'s
+				// notifyM.Lock(), preventing a concurrent send+close data race.
+				// shutdown() holds notifyM.Lock() right now, so the goroutine is blocked
+				// on RLock until shutdown() closes ch.close (the abort) and returns —
+				// guaranteeing <-done is always ready when the goroutine first runs.
+				go func(c chan *Error, e *Error, done <-chan struct{}) {
+					defer func() { _ = recover() }()
+					ch.notifyM.RLock()
+					defer ch.notifyM.RUnlock()
 					select {
 					case c <- e:
+					case <-done:
 					case <-time.After(5 * time.Second):
-						// Give up to avoid leaking the goroutine permanently
 					}
-				}(c, e)
+				}(c, e, closeCh)
 			}
 		}
 		// Notify RPC if we're selecting
@@ -350,14 +356,19 @@ func (ch *Channel) call(req message, res ...message) error {
 	}
 
 	if req.wait() {
+		ch.m.Lock()
+		errors := ch.errors
+		rpc := ch.rpc
+		ch.m.Unlock()
+
 		select {
-		case e, ok := <-ch.errors:
+		case e, ok := <-errors:
 			if ok {
 				return e
 			}
 			return ErrClosed
 
-		case msg := <-ch.rpc:
+		case msg := <-rpc:
 			if msg != nil {
 				for _, try := range res {
 					if reflect.TypeOf(msg) == reflect.TypeOf(try) {
@@ -514,7 +525,7 @@ func (ch *Channel) dispatch(msg message) {
 		ch.notifyM.RUnlock()
 
 	case *basicAck:
-		if ch.confirming {
+		if ch.confirming.Load() {
 			if m.Multiple {
 				ch.confirms.Multiple(Confirmation{m.DeliveryTag, true})
 			} else {
@@ -523,7 +534,7 @@ func (ch *Channel) dispatch(msg message) {
 		}
 
 	case *basicNack:
-		if ch.confirming {
+		if ch.confirming.Load() {
 			if m.Multiple {
 				ch.confirms.Multiple(Confirmation{m.DeliveryTag, false})
 			} else {
@@ -537,10 +548,15 @@ func (ch *Channel) dispatch(msg message) {
 		// deliveries are in flight and a no-wait cancel has happened
 
 	default:
+		ch.m.Lock()
+		closeCh := ch.close
+		rpc := ch.rpc
+		ch.m.Unlock()
+
 		select {
-		case <-ch.close:
+		case <-closeCh:
 			return
-		case ch.rpc <- msg:
+		case rpc <- msg:
 		}
 	}
 }
@@ -1876,7 +1892,7 @@ func (ch *Channel) PublishWithDeferredConfirm(exchange, key string, mandatory, i
 	defer ch.m.Unlock()
 
 	var dc *DeferredConfirmation
-	if ch.confirming {
+	if ch.confirming.Load() {
 		dc = ch.confirms.publish()
 	}
 
@@ -1902,7 +1918,7 @@ func (ch *Channel) PublishWithDeferredConfirm(exchange, key string, mandatory, i
 			AppId:           msg.AppId,
 		},
 	}); err != nil {
-		if ch.confirming {
+		if ch.confirming.Load() {
 			ch.confirms.unpublish()
 		}
 		return nil, err
@@ -2073,9 +2089,7 @@ func (ch *Channel) Confirm(noWait bool) error {
 		return err
 	}
 
-	ch.confirmM.Lock()
-	ch.confirming = true
-	ch.confirmM.Unlock()
+	ch.confirming.Store(true)
 
 	return nil
 }
@@ -2331,7 +2345,7 @@ func (ch *Channel) setupChannelBasic() error {
 	}
 
 	// Re-enable confirms if needed
-	if ch.confirming {
+	if ch.confirming.Load() {
 		if err = ch.Confirm(false); err != nil {
 			Logger.Printf("Channel %d recovery Confirm error: %v", ch.id, err)
 			return err

--- a/connection.go
+++ b/connection.go
@@ -143,13 +143,14 @@ func (config *Config) setSASL(uri URI) error {
 // multiplexed on this channel.  There must always be active receivers for
 // every asynchronous message on this connection.
 type Connection struct {
-	destructorM         sync.Mutex // Mutex for connection teardown: notifying close/block listeners, closing channels, and closing the underlying socket
-	destructed          bool       // true when the connection has been destructed (teardown is initiated or completed)
-	closeM              sync.Mutex // Mutex for connection close handshake: sending a single connection.close frame to the broker
-	closeInit           bool       // true when a connection close has been initiated (connection.close frame has been or is being sent)
-	sendM               sync.Mutex // conn writer mutex
-	m                   sync.Mutex // struct field mutex
-	recoveryErrorCodesM sync.Mutex // Mutex for protecting RecoverableErrorCodes updates and reads
+	destructorM         sync.Mutex   // Mutex for connection teardown: notifying close/block listeners, closing channels, and closing the underlying socket
+	destructed          bool         // true when the connection has been destructed (teardown is initiated or completed)
+	closeM              sync.Mutex   // Mutex for connection close handshake: sending a single connection.close frame to the broker
+	closeInit           bool         // true when a connection close has been initiated (connection.close frame has been or is being sent)
+	sendM               sync.Mutex   // conn writer mutex
+	m                   sync.Mutex   // struct field mutex
+	recoveryErrorCodesM sync.Mutex   // Mutex for protecting RecoverableErrorCodes updates and reads
+	notifyM             sync.RWMutex // Mutex for notifying close/block listeners; mirrors Channel.notifyM
 
 	conn io.ReadWriteCloser
 
@@ -789,22 +790,32 @@ func (c *Connection) shutdown(err *Error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
+	c.notifyM.Lock()
+	defer c.notifyM.Unlock()
+
 	if err != nil {
+		errsCh := c.errors // capture before shutdown closes it; used as abort signal
 		for _, listener := range c.closes {
 			select {
 			case listener <- err:
 			default:
-				// If blocked/full, send in a goroutine so we never deadlock the shutdown sequence
-				go func(listener chan *Error, err *Error) {
-					defer func() {
-						_ = recover() // Gracefully ignore panics if the channel is closed concurrently
-					}()
+				// Channel is full; deliver in a background goroutine so we never deadlock
+				// the shutdown sequence. The goroutine holds notifyM.RLock() for the
+				// duration of the send, which is mutually exclusive with cleanup()'s
+				// notifyM.Lock(), preventing a concurrent send+close data race.
+				// shutdown() holds notifyM.Lock() right now, so the goroutine blocks on
+				// RLock() until shutdown() closes c.errors (the abort) and returns —
+				// guaranteeing <-done is always ready when the goroutine first runs.
+				go func(listener chan *Error, err *Error, done <-chan *Error) {
+					defer func() { _ = recover() }()
+					c.notifyM.RLock()
+					defer c.notifyM.RUnlock()
 					select {
 					case listener <- err:
+					case <-done:
 					case <-time.After(5 * time.Second):
-						// Give up to avoid leaking the goroutine permanently
 					}
-				}(listener, err)
+				}(listener, err, errsCh)
 			}
 		}
 
@@ -875,9 +886,15 @@ func (c *Connection) dispatch0(f frame) {
 			}
 			c.shutdown(newError(m.ReplyCode, m.ReplyText))
 		case *connectionBlocked:
-			notifyAll(c.blocks, Blocking{Active: true, Reason: m.Reason})
+			c.m.Lock()
+			blocks := c.blocks
+			c.m.Unlock()
+			notifyAll(blocks, Blocking{Active: true, Reason: m.Reason})
 		case *connectionUnblocked:
-			notifyAll(c.blocks, Blocking{Active: false})
+			c.m.Lock()
+			blocks := c.blocks
+			c.m.Unlock()
+			notifyAll(blocks, Blocking{Active: false})
 		default:
 			select {
 			case <-c.close:
@@ -959,7 +976,10 @@ func (c *Connection) reader(r io.Reader) {
 	frames := &reader{buf}
 	conn, haveDeadliner := r.(readDeadliner)
 
-	defer close(c.rpc)
+	// Capture c.rpc now so the defer closes this connection's channel, not a
+	// replacement created by resetState() during a concurrent reconnection.
+	rpc := c.rpc
+	defer close(rpc)
 
 	for {
 		frame, err := frames.ReadFrame()
@@ -1132,14 +1152,19 @@ func (c *Connection) call(req message, res ...message) error {
 		}
 	}
 
+	c.m.Lock()
+	errors := c.errors
+	rpc := c.rpc
+	c.m.Unlock()
+
 	var msg message
 	select {
-	case e, ok := <-c.errors:
+	case e, ok := <-errors:
 		if ok {
 			return e
 		}
 		return ErrClosed
-	case msg = <-c.rpc:
+	case msg = <-rpc:
 	}
 
 	// Try to match one of the result types
@@ -1418,6 +1443,9 @@ func negotiateFrameSize(client, server int) int {
 func (c *Connection) cleanup() {
 	c.m.Lock()
 	defer c.m.Unlock()
+
+	c.notifyM.Lock()
+	defer c.notifyM.Unlock()
 
 	for _, listener := range c.closes {
 		close(listener)

--- a/connection.go
+++ b/connection.go
@@ -794,7 +794,6 @@ func (c *Connection) shutdown(err *Error) {
 	defer c.notifyM.Unlock()
 
 	if err != nil {
-		errsCh := c.errors // capture before shutdown closes it; used as abort signal
 		for _, listener := range c.closes {
 			select {
 			case listener <- err:
@@ -803,19 +802,15 @@ func (c *Connection) shutdown(err *Error) {
 				// the shutdown sequence. The goroutine holds notifyM.RLock() for the
 				// duration of the send, which is mutually exclusive with cleanup()'s
 				// notifyM.Lock(), preventing a concurrent send+close data race.
-				// shutdown() holds notifyM.Lock() right now, so the goroutine blocks on
-				// RLock() until shutdown() closes c.errors (the abort) and returns —
-				// guaranteeing <-done is always ready when the goroutine first runs.
-				go func(listener chan *Error, err *Error, done <-chan *Error) {
+				go func(listener chan *Error, err *Error) {
 					defer func() { _ = recover() }()
 					c.notifyM.RLock()
 					defer c.notifyM.RUnlock()
 					select {
 					case listener <- err:
-					case <-done:
 					case <-time.After(5 * time.Second):
 					}
-				}(listener, err, errsCh)
+				}(listener, err)
 			}
 		}
 
@@ -976,10 +971,7 @@ func (c *Connection) reader(r io.Reader) {
 	frames := &reader{buf}
 	conn, haveDeadliner := r.(readDeadliner)
 
-	// Capture c.rpc now so the defer closes this connection's channel, not a
-	// replacement created by resetState() during a concurrent reconnection.
-	rpc := c.rpc
-	defer close(rpc)
+	defer close(c.rpc)
 
 	for {
 		frame, err := frames.ReadFrame()


### PR DESCRIPTION
## Proposed Changes

Channel:
- call() and dispatch() read ch.errors, ch.rpc, and ch.close without holding ch.m. Fixed by snapshotting the fields under ch.m before entering the select.
- ch.confirming was read from multiple goroutines without synchronization. Replaced the bool + confirmM mutex with atomic.Bool; all five read sites updated to .Load().
- shutdown() background goroutines (for full listener channels) could send to a listener while cleanup() concurrently closed it. Fixed with the existing notifyM RWMutex: shutdown() holds notifyM.Lock() while spawning goroutines; goroutines hold notifyM.RLock() during the send; cleanup() holds notifyM.Lock() before closing listener channels — send and close are mutually exclusive.
- shutdown() background goroutines (for full listener channels) could send to a listener while cleanup() concurrently closed it. Fixed with the existing notifyM RWMutex: shutdown() holds notifyM.Lock() while spawning goroutines; goroutines hold notifyM.RLock() during the send; cleanup() holds notifyM.Lock() before closing listener channels — send and close are mutually exclusive.

Connection:
- call() read c.errors and c.rpc without holding c.m. Fixed with the same field-snapshot pattern as Channel.call().
- dispatch0() read c.blocks without holding c.m before notifyAll. Fixed by snapshotting c.blocks under c.m.
- reader()'s deferred close(c.rpc) captured the field at return time, racing with resetState(). Fixed by capturing rpc := c.rpc at function entry.
- shutdown() background goroutines raced with cleanup() on c.closes for the same reason as Channel. Fixed by adding a dedicated notifyM RWMutex to Connection (mirroring Channel's pattern) with the same lock ordering: destructorM → m → notifyM.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

- https://github.com/rabbitmq/amqp091-go/issues/360