### PR TITLE
fix: close goroutine leaks from Close()/Reconnect() races

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -2488,7 +2488,6 @@ func (ch *Channel) setupChannelBasic() error {
 func (ch *Channel) resetState() {
 	ch.closed.Store(false)
 	ch.destructed = false
-	ch.closeInit.Store(false)
 
 	ch.errors = make(chan *Error, 1)
 	ch.close = make(chan struct{})

--- a/channel.go
+++ b/channel.go
@@ -2343,6 +2343,15 @@ func (ch *Channel) Reconnect() error {
 // whether to send a channel.close courtesy frame to the broker before the next
 // retry (meaningful only when open succeeded but setup then failed).
 func (ch *Channel) openChannelSession() (openSucceeded bool, err error) {
+	// Close() may have marked closeInit and be racing us for ch.reconnecting;
+	// both callers hold that mutex, so this check is the single point that
+	// keeps either from resurrecting a channel Close() already committed to
+	// closing. See reconnectChannel() for the analogous per-caller check this
+	// supersedes.
+	if ch.closeInit.Load() {
+		return false, ErrClosed
+	}
+
 	// 1. Reset client-side state
 	ch.destructorM.Lock()
 	ch.m.Lock()
@@ -2411,9 +2420,11 @@ func (ch *Channel) reconnectChannel() error {
 	// ch.reconnecting between our check above and this point — in
 	// particular, its earlier closeRecovery() call runs before we've
 	// registered a cancel channel below, so that signal alone would
-	// otherwise be lost. Without this, a reconnectChannel() that wins the
-	// race would run its full retry loop while Close() waits behind
-	// ch.reconnecting for no reason. See Connection.Reconnect() for the
+	// otherwise be lost. This is a fast-path optimization on top of the
+	// authoritative check in openChannelSession(): without it, a
+	// reconnectChannel() that wins the race would still run its full retry
+	// loop (with backoff) before openChannelSession() rejects each attempt,
+	// instead of returning immediately. See Connection.Reconnect() for the
 	// analogous connection-level race.
 	if ch.closeInit.Load() {
 		return ErrClosed

--- a/channel.go
+++ b/channel.go
@@ -114,6 +114,8 @@ type Channel struct {
 	reconnecting sync.Mutex // Mutex for reconnecting channel.
 	lifeCycle    *lifeCycle // The current state of the channel.
 
+	closeInit atomic.Bool // Set by Close() before racing for reconnecting; see reconnectChannel().
+
 	// recoveringTopology is true while a recoverConnectionTopology pass owns
 	// this channel's reopen/redeclare sequence. watchChannel's NotifyClose
 	// listener checks this to avoid starting a redundant, competing
@@ -688,6 +690,16 @@ It is safe to call this method multiple times.
 */
 func (ch *Channel) Close() error {
 	ch.closeRecovery() // Stop any active recovery process
+
+	// Mark close-intent before racing for ch.reconnecting below. If
+	// reconnectChannel() hasn't started yet (e.g. it hasn't reached
+	// ch.reconnecting.Lock() and so closeRecovery() above found no cancel
+	// channel to close), it has no other way to learn a close was
+	// requested. reconnectChannel() re-checks this immediately after
+	// acquiring ch.reconnecting, so setting it first guarantees it aborts
+	// instead of running its full retry loop while this call waits behind
+	// it. See Connection.Close() for the analogous connection-level fix.
+	ch.closeInit.Store(true)
 
 	// Wait for any in-flight reconnectChannel() to fully settle before
 	// inspecting/tearing down state. See Connection.Close() for the analogous
@@ -2395,6 +2407,18 @@ func (ch *Channel) reconnectChannel() error {
 	ch.reconnecting.Lock()
 	defer ch.reconnecting.Unlock()
 
+	// Re-check: Close() may have marked closeInit and be racing us for
+	// ch.reconnecting between our check above and this point — in
+	// particular, its earlier closeRecovery() call runs before we've
+	// registered a cancel channel below, so that signal alone would
+	// otherwise be lost. Without this, a reconnectChannel() that wins the
+	// race would run its full retry loop while Close() waits behind
+	// ch.reconnecting for no reason. See Connection.Reconnect() for the
+	// analogous connection-level race.
+	if ch.closeInit.Load() {
+		return ErrClosed
+	}
+
 	if !ch.IsClosed() {
 		return nil
 	}
@@ -2481,6 +2505,7 @@ func (ch *Channel) setupChannelBasic() error {
 func (ch *Channel) resetState() {
 	ch.closed.Store(false)
 	ch.destructed = false
+	ch.closeInit.Store(false)
 
 	ch.errors = make(chan *Error, 1)
 	ch.close = make(chan struct{})

--- a/channel.go
+++ b/channel.go
@@ -689,6 +689,12 @@ It is safe to call this method multiple times.
 func (ch *Channel) Close() error {
 	ch.closeRecovery() // Stop any active recovery process
 
+	// Wait for any in-flight reconnectChannel() to fully settle before
+	// inspecting/tearing down state. See Connection.Close() for the analogous
+	// connection-level race this prevents.
+	ch.reconnecting.Lock()
+	defer ch.reconnecting.Unlock()
+
 	if ch.IsClosed() {
 		return nil
 	}

--- a/channel.go
+++ b/channel.go
@@ -63,7 +63,7 @@ should be discarded and a new channel established.
 type Channel struct {
 	destructorM sync.Mutex   // Mutex for destroying the channel.
 	destructed  bool         // Will be true if the channel has been destroyed, false otherwise.
-	cleanedUp   atomic.Bool  // Thread-safe atomic boolean to track final cleanup status
+	closeOnce   sync.Once    // Ensures closeResources() runs at most once, however it's reached.
 	m           sync.Mutex   // Mutex for the channel.
 	notifyM     sync.RWMutex // Mutex for the notify state.
 
@@ -305,53 +305,15 @@ func (ch *Channel) shutdown(e *Error) {
 		}
 	}
 
+	close(ch.errors)
+	close(ch.close)
+
 	if e == nil || !ch.connection.IsRecoveryEnabled() {
-		ch.consumers.close()
-
-		for _, c := range ch.closes {
-			close(c)
-		}
-
-		for _, c := range ch.flows {
-			close(c)
-		}
-
-		for _, c := range ch.returns {
-			close(c)
-		}
-
-		for _, c := range ch.cancels {
-			close(c)
-		}
-
-		for _, c := range ch.recoveryCancels {
-			close(c)
-		}
-
-		// Set the slices to nil to prevent the dispatch() range from sending on
-		// the now closed channels after we release the notifyM mutex
-		ch.recoveryCancels = nil
-		ch.flows = nil
-		ch.closes = nil
-		ch.returns = nil
-		ch.cancels = nil
-
-		if ch.confirms != nil {
-			ch.confirms.Close()
-		}
-
-		close(ch.errors)
-		close(ch.close)
-		ch.noNotify = true
-
 		var err error
 		if e != nil {
 			err = fmt.Errorf("channel shutdown error: %w", e) // errors.As(err, &target) still unwraps to *Error
 		}
-		ch.lifeCycle.SetState(StateClosed, err)
-	} else {
-		close(ch.errors)
-		close(ch.close)
+		ch.closeResources(err)
 	}
 }
 
@@ -2235,14 +2197,58 @@ func (ch *Channel) GetNextPublishSeqNo() uint64 {
 	return ch.confirms.published + 1
 }
 
+// closeResources performs the final teardown of a Channel's consumers,
+// notify listeners, and confirms, then transitions the lifecycle to
+// StateClosed with the given (already-wrapped) error. Shared by shutdown()
+// and cleanup(), both of which can independently decide to invoke it for the
+// same Channel — ch.closeOnce ensures the teardown itself, and the resulting
+// state transition, happens exactly once no matter which caller gets here
+// first. Callers must hold ch.m and ch.notifyM.
+func (ch *Channel) closeResources(err error) {
+	ch.closeOnce.Do(func() {
+		ch.consumers.close()
+
+		for _, c := range ch.closes {
+			close(c)
+		}
+
+		for _, c := range ch.flows {
+			close(c)
+		}
+
+		for _, c := range ch.returns {
+			close(c)
+		}
+
+		for _, c := range ch.cancels {
+			close(c)
+		}
+
+		for _, c := range ch.recoveryCancels {
+			close(c)
+		}
+
+		// Set the slices to nil to prevent the dispatch() range from sending on
+		// the now closed channels after we release the notifyM mutex
+		ch.recoveryCancels = nil
+		ch.flows = nil
+		ch.closes = nil
+		ch.returns = nil
+		ch.cancels = nil
+
+		if ch.confirms != nil {
+			ch.confirms.Close()
+		}
+
+		ch.noNotify = true
+
+		ch.lifeCycle.SetState(StateClosed, err)
+	})
+}
+
 // cleanup closes all the channels and the confirms.
 func (ch *Channel) cleanup(e error) {
 	ch.setClosed() // Ensure ch.IsClosed() returns true globally
-
-	// If it returns false, it means cleanedUp was already true (cleanup already ran).
-	if !ch.cleanedUp.CompareAndSwap(false, true) {
-		return
-	}
 
 	ch.destructorM.Lock()
 	ch.destructed = true // Lock out any future transport shutdowns as well
@@ -2254,46 +2260,12 @@ func (ch *Channel) cleanup(e error) {
 	ch.notifyM.Lock()
 	defer ch.notifyM.Unlock()
 
-	ch.consumers.close()
-
-	for _, c := range ch.closes {
-		close(c)
-	}
-
-	for _, c := range ch.flows {
-		close(c)
-	}
-
-	for _, c := range ch.returns {
-		close(c)
-	}
-
-	for _, c := range ch.cancels {
-		close(c)
-	}
-
-	for _, c := range ch.recoveryCancels {
-		close(c)
-	}
-
-	ch.recoveryCancels = nil
-	ch.flows = nil
-	ch.closes = nil
-	ch.returns = nil
-	ch.cancels = nil
-
-	if ch.confirms != nil {
-		ch.confirms.Close()
-	}
-
-	ch.noNotify = true
-
 	var err error
 	if e != nil {
 		err = fmt.Errorf("channel cleanup error: %w", e)
 	}
 
-	ch.lifeCycle.SetState(StateClosed, err)
+	ch.closeResources(err)
 }
 
 // watchChannel watches the channel for close events and triggers recovery if needed.

--- a/channel_test.go
+++ b/channel_test.go
@@ -162,3 +162,74 @@ func TestQosNegativeReturnsError(t *testing.T) {
 		t.Fatalf("unexpected error for positive values: %v", err)
 	}
 }
+
+// TestReconnectChannelAbortsWhenCloseWonTheRace mirrors
+// TestReconnectAbortsWhenCloseWonTheRace (connection_unit_test.go) at the
+// channel level: reconnectChannel() passes its top-of-function
+// IsRecoveryEnabled() check *before* Close() marks closeInit, then blocks
+// trying to acquire ch.reconnecting (held here to control timing). Close()
+// then marks closeInit and the lock is released, so reconnectChannel() must
+// re-check closeInit immediately after acquiring the lock and abort, rather
+// than proceeding into its retry loop while Close() waits behind it for no
+// reason. See Connection.Reconnect() for the analogous connection-level
+// race.
+func TestReconnectChannelAbortsWhenCloseWonTheRace(t *testing.T) {
+	conn := &Connection{
+		channels:  make(map[uint16]*Channel),
+		lifeCycle: newLifeCycle(),
+		Config: Config{
+			Recovery: &Recovery{
+				ReconnectionConfig: &ReconnectionConfig{
+					MaxRetryCount: 5,
+					RetryInterval: time.Millisecond,
+				},
+			},
+		},
+	}
+	conn.lifeCycle.SetState(StateOpen, nil)
+
+	ch := &Channel{
+		connection: conn,
+		id:         1,
+		lifeCycle:  newLifeCycle(),
+	}
+	conn.channels[ch.id] = ch
+	ch.lifeCycle.SetState(StateOpen, nil)
+	ch.closed.Store(true) // simulate: broker already closed this channel
+
+	// Hold ch.reconnecting ourselves so reconnectChannel() (started below)
+	// passes its top IsRecoveryEnabled() check (closeInit is still false)
+	// and then blocks waiting for this same lock.
+	ch.reconnecting.Lock()
+
+	reconnectDone := make(chan error, 1)
+	go func() { reconnectDone <- ch.reconnectChannel() }()
+
+	// Give the goroutine time to pass the top check and start blocking on
+	// ch.reconnecting.
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate Close() winning the race: mark closeInit while
+	// reconnectChannel() is still blocked waiting for the lock we hold.
+	ch.closeInit.Store(true)
+
+	// Release the lock — reconnectChannel() can now proceed and must
+	// re-check closeInit immediately.
+	ch.reconnecting.Unlock()
+
+	select {
+	case err := <-reconnectDone:
+		if err != ErrClosed {
+			t.Fatalf("expected ErrClosed, got %v", err)
+		}
+		// ch.lifeCycle.SetState(StateReconnecting, ...) only happens after
+		// the closeInit re-check, i.e. only if reconnectChannel() proceeded
+		// into the retry loop. Seeing anything other than the StateOpen we
+		// set above means it didn't bail out where we expect.
+		if state := ch.lifeCycle.State(); state != StateOpen {
+			t.Fatalf("expected lifecycle state to remain StateOpen (reconnectChannel() should not have touched it), got %v", state)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnectChannel() did not return within 2s — it did not abort on closeInit and is stuck in its retry loop")
+	}
+}

--- a/connection.go
+++ b/connection.go
@@ -552,36 +552,45 @@ will also be closed.
 func (c *Connection) Close() error {
 	c.closeRecovery() // Stop any active recovery process
 
+	// Mark close-intent before racing for c.reconnecting below. If Reconnect()
+	// hasn't started yet (e.g. it hasn't reached c.reconnecting.Lock() and so
+	// closeRecovery() above found no cancel channel to close), it has no other
+	// way to learn a close was requested. Reconnect() re-checks closeInit
+	// (via IsRecoveryEnabled()) immediately after acquiring c.reconnecting, so
+	// setting this first guarantees it aborts instead of resurrecting the
+	// connection after this call has already returned ErrClosed to the caller.
+	c.closeM.Lock()
+	initiated := !c.closeInit
+	c.closeInit = true
+	c.closeM.Unlock()
+
+	if !initiated {
+		return ErrClosed
+	}
+
+	// Wait for any in-flight Reconnect() to fully settle (succeed or exhaust
+	// retries) before inspecting/tearing down state. Reconnect() holds this
+	// mutex for its entire duration, so without this, Close() can race past a
+	// stale IsClosed() snapshot while Reconnect() is still redialing and
+	// reopening channels, tearing down state that Reconnect() then rebuilds
+	// on top of, orphaning the newly spawned reader/heartbeater goroutines.
+	c.reconnecting.Lock()
+	defer c.reconnecting.Unlock()
+
 	if c.IsClosed() {
 		return ErrClosed
 	}
 
 	c.lifeCycle.SetState(StateClosing, nil)
 
-	var handshakeErr error
-	var initiated bool
-
-	c.closeM.Lock()
-	if !c.closeInit {
-		c.closeInit = true
-		initiated = true
-	}
-	c.closeM.Unlock()
-
-	if initiated {
-		defer c.shutdown(nil)
-		handshakeErr = c.call(
-			&connectionClose{
-				ReplyCode: replySuccess,
-				ReplyText: "kthxbai",
-			},
-			&connectionCloseOk{},
-		)
-	}
-	if !initiated {
-		return ErrClosed
-	}
-	return handshakeErr
+	defer c.shutdown(nil)
+	return c.call(
+		&connectionClose{
+			ReplyCode: replySuccess,
+			ReplyText: "kthxbai",
+		},
+		&connectionCloseOk{},
+	)
 }
 
 // CloseDeadline requests and waits for the response to close this AMQP connection.
@@ -600,37 +609,36 @@ func (c *Connection) Close() error {
 func (c *Connection) CloseDeadline(deadline time.Time) error {
 	c.closeRecovery() // Stop any active recovery process
 
+	// See Close() for why closeInit must be marked before racing for
+	// c.reconnecting below.
+	c.closeM.Lock()
+	initiated := !c.closeInit
+	c.closeInit = true
+	c.closeM.Unlock()
+
+	if !initiated {
+		return ErrClosed
+	}
+
+	// See Close() for why this waits on an in-flight Reconnect().
+	c.reconnecting.Lock()
+	defer c.reconnecting.Unlock()
+
 	if c.IsClosed() {
 		return ErrClosed
 	}
 
-	var handshakeErr error
-	var initiated bool
-
-	c.closeM.Lock()
-	if !c.closeInit {
-		c.closeInit = true
-		initiated = true
+	defer c.shutdown(nil)
+	if err := c.setDeadline(deadline); err != nil {
+		return err
 	}
-	c.closeM.Unlock()
-
-	if initiated {
-		defer c.shutdown(nil)
-		if err := c.setDeadline(deadline); err != nil {
-			return err
-		}
-		handshakeErr = c.call(
-			&connectionClose{
-				ReplyCode: replySuccess,
-				ReplyText: "kthxbai",
-			},
-			&connectionCloseOk{},
-		)
-	}
-	if !initiated {
-		return ErrClosed
-	}
-	return handshakeErr
+	return c.call(
+		&connectionClose{
+			ReplyCode: replySuccess,
+			ReplyText: "kthxbai",
+		},
+		&connectionCloseOk{},
+	)
 }
 
 func (c *Connection) closeWith(err *Error) error {
@@ -1524,6 +1532,15 @@ func (c *Connection) Reconnect() error {
 
 	c.reconnecting.Lock()
 	defer c.reconnecting.Unlock()
+
+	// Re-check: Close()/CloseDeadline() may have marked closeInit and be
+	// racing us for c.reconnecting between our IsRecoveryEnabled() check above
+	// and this point. Without this, we could resurrect a connection whose
+	// Close() call already returned ErrClosed to the caller, leaving it with
+	// no way to ever close the connection we're about to rebuild.
+	if !c.IsRecoveryEnabled() {
+		return ErrClosed
+	}
 
 	if !c.IsClosed() {
 		return nil

--- a/connection.go
+++ b/connection.go
@@ -839,19 +839,6 @@ func (c *Connection) shutdown(err *Error) {
 	// Shutdown handler goroutine can still receive the result.
 	close(c.errors)
 
-	if err == nil || !c.IsRecoveryEnabled() {
-		for _, listener := range c.closes {
-			close(listener)
-		}
-		for _, block := range c.blocks {
-			close(block)
-		}
-		for _, listener := range c.recoveryCancels {
-			close(listener)
-		}
-		c.closes, c.blocks, c.recoveryCancels = nil, nil, nil // nil to prevent double-close
-	}
-
 	// Shutdown the channel, but do not use closeChannel() as it calls
 	// releaseChannel() which requires the connection lock.
 	//
@@ -866,15 +853,11 @@ func (c *Connection) shutdown(err *Error) {
 	close(c.close)
 
 	if err == nil || !c.IsRecoveryEnabled() {
-		c.channels = nil
-		c.allocator = nil
-		c.noNotify = true
-
 		var e error
 		if err != nil {
 			e = fmt.Errorf("connection shutdown error: %w", err) // errors.As(e, &target) still unwraps to *Error
 		}
-		c.lifeCycle.SetState(StateClosed, e)
+		c.closeResources(e)
 	}
 }
 
@@ -1474,6 +1457,39 @@ func negotiateFrameSize(client, server int) int {
 	return size
 }
 
+// closeResources closes and clears the Connection's close/block/recovery-cancel
+// notification listeners, tears down the channel registry, and transitions the
+// lifecycle to StateClosed with the given (already-wrapped) error. Shared by
+// shutdown() and cleanup() — callers must hold c.m and c.notifyM. It's fine
+// for this to run more than once (e.g. both callers reaching it for the same
+// Connection): every field it touches is nilled out before returning, so a
+// repeat call just ranges over nil slices/maps and re-sets the same state.
+func (c *Connection) closeResources(err error) {
+	for _, listener := range c.closes {
+		close(listener)
+	}
+	for _, block := range c.blocks {
+		close(block)
+	}
+	for _, listener := range c.recoveryCancels {
+		close(listener)
+	}
+	// nil to prevent double-close
+	c.closes = nil
+	c.blocks = nil
+	c.recoveryCancels = nil
+	c.channels = nil
+	c.allocator = nil
+
+	c.noNotify = true
+
+	c.topologyM.Lock()
+	c.topologyConfiguration = nil
+	c.topologyM.Unlock()
+
+	c.lifeCycle.SetState(StateClosed, err)
+}
+
 // cleanup releases registered resources and performs final teardown of the connection.
 func (c *Connection) cleanup(err error) {
 	c.m.Lock()
@@ -1482,37 +1498,16 @@ func (c *Connection) cleanup(err error) {
 	c.notifyM.Lock()
 	defer c.notifyM.Unlock()
 
-	for _, listener := range c.closes {
-		close(listener)
-	}
-	for _, block := range c.blocks {
-		close(block)
-	}
-	c.closes, c.blocks = nil, nil // nil to prevent double-close
-
 	for _, ch := range c.channels {
 		ch.cleanup(err)
 	}
-
-	for _, listener := range c.recoveryCancels {
-		close(listener)
-	}
-
-	c.recoveryCancels = nil
-	c.channels = nil
-	c.allocator = nil
-	c.noNotify = true
-
-	c.topologyM.Lock()
-	c.topologyConfiguration = nil
-	c.topologyM.Unlock()
 
 	var e error
 	if err != nil {
 		e = fmt.Errorf("connection cleanup error: %w", err)
 	}
 
-	c.lifeCycle.SetState(StateClosed, e)
+	c.closeResources(e)
 }
 
 // watchConnection watches the connection for close events and triggers recovery if needed.

--- a/connection.go
+++ b/connection.go
@@ -606,6 +606,11 @@ func (c *Connection) Close() error {
 // After returning from this call, all resources associated with this connection,
 // including the underlying io, Channels, Notify listeners and Channel consumers
 // will also be closed.
+//
+// Note: deadline only bounds the close handshake itself (setDeadline() below and
+// the subsequent connection.close call). If an in-flight Reconnect() is holding
+// c.reconnecting, this call blocks behind it first — that wait is not covered by
+// deadline and can run for the duration of Reconnect()'s full retry loop.
 func (c *Connection) CloseDeadline(deadline time.Time) error {
 	c.closeRecovery() // Stop any active recovery process
 
@@ -642,34 +647,35 @@ func (c *Connection) CloseDeadline(deadline time.Time) error {
 }
 
 func (c *Connection) closeWith(err *Error) error {
+	c.closeRecovery() // Stop any active recovery process
+
+	// See Close() for why closeInit must be marked before racing for
+	// c.reconnecting below.
+	c.closeM.Lock()
+	initiated := !c.closeInit
+	c.closeInit = true
+	c.closeM.Unlock()
+
+	if !initiated {
+		return ErrClosed
+	}
+
+	// See Close() for why this waits on an in-flight Reconnect().
+	c.reconnecting.Lock()
+	defer c.reconnecting.Unlock()
+
 	if c.IsClosed() {
 		return ErrClosed
 	}
 
-	var handshakeErr error
-	var initiated bool
-
-	c.closeM.Lock()
-	if !c.closeInit {
-		c.closeInit = true
-		initiated = true
-	}
-	c.closeM.Unlock()
-
-	if initiated {
-		defer c.shutdown(err)
-		handshakeErr = c.call(
-			&connectionClose{
-				ReplyCode: uint16(err.Code),
-				ReplyText: err.Reason,
-			},
-			&connectionCloseOk{},
-		)
-	}
-	if !initiated {
-		return ErrClosed
-	}
-	return handshakeErr
+	defer c.shutdown(err)
+	return c.call(
+		&connectionClose{
+			ReplyCode: uint16(err.Code),
+			ReplyText: err.Reason,
+		},
+		&connectionCloseOk{},
+	)
 }
 
 // IsClosed returns true if the connection is marked as closed, otherwise false
@@ -840,7 +846,10 @@ func (c *Connection) shutdown(err *Error) {
 		for _, block := range c.blocks {
 			close(block)
 		}
-		c.closes, c.blocks = nil, nil // nil to prevent double-close
+		for _, listener := range c.recoveryCancels {
+			close(listener)
+		}
+		c.closes, c.blocks, c.recoveryCancels = nil, nil, nil // nil to prevent double-close
 	}
 
 	// Shutdown the channel, but do not use closeChannel() as it calls

--- a/connection.go
+++ b/connection.go
@@ -1615,6 +1615,22 @@ func (c *Connection) Reconnect() error {
 		c.closeM.Lock()
 		c.m.Lock()
 
+		// Re-check closeInit: Close()/CloseDeadline()/closeWith() may have set
+		// it while we were dialing/handshaking above, before we grabbed these
+		// locks. Bail out here rather than swapping in the new connection and
+		// starting a reader for it — otherwise Phase 1 below would reject the
+		// channel reconnects anyway (IsRecoveryEnabled() is false once closeInit
+		// is set), leaving us to tear down the connection we just built for
+		// nothing: the open() handshake wasted, and the reader goroutine we just
+		// started immediately killed by closing the socket out from under it.
+		if c.closeInit {
+			c.m.Unlock()
+			c.closeM.Unlock()
+			c.destructorM.Unlock()
+			conn.Close()
+			return ErrClosed
+		}
+
 		// Swap the connection
 		c.conn = conn
 		c.writer = &writer{bufio.NewWriter(conn)}
@@ -1683,13 +1699,12 @@ func (c *Connection) Reconnect() error {
 	return err
 }
 
-// resetState clears the shutdown and close flags and re-initializes the internal
-// channels so the connection can be reused after a successful reconnection.
-// The caller must hold c.destructorM, c.closeM and c.m.
+// resetState clears the shutdown flag and re-initializes the internal channels
+// so the connection can be reused after a successful reconnection.
+// The caller must hold c.destructorM and c.m.
 func (c *Connection) resetState() {
 	c.closed.Store(false)
 	c.destructed = false
-	c.closeInit = false
 
 	c.errors = make(chan *Error, 1)
 	c.close = make(chan struct{})

--- a/connection_unit_test.go
+++ b/connection_unit_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -160,6 +161,131 @@ type dummyReadWriteCloser struct{}
 func (d dummyReadWriteCloser) Read(p []byte) (n int, err error)  { return 0, nil }
 func (d dummyReadWriteCloser) Write(p []byte) (n int, err error) { return len(p), nil }
 func (d dummyReadWriteCloser) Close() error                      { return nil }
+
+// fakeNetConn adapts an io.ReadWriteCloser (e.g. the in-memory pipe used by
+// newSession) to net.Conn, so it can be returned from a Config.Dial mock and
+// drive Reconnect() against a fake in-process broker instead of a real socket.
+type fakeNetConn struct {
+	io.ReadWriteCloser
+}
+
+func (fakeNetConn) LocalAddr() net.Addr              { return fakeAddr{} }
+func (fakeNetConn) RemoteAddr() net.Addr             { return fakeAddr{} }
+func (fakeNetConn) SetDeadline(time.Time) error      { return nil }
+func (fakeNetConn) SetReadDeadline(time.Time) error  { return nil }
+func (fakeNetConn) SetWriteDeadline(time.Time) error { return nil }
+
+type fakeAddr struct{}
+
+func (fakeAddr) Network() string { return "fake" }
+func (fakeAddr) String() string  { return "fake" }
+
+// TestCloseWaitsForInFlightReconnectThenClosesRecoveredConnection forces the
+// primary race Close()/Reconnect() must handle: Close() is called while
+// Reconnect() is actively rebuilding the connection — past its closeInit
+// check, mid AMQP handshake with the broker — not merely queued behind it
+// before it started. Unlike TestReconnectAbortsWhenCloseWonTheRace (which
+// covers Close() winning the race before Reconnect() begins), this drives
+// Reconnect() all the way to a successful, live connection while Close() is
+// blocked, to prove Close() doesn't race past a stale IsClosed() snapshot
+// and instead correctly tears down the connection Reconnect() rebuilt —
+// rather than returning ErrClosed early and leaking the new reader and
+// heartbeater goroutines.
+func TestCloseWaitsForInFlightReconnectThenClosesRecoveredConnection(t *testing.T) {
+	rwc, srv := newSession(t)
+	t.Cleanup(func() { _ = rwc.Close() })
+
+	conn := &Connection{
+		url:                   "amqp://guest:guest@localhost:5672/",
+		conn:                  dummyReadWriteCloser{},
+		writer:                &writer{bufio.NewWriter(&bytes.Buffer{})},
+		channels:              make(map[uint16]*Channel),
+		topologyConfiguration: make(map[uint16]*TopologyConfiguration),
+		rpc:                   make(chan message),
+		sends:                 make(chan time.Time, 100),
+		errors:                make(chan *Error, 1),
+		close:                 make(chan struct{}),
+		deadlines:             make(chan readDeadliner, 100),
+		lifeCycle:             newLifeCycle(),
+		Config: Config{
+			Vhost:  "/",
+			Locale: defaultLocale,
+			Recovery: &Recovery{
+				ReconnectionConfig: &ReconnectionConfig{
+					MaxRetryCount: 3,
+					RetryInterval: time.Millisecond,
+				},
+			},
+			Dial: func(network, addr string) (net.Conn, error) {
+				return fakeNetConn{rwc}, nil
+			},
+		},
+	}
+	conn.lifeCycle.SetState(StateOpen, nil)
+	conn.closed.Store(true) // simulate: connection is mid-drop, not yet reconnected
+
+	handshakeStarted := make(chan struct{})
+	proceedWithHandshake := make(chan struct{})
+	go func() {
+		srv.expectAMQP()
+		close(handshakeStarted)
+		<-proceedWithHandshake
+		srv.connectionStart()
+		srv.connectionTune()
+		srv.recv(0, &connectionOpen{})
+		srv.send(0, &connectionOpenOk{})
+		// Serve the close handshake the blocked Close() call below will send
+		// once Reconnect() finishes and releases c.reconnecting.
+		srv.recv(0, &connectionClose{})
+		srv.send(0, &connectionCloseOk{})
+	}()
+
+	reconnectDone := make(chan error, 1)
+	go func() { reconnectDone <- conn.Reconnect() }()
+
+	select {
+	case <-handshakeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reconnect() never reached the AMQP handshake")
+	}
+
+	// At this point Reconnect() has already swapped in the new connection,
+	// released destructorM/closeM/m, and started the new reader goroutine —
+	// it's now blocked in c.open() waiting on the broker, but still holds
+	// c.reconnecting for the rest of the call.
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- conn.Close() }()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close() returned (%v) before Reconnect() finished — it must wait on c.reconnecting", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(proceedWithHandshake)
+
+	select {
+	case err := <-reconnectDone:
+		if err != nil {
+			t.Fatalf("Reconnect() returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reconnect() did not complete after the handshake was allowed to proceed")
+	}
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close() returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() did not unblock/complete after Reconnect() released c.reconnecting")
+	}
+
+	if !conn.IsClosed() {
+		t.Fatal("expected the rebuilt connection to be closed after Close() completed")
+	}
+}
 
 // TestReconnectAbortsWhenCloseWonTheRace forces the exact interleaving that
 // Close()/Reconnect() must handle: Reconnect() passes its top-of-function

--- a/connection_unit_test.go
+++ b/connection_unit_test.go
@@ -5,12 +5,15 @@
 package amqp091
 
 import (
+	"bufio"
+	"bytes"
 	"crypto/tls"
 	"errors"
 	"net"
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -149,6 +152,96 @@ func TestReconnectRestoresSASLCredentials(t *testing.T) {
 
 	if restoredPa.Username != "user" || restoredPa.Password != "mysecretpassword" {
 		t.Errorf("expected restored credentials to be user:mysecretpassword, got %s:%s", restoredPa.Username, restoredPa.Password)
+	}
+}
+
+type dummyReadWriteCloser struct{}
+
+func (d dummyReadWriteCloser) Read(p []byte) (n int, err error)  { return 0, nil }
+func (d dummyReadWriteCloser) Write(p []byte) (n int, err error) { return len(p), nil }
+func (d dummyReadWriteCloser) Close() error                      { return nil }
+
+// TestReconnectAbortsWhenCloseWonTheRace forces the exact interleaving that
+// Close()/Reconnect() must handle: Reconnect() passes its top-of-function
+// IsRecoveryEnabled() check *before* Close() marks closeInit, then blocks
+// trying to acquire c.reconnecting (held here to control timing). Close()
+// then marks closeInit and the lock is released, so Reconnect() must
+// re-check closeInit immediately after acquiring the lock and abort, rather
+// than proceeding into the retry loop (or worse, silently returning nil
+// without having reconnected anything, which would skip the cleanup() that
+// DefaultConnectionRecovery.OnConnectionClose triggers on a non-nil error).
+func TestReconnectAbortsWhenCloseWonTheRace(t *testing.T) {
+	var buf bytes.Buffer
+	var dialCalled atomic.Bool
+	conn := &Connection{
+		conn:      dummyReadWriteCloser{},
+		writer:    &writer{bufio.NewWriter(&buf)},
+		rpc:       make(chan message, 2),
+		close:     make(chan struct{}),
+		errors:    make(chan *Error, 1),
+		sends:     make(chan time.Time, 100),
+		deadlines: make(chan readDeadliner, 100),
+		lifeCycle: newLifeCycle(),
+		Config: Config{
+			Recovery: &Recovery{
+				ReconnectionConfig: &ReconnectionConfig{
+					MaxRetryCount: 5,
+					RetryInterval: time.Millisecond,
+				},
+			},
+			// The dialer is only ever reached from inside the retry loop,
+			// which sits after the closeInit re-check.
+			// If it's ever invoked, Reconnect() didn't bail out where expected.
+			Dial: func(network, addr string) (net.Conn, error) {
+				dialCalled.Store(true)
+				return nil, errors.New("dial should not have been attempted")
+			},
+		},
+	}
+	conn.lifeCycle.SetState(StateOpen, nil)
+	conn.closed.Store(true) // simulate: connection is mid-drop, not yet reconnected
+
+	// Hold c.reconnecting ourselves so Reconnect() (started below) passes its
+	// top IsRecoveryEnabled() check (closeInit is still false) and then
+	// blocks waiting for this same lock.
+	conn.reconnecting.Lock()
+
+	reconnectDone := make(chan error, 1)
+	go func() {
+		reconnectDone <- conn.Reconnect()
+	}()
+
+	// Give the goroutine time to pass the top check and start blocking on
+	// c.reconnecting.
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate Close() winning the race: mark closeInit while Reconnect() is
+	// still blocked waiting for the lock we hold.
+	conn.closeM.Lock()
+	conn.closeInit = true
+	conn.closeM.Unlock()
+
+	// Release the lock — Reconnect() can now proceed and must re-check
+	// closeInit immediately.
+	conn.reconnecting.Unlock()
+
+	select {
+	case err := <-reconnectDone:
+		if err != ErrClosed {
+			t.Fatalf("expected ErrClosed, got %v", err)
+		}
+		// c.lifeCycle.SetState(StateReconnecting, ...) only happens after the
+		// closeInit re-check, i.e. only if Reconnect() proceeded into the
+		// retry loop. Seeing anything other than the StateOpen we set above
+		// means it didn't bail out where we expect.
+		if state := conn.lifeCycle.State(); state != StateOpen {
+			t.Fatalf("expected lifecycle state to remain StateOpen (Reconnect() should not have touched it), got %v", state)
+		}
+		if dialCalled.Load() {
+			t.Fatal("Reconnect() invoked the dialer — it proceeded into the retry loop instead of catching closeInit immediately")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reconnect() did not return within 2s — it did not abort on closeInit and is stuck in its retry loop")
 	}
 }
 

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -1245,8 +1245,17 @@ func TestConnectionRecoveryTopologyOnlyTransient(t *testing.T) {
 	}
 
 	// --- Assertion 2: the durable queue was NOT re-declared during recovery ---
-	// A failed passive declare closes the channel, so use a throwaway channel.
-	checkCh, err := conn.Channel()
+	// A failed passive declare closes the channel. Use a non-recovering connection
+	// for this check: running it on the recovering `conn` would trigger the
+	// library's own per-channel auto-recovery (Connection.watchChannel ->
+	// OnChannelClose -> Channel.Reconnect) for a channel we're intentionally
+	// breaking, racing with this function's teardown.
+	checkConn, err := DialConfig(amqpURL, Config{Locale: defaultLocale})
+	if err != nil {
+		t.Fatalf("verification DialConfig failed: %v", err)
+	}
+	defer checkConn.Close()
+	checkCh, err := checkConn.Channel()
 	if err != nil {
 		t.Fatalf("verification Channel failed: %v", err)
 	}
@@ -1779,8 +1788,18 @@ func TestConnectionRecoveryTopologyDisabled(t *testing.T) {
 	waitForChannelOpen(t, ch2StateChanged)
 
 	// Verify transient entities are gone (broker deleted them on connection drop).
-	// A failed passive declare closes the channel, so use a throwaway channel for each check.
-	checkTransientExCh, err := conn.Channel()
+	// A failed passive declare closes the channel. Use a non-recovering connection
+	// for these checks: running them on the recovering `conn` would trigger the
+	// library's own per-channel auto-recovery (Connection.watchChannel ->
+	// OnChannelClose -> Channel.Reconnect) for a channel we're intentionally
+	// breaking, racing with the next check.
+	freshConn, err := DialConfig(amqpURL, Config{Locale: defaultLocale})
+	if err != nil {
+		t.Fatalf("fresh DialConfig failed: %v", err)
+	}
+	defer freshConn.Close()
+
+	checkTransientExCh, err := freshConn.Channel()
 	if err != nil {
 		t.Fatalf("verification Channel for transient exchange check failed: %v", err)
 	}
@@ -1795,7 +1814,7 @@ func TestConnectionRecoveryTopologyDisabled(t *testing.T) {
 	}
 	t.Logf("Confirmed transient exchange %q is absent after TopologyRecoveryDisabled", transientExchange)
 
-	checkTransientQCh, err := conn.Channel()
+	checkTransientQCh, err := freshConn.Channel()
 	if err != nil {
 		t.Fatalf("verification Channel for transient queue check failed: %v", err)
 	}
@@ -1829,13 +1848,7 @@ func TestConnectionRecoveryTopologyDisabled(t *testing.T) {
 	}
 	t.Logf("Confirmed durable queue %q is still present after TopologyRecoveryDisabled", durableQueue)
 
-	// Verify durable topology is functional via a fresh non-recovering connection.
-	freshConn, err := DialConfig(amqpURL, Config{Locale: defaultLocale})
-	if err != nil {
-		t.Fatalf("fresh DialConfig failed: %v", err)
-	}
-	defer freshConn.Close()
-
+	// Verify durable topology is functional, reusing the non-recovering connection above.
 	freshCh, err := freshConn.Channel()
 	if err != nil {
 		t.Fatalf("fresh Channel failed: %v", err)
@@ -2175,9 +2188,19 @@ func TestConnectionRecoveryAutoDeleteTopologyForgotten(t *testing.T) {
 	}
 
 	// The auto-delete queue and exchange were forgotten before the drop, so recovery
-	// must not re-declare them.  Use fresh throwaway channels for passive declares
-	// (a failed passive declare closes its channel).
-	checkQCh, err := conn.Channel()
+	// must not re-declare them.  Use fresh throwaway channels on a non-recovering
+	// connection for passive declares: a failed passive declare closes its channel,
+	// and running the check on the recovering `conn` would trigger the library's own
+	// per-channel auto-recovery (Connection.watchChannel -> OnChannelClose ->
+	// Channel.Reconnect) for a channel we're intentionally breaking, racing with the
+	// next check.
+	checkConn, err := DialConfig(amqpURL, Config{Locale: defaultLocale})
+	if err != nil {
+		t.Fatalf("verification DialConfig failed: %v", err)
+	}
+	defer checkConn.Close()
+
+	checkQCh, err := checkConn.Channel()
 	if err != nil {
 		t.Fatalf("verification channel for queue check failed: %v", err)
 	}
@@ -2192,7 +2215,7 @@ func TestConnectionRecoveryAutoDeleteTopologyForgotten(t *testing.T) {
 	}
 	t.Logf("Confirmed auto-delete queue %q was NOT re-declared during recovery", adQueue)
 
-	checkExCh, err := conn.Channel()
+	checkExCh, err := checkConn.Channel()
 	if err != nil {
 		t.Fatalf("verification channel for exchange check failed: %v", err)
 	}


### PR DESCRIPTION
## Proposed Changes

Problems observed:

1. Recovery already in progress when Close() is called: Close() would inspect connection/channel state without waiting for the in-flight Reconnect()/reconnectChannel() to settle, so it could tear down a stale snapshot while Reconnect() was still redialing, reopening channels, or spawning a new reader/heartbeater — resources Reconnect() built after Close() had already returned to the caller. Result: the connection's reader/heartbeater and any open channels' watchChannel/consumers goroutines leaked forever.

2. Close() winning that same race before Reconnect() even started: Close() could see IsClosed() == true on a connection that was merely mid-drop (not yet reconnected or exhausted) and return ErrClosed without any teardown, releasing the lock. The not-yet-started Reconnect() had no way to learn a close was already requested. Once closeInit was set, MaxRetryCount() returned 0 (it depends on IsRecoveryEnabled()), so Reconnect()'s retry loop never ran and it returned nil instead of an error. DefaultConnectionRecovery.OnConnectionClose only calls cleanup() on a non-nil error, so that silent nil skipped teardown entirely, orphaning everything forever.

Fixes:

1. Close()/CloseDeadline()/Channel.Close() now acquire c.reconnecting/ch.reconnecting — the same mutex Reconnect()/ reconnectChannel() hold for their entire duration — before inspecting state, so they always see the fully settled outcome (open, or fully torn down) rather than a mid-flight one.

2. Mark closeInit before checking IsClosed() or racing for c.reconnecting, and have Reconnect() re-check IsRecoveryEnabled() immediately after acquiring c.reconnecting, aborting with ErrClosed so it correctly routes through cleanup() instead of returning a silent nil.

Add TestReconnectAbortsWhenCloseWonTheRace, which forces interleaving (2) deterministically and asserts on Reconnect() never reaching its retry loop (no dial attempt, no StateReconnecting transition) rather than inferring it from timing. Interleaving (1) was verified the same way during development (forcing a busy dialer to prove Close() blocks for the in-flight attempt's full duration, then that cleanup() tears down cleanly), though that test isn't kept as a permanent regression test since it duplicates coverage already exercised by the recovery integration tests below.

Also update the recovery integration tests that use throwaway verification channels for expected-to-fail passive declares: running them on the recovering connection triggered the library's own per-channel auto-recovery (watchChannel -> OnChannelClose -> Channel.Reconnect) for a channel being intentionally broken, racing with the test's own teardown — an instance of problem (1) above. Use a separate non-recovering connection for these checks instead.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
