### PR TITLE
Fix auto-recovery correctness gaps

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -2444,8 +2444,13 @@ func (ch *Channel) reconnectChannel() error {
 				// gracefully close the broker-side session before the next attempt.
 				// channelClose must be sent before setClosed()
 				_ = ch.call(&channelClose{ReplyCode: replySuccess, ReplyText: "Recovery retry"}, &channelCloseOk{})
-				ch.setClosed()
 			}
+			// resetState() in openChannelSession() already flipped ch.closed
+			// to false for this attempt; restore it here on any failure
+			// (including open() itself failing, opened == false) so a
+			// concurrently-blocked Close() doesn't mistake the dead channel
+			// for a live one once reconnectChannel() gives up.
+			ch.setClosed()
 			continue
 		}
 

--- a/channel.go
+++ b/channel.go
@@ -2380,6 +2380,14 @@ func (ch *Channel) reopenIfClosed() {
 
 // reconnectChannel opens a fresh channel on the broker and performs basic setup (QoS, Confirms).
 // It does NOT recover the channel's topology.
+//
+// Applications must coordinate with in-progress recovery rather than calling into the
+// Channel unconditionally: register NotifyStateChange and hold off on new operations on
+// this Channel until state is StateOpen again. In order to reopen the channel, IsClosed()
+// will momentarily return false before the channel.open handshake actually completes — a
+// call made on this Channel in that window, without waiting for StateOpen, can interleave a
+// frame with the handshake and cause the broker to reject it as a protocol violation.
+// Waiting for StateOpen via NotifyStateChange before issuing new calls avoids this entirely.
 func (ch *Channel) reconnectChannel() error {
 	if !ch.connection.IsRecoveryEnabled() {
 		return ErrClosed

--- a/connection.go
+++ b/connection.go
@@ -1529,6 +1529,15 @@ func (c *Connection) watchConnection() {
 // and recovers both connection and channel states.
 // It performs a retry loop to dial the broker, negotiate the AMQP handshake, and recover all
 // active channels and their registered consumers sequentially.
+//
+// Applications must coordinate with in-progress recovery rather than calling into the
+// Connection unconditionally: register NotifyStateChange and hold off on new connection-level
+// calls (e.g. Channel(), UpdateSecret()) until state is StateOpen again. In order to initiate
+// the AMQP handshake below, IsClosed() will momentarily return false before c.open actually
+// completes it — a connection-level call made in that window, without waiting for StateOpen,
+// can interleave a frame with the handshake and cause the broker to reject it as a protocol
+// violation. Waiting for StateOpen via NotifyStateChange before issuing new connection-level
+// calls avoids this entirely.
 func (c *Connection) Reconnect() (err error) {
 	if !c.IsRecoveryEnabled() {
 		return ErrClosed

--- a/connection.go
+++ b/connection.go
@@ -1529,7 +1529,7 @@ func (c *Connection) watchConnection() {
 // and recovers both connection and channel states.
 // It performs a retry loop to dial the broker, negotiate the AMQP handshake, and recover all
 // active channels and their registered consumers sequentially.
-func (c *Connection) Reconnect() error {
+func (c *Connection) Reconnect() (err error) {
 	if !c.IsRecoveryEnabled() {
 		return ErrClosed
 	}
@@ -1550,11 +1550,26 @@ func (c *Connection) Reconnect() error {
 		return nil
 	}
 
+	// resetState() below flips c.closed to false mid-attempt so open() and
+	// channel recovery can send frames on the new connection. If this attempt
+	// then fails or is aborted, leaving c.closed false would let a
+	// concurrently-blocked Close() (which waits on c.reconnecting for us to
+	// settle) mistake the dead connection for a live one once we return.
+	// Guarantee the invariant here instead of at every failure/abort return
+	// site below: any non-nil return means the connection is closed. Registered
+	// only past the guard clauses above, so it can't fire for a connection
+	// that was never actually touched by this attempt (already open, or
+	// recovery disabled/closing).
+	defer func() {
+		if err != nil {
+			c.closed.Store(true)
+		}
+	}()
+
 	c.lifeCycle.SetState(StateReconnecting, nil)
 
 	cancelCh := c.NotifyRecoveryCancel(make(chan struct{}))
 
-	var err error
 	for i := 0; i < c.MaxRetryCount(); i++ {
 		Logger.Printf("Connection recovery attempt %d of %d", i+1, c.MaxRetryCount())
 		jitter := time.Duration(rand.Intn(500)) * time.Millisecond // Random 500ms jitter to avoid thundering herd
@@ -1694,7 +1709,6 @@ func (c *Connection) Reconnect() error {
 	if c.conn != nil {
 		c.conn.Close()
 	}
-	c.closed.Store(true)
 
 	return err
 }

--- a/connection.go
+++ b/connection.go
@@ -2502,6 +2502,15 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 					return skipped, fatal
 				}
 				ch.reopenIfClosed()
+
+				// basic.consume never reached the broker, so it will never send
+				// basic.cancel for this tag — synthesize the same local cleanup
+				// dispatch() does for a broker-initiated cancel, so the buffer
+				// goroutine and the caller's delivery channel don't leak forever.
+				ch.notifyM.RLock()
+				notifyAll(ch.cancels, tag)
+				ch.notifyM.RUnlock()
+				ch.consumers.cancel(tag)
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

Three fixes to the `Connection`/`Channel` automatic-recovery path:

- **`closed` state left stale after a failed recovery attempt.** `resetState()` optimistically flips `closed`/`ch.closed` to `false` mid-attempt so the internal handshake can send frames on the new socket/channel, but several failure and abort paths returned or `continue`d without restoring it to `true`. A `Close()`/`Channel.Close()` blocked waiting on the recovery attempt to settle would then read a stale `false` and try to run its close handshake against an already-dead socket instead of getting a clean `ErrClosed`. Fixed by guaranteeing the invariant via a `defer` in `Reconnect()` and by making `reconnectChannel()` call `setClosed()` on every failure branch, not just the "open succeeded but setup failed" one.

- **Consumers left dangling when topology recovery skips a failed resubscribe.** When `basic.consume` fails to re-establish a consumer during topology recovery and `OnTopologyEntityError` chooses to skip rather than abort, the broker never learns about that consumer tag, so it never sends `basic.cancel` — nothing closed the buffer goroutine or the caller's delivery channel. The consumer looked alive to the app but silently stopped receiving forever, leaking a goroutine for the connection's lifetime. Fixed by synthesizing the same local cleanup `dispatch()` performs for a broker-initiated cancel: firing `NotifyCancel` and calling `consumers.cancel(tag)`, so behavior matches real cancel semantics — the app is told the consumer is gone and must re-`Consume()`.

- **Documented a narrow handshake-window race.** `IsClosed()` momentarily reports `false` as soon as the new socket/channel is swapped in, before the AMQP handshake actually completes. A connection/channel-level call made unconditionally in that window can interleave a frame with the in-progress handshake and get rejected by the broker as a protocol violation. Rather than a deeper core-flow change (touching the shared send/call plumbing used by every public API), this is now documented on `Reconnect()`/`reconnectChannel()`: applications should register `NotifyStateChange` and hold off on new connection/channel-level calls until state is `StateOpen` again.


## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

