### PR TITLE
fix: reject frames exceeding negotiated frame_max before allocation

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -56,7 +56,7 @@ func newServer(t *testing.T, serverIO, clientIO io.ReadWriteCloser) *server {
 
 	return &server{
 		T: t,
-		r: reader{serverIO},
+		r: reader{r: serverIO},
 		w: writer{serverIO},
 		S: serverIO,
 		C: clientIO,

--- a/connection.go
+++ b/connection.go
@@ -184,6 +184,11 @@ type Connection struct {
 
 	closed atomic.Bool // Will be true if the connection is closed, false otherwise.
 
+	// maxFrameSize mirrors Config.FrameSize once negotiated via connection.tune,
+	// letting the reader goroutine reject over-sized frames before allocating
+	// memory for them. 0 means no limit is enforced yet (or none was negotiated).
+	maxFrameSize atomic.Uint32
+
 	reconnecting sync.Mutex // Mutex for protecting reconnect/recovery operations to ensure serialization and prevent race conditions.
 	lifeCycle    *lifeCycle // The current state of the connection.
 
@@ -968,7 +973,7 @@ func (c *Connection) dispatchClosed(f frame) {
 // handle on channel 0 (the connection channel).
 func (c *Connection) reader(r io.Reader) {
 	buf := bufio.NewReader(r)
-	frames := &reader{buf}
+	frames := &reader{r: buf, maxFrameSize: &c.maxFrameSize}
 	conn, haveDeadliner := r.(readDeadliner)
 
 	defer close(c.rpc)
@@ -1277,6 +1282,7 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 	// minimum floor of frameMinSize (4096 bytes) to prevent malicious servers
 	// from forcing extreme fragmentation and CPU overhead.
 	c.Config.FrameSize = negotiateFrameSize(config.FrameSize, int(tune.FrameMax))
+	c.maxFrameSize.Store(uint32(c.Config.FrameSize))
 
 	// Save this off for resetDeadline()
 	c.Config.Heartbeat = time.Second * time.Duration(pick(

--- a/connection.go
+++ b/connection.go
@@ -1282,6 +1282,10 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 	// minimum floor of frameMinSize (4096 bytes) to prevent malicious servers
 	// from forcing extreme fragmentation and CPU overhead.
 	c.Config.FrameSize = negotiateFrameSize(config.FrameSize, int(tune.FrameMax))
+	// This is the only place maxFrameSize is written. reader.ReadFrame relies on
+	// any nonzero value here being >= frameMinSize (negotiateFrameSize's floor)
+	// to safely subtract frameHeaderSize without underflow — keep it that way if
+	// another write path is ever added.
 	c.maxFrameSize.Store(uint32(c.Config.FrameSize))
 
 	// Save this off for resetDeadline()

--- a/fuzz.go
+++ b/fuzz.go
@@ -11,7 +11,7 @@ package amqp091
 import "bytes"
 
 func Fuzz(data []byte) int {
-	r := reader{bytes.NewReader(data)}
+	r := reader{r: bytes.NewReader(data)}
 	frame, err := r.ReadFrame()
 	if err != nil {
 		if frame != nil {

--- a/read.go
+++ b/read.go
@@ -54,6 +54,12 @@ func (r *reader) ReadFrame() (frame frame, err error) {
 	channel := binary.BigEndian.Uint16(scratch[1:3])
 	size := binary.BigEndian.Uint32(scratch[3:7])
 
+	if r.maxFrameSize != nil {
+		if max := r.maxFrameSize.Load(); max > 0 && uint64(size)+frameHeaderSize > uint64(max) {
+			return nil, ErrFrameTooLarge
+		}
+	}
+
 	switch typ {
 	case frameMethod:
 		if frame, err = r.parseMethodFrame(channel, size); err != nil {

--- a/read.go
+++ b/read.go
@@ -55,7 +55,10 @@ func (r *reader) ReadFrame() (frame frame, err error) {
 	size := binary.BigEndian.Uint32(scratch[3:7])
 
 	if r.maxFrameSize != nil {
-		if max := r.maxFrameSize.Load(); max > 0 && uint64(size)+frameHeaderSize > uint64(max) {
+		// max-frameHeaderSize is safe from underflow only because maxFrameSize,
+		// whenever nonzero, is always negotiateFrameSize's floor (frameMinSize,
+		// 4096) or higher — see the Store call at Connection.openTune.
+		if max := r.maxFrameSize.Load(); max > 0 && size > (max-frameHeaderSize) {
 			return nil, ErrFrameTooLarge
 		}
 	}

--- a/read_test.go
+++ b/read_test.go
@@ -7,8 +7,10 @@ package amqp091
 
 import (
 	"bytes"
+	"encoding/binary"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -24,10 +26,50 @@ import (
 // padding bytes before the frame-end octet.
 func TestParseHeaderFrameConsumesPaddingBytes(t *testing.T) {
 	frame := "\x02\x00\x01\x00\x00\x00\x12\x00\x3c\x00\x00\x00\x00\x00\x00\x00\x00\x0a\x54\x00\x00\x00\x00\x00\x00\xce"
-	r := reader{strings.NewReader(frame)}
+	r := reader{r: strings.NewReader(frame)}
 	_, err := r.ReadFrame()
 	if err != nil {
 		t.Fatalf("expected no error reading header frame, got: %v", err)
+	}
+}
+
+// TestReadFrameRejectsOversizedFrame verifies that a frame whose declared
+// size exceeds the negotiated frame_max is rejected before its payload is
+// allocated or read, preventing a malicious server from forcing large
+// allocations by lying about a frame's size in the frame header.
+func TestReadFrameRejectsOversizedFrame(t *testing.T) {
+	const negotiatedMax = 4096 // total frame size, including header and frame-end byte
+
+	header := make([]byte, 7)
+	header[0] = frameBody
+	binary.BigEndian.PutUint16(header[1:3], 1)
+	binary.BigEndian.PutUint32(header[3:7], negotiatedMax) // payload alone already exceeds the limit
+
+	var maxFrameSize atomic.Uint32
+	maxFrameSize.Store(negotiatedMax)
+
+	r := reader{r: bytes.NewReader(header), maxFrameSize: &maxFrameSize}
+	frame, err := r.ReadFrame()
+	if err != ErrFrameTooLarge {
+		t.Fatalf("expected ErrFrameTooLarge, got frame=%#v err=%v", frame, err)
+	}
+}
+
+// TestReadFrameAllowsUnlimitedWhenNegotiatedUnbounded verifies that a nil or
+// zero-valued maxFrameSize (frame_max negotiated as unlimited, or not yet
+// negotiated) does not reject frames, preserving prior behavior.
+func TestReadFrameAllowsUnlimitedWhenNegotiatedUnbounded(t *testing.T) {
+	header := make([]byte, 7)
+	header[0] = frameBody
+	binary.BigEndian.PutUint16(header[1:3], 1)
+	binary.BigEndian.PutUint32(header[3:7], 3)
+
+	buf := append(header, []byte("abc")...)
+	buf = append(buf, frameEnd)
+
+	r := reader{r: bytes.NewReader(buf)}
+	if _, err := r.ReadFrame(); err != nil {
+		t.Fatalf("expected no error with nil maxFrameSize, got: %v", err)
 	}
 }
 
@@ -43,7 +85,7 @@ func TestGoFuzzCrashers(t *testing.T) {
 	}
 
 	for idx, testStr := range testData {
-		r := reader{strings.NewReader(testStr)}
+		r := reader{r: strings.NewReader(testStr)}
 		frame, err := r.ReadFrame()
 		if err != nil && frame != nil {
 			t.Errorf("%d. frame is not nil: %#v err = %v", idx, frame, err)

--- a/read_test.go
+++ b/read_test.go
@@ -73,6 +73,30 @@ func TestReadFrameAllowsUnlimitedWhenNegotiatedUnbounded(t *testing.T) {
 	}
 }
 
+// TestReadFrameAllowsAnySizeWhenMaxFrameSizeIsZero verifies that a non-nil
+// maxFrameSize storing 0 (frame_max explicitly negotiated as unlimited, per
+// negotiateFrameSize when both client and server request 0) does not reject
+// frames, regardless of declared size.
+func TestReadFrameAllowsAnySizeWhenMaxFrameSizeIsZero(t *testing.T) {
+	const declaredSize = 1 << 20 // far larger than any realistic negotiated frame_max
+
+	header := make([]byte, 7)
+	header[0] = frameBody
+	binary.BigEndian.PutUint16(header[1:3], 1)
+	binary.BigEndian.PutUint32(header[3:7], declaredSize)
+
+	payload := make([]byte, declaredSize)
+	buf := append(header, payload...)
+	buf = append(buf, frameEnd)
+
+	var maxFrameSize atomic.Uint32 // zero value: unlimited
+
+	r := reader{r: bytes.NewReader(buf), maxFrameSize: &maxFrameSize}
+	if _, err := r.ReadFrame(); err != nil {
+		t.Fatalf("expected no error with maxFrameSize == 0, got: %v", err)
+	}
+}
+
 func TestGoFuzzCrashers(t *testing.T) {
 	if testing.Short() {
 		t.Skip("excessive allocation")

--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ package amqp091
 import (
 	"fmt"
 	"io"
+	"sync/atomic"
 	"time"
 )
 
@@ -66,6 +67,10 @@ var (
 	// ErrFrame is returned when the protocol frame cannot be read from the
 	// server, indicating an unsupported protocol or unsupported frame type.
 	ErrFrame = &Error{Code: FrameError, Reason: "frame could not be parsed"}
+
+	// ErrFrameTooLarge is returned when the server sends a frame whose
+	// declared size exceeds the frame_max negotiated during connection.tune.
+	ErrFrameTooLarge = &Error{Code: FrameError, Reason: "frame size exceeds negotiated frame_max"}
 
 	// ErrCommandInvalid is returned when the server sends an unexpected response
 	// to this requested message type. This indicates a bug in this client.
@@ -505,6 +510,12 @@ func updateChannel(f frame, channel *Channel) {
 
 type reader struct {
 	r io.Reader
+
+	// maxFrameSize, when non-nil, points at the connection's negotiated
+	// frame_max (total frame length, including header and frame-end byte).
+	// A nil pointer or a stored value of 0 means no limit is enforced,
+	// matching the pre-negotiation and explicitly-unlimited cases.
+	maxFrameSize *atomic.Uint32
 }
 
 type writer struct {


### PR DESCRIPTION
## Proposed Changes

A malicious or compromised broker could declare an oversized length in a frame header (e.g. within a basic.deliver content body frame) and force the client to allocate memory for it, bypassing the frame_max negotiated during connection.tune and enabling a memory-exhaustion DoS.

Track the negotiated frame_max in a new atomic Connection.maxFrameSize field, mirrored from Config.FrameSize once connection.tune completes, and check every incoming frame's declared size against it in reader.ReadFrame before dispatching to the type-specific parsers that allocate the payload buffer. Frames over the limit are rejected with ErrFrameTooLarge instead of being read.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
