### PR TITLE
fix: prevent recursive channel recovery during connection reconnection

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -299,8 +299,13 @@ func (ch *Channel) shutdown(e *Error) {
 			close(c)
 		}
 
+		for _, c := range ch.recoveryCancels {
+			close(c)
+		}
+
 		// Set the slices to nil to prevent the dispatch() range from sending on
 		// the now closed channels after we release the notifyM mutex
+		ch.recoveryCancels = nil
 		ch.flows = nil
 		ch.closes = nil
 		ch.returns = nil

--- a/recovery.go
+++ b/recovery.go
@@ -169,8 +169,9 @@ func (d *DefaultConnectionRecovery) OnChannelClose(ch *Channel, err *Error) {
 		return
 	}
 
-	if ch.connection.IsClosed() {
-		Logger.Printf("Connection is closed, letting connection recovery handle channel %d.", ch.id)
+	// Guard against concurrent recovery loops if the connection is already reconnecting
+	if ch.connection.IsClosed() || ch.connection.lifeCycle.State() == StateReconnecting {
+		Logger.Printf("Connection is closed or reconnecting, letting connection recovery handle channel %d.", ch.id)
 		return
 	}
 


### PR DESCRIPTION
## Proposed Changes

In DefaultConnectionRecovery.OnChannelClose, guard against spawning per-channel recovery when the connection is already in StateReconnecting. 
Previously, only IsClosed() was checked, so channels closed mid-reconnect could trigger their own independent recovery attempts concurrently with the connection-level recovery, leading to a recursive/duplicate recovery loop.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
