### PR TITLE
fix: eliminate flakiness in TestTLSHandshake

### DIFF
--- a/tls_test.go
+++ b/tls_test.go
@@ -74,7 +74,7 @@ func (s *tlsServer) Serve(t *testing.T) {
 func startTLSServer(t *testing.T, cfg *tls.Config) tlsServer {
 	t.Helper()
 
-	l, err := tls.Listen("tcp", "127.0.0.1:3456", cfg)
+	l, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
 	if err != nil {
 		t.Fatalf("TLS server Listen error: %+v", err)
 	}
@@ -118,7 +118,7 @@ func TestTLSHandshake(t *testing.T) {
 
 	go func() {
 		select {
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(5 * time.Second):
 			errs <- errors.New("server timeout waiting for TLS handshake from client")
 		case session := <-srv.Sessions:
 			session.connectionOpen()


### PR DESCRIPTION
## Summary
- `TestTLSHandshake`'s server-side handshake wait used a 10ms timeout, which races against real TLS handshake latency instead of asserting anything meaningful. Under load, the handshake occasionally took longer than 10ms, failing the test spuriously.
- The test server also bound to a hardcoded port (`127.0.0.1:3456`), risking collisions with other processes.

## Fix
- Bumped the server-side handshake wait to 5s — this only affects the failure path (a genuinely hung/broken handshake), not normal passing runs.
- Bind to `127.0.0.1:0` so the OS assigns a free port.

## Test plan
- [x] Reproduced the flake locally by running 8 concurrent `go test -race -run TestTLSHandshake -count=1 .` invocations against the old code — one failed with `server timeout waiting for TLS handshake from client`.
- [x] Reran the same 8-way concurrent stress test with the fix — all 8 passed.
- [x] `go test -race -run TestTLSHandshake -v .` passes individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)