### PR TITLE
Retry consumer recovery instead of cancelling on a failed re-subscribe

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2504,14 +2504,37 @@ func (c *Connection) recoverConnectionTopology(channels []*Channel) ([]TopologyR
 				}
 				ch.reopenIfClosed()
 
-				// basic.consume never reached the broker, so it will never send
-				// basic.cancel for this tag — synthesize the same local cleanup
-				// dispatch() does for a broker-initiated cancel, so the buffer
-				// goroutine and the caller's delivery channel don't leak forever.
-				ch.notifyM.RLock()
-				notifyAll(ch.cancels, tag)
-				ch.notifyM.RUnlock()
-				ch.consumers.cancel(tag)
+				// Deliberately keep ch.consumers.configs[tag] and the caller's
+				// delivery channel intact, so a later recovery attempt can
+				// re-subscribe this consumer.
+				//
+				// configs is the only record this client has of a consumer (there
+				// is no recordConsumer counterpart to recordExchange/recordQueue/
+				// recordBinding) and it is the map this loop iterates, so cancelling
+				// here would erase the consumer from the client's own topology and no
+				// later attempt could retry it. One transient failure on one
+				// basic.consume would lose the consumer for the life of the
+				// connection while recovery reports success and the channel stays
+				// open. Keeping the record matches how steps 1-4 treat a failed
+				// entity: log, skip, keep the record, retry on the next attempt.
+				//
+				// It also matches the reference clients. Neither the Java nor the
+				// .NET client removes a recorded consumer when the recovery-time
+				// basic.consume fails: both report the failure through their topology
+				// recovery exception handler and leave the record in place, and the
+				// Java client has explicit retry machinery for exactly this case
+				// (TopologyRecoveryRetryLogic.RECOVER_CONSUMER). In both, the record
+				// is removed only on a client-initiated basic.cancel or on channel
+				// teardown. A broker-sent basic.cancel is a different event and is
+				// still handled as a cancellation, in dispatch().
+				//
+				// The leak that motivated the earlier cleanup here stays bounded:
+				// closeResources -> consumers.close() closes every remaining buffer
+				// channel and waits on the WaitGroup at channel teardown, and a
+				// successful re-subscribe on a later attempt reuses this same entry
+				// rather than creating a second one. The failure is reported to
+				// applications through SkippedTopologyEntities on the
+				// StateReconnecting -> StateOpen transition.
 			}
 		}
 	}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -2813,3 +2813,241 @@ waitOpen:
 	}
 	t.Logf("Channel settled after %d RecoverTopology call(s), no further calls over %v", firstCount, 3*notifyTimeout)
 }
+
+// blockingTopologyRecovery wraps DefaultTopologyRecovery and holds an exclusive
+// consumer on targetQueue for the duration of the recovery pass, so the
+// recovery-time basic.consume for that queue fails with 403 ACCESS_REFUSED.
+//
+// The blocker is taken immediately before the pass and released immediately
+// after, which makes the failure deterministic (no sleeps or timing windows) and
+// guarantees the obstruction is gone before any subsequent recovery attempt.
+// Anything that is still missing afterwards is missing because recovery forgot
+// it, not because the broker is still refusing.
+// RecoverTopology runs on an internal recovery goroutine that can outlive the
+// test function, so it reports through Logger rather than testing.T, whose Logf
+// panics once the test has returned.
+type blockingTopologyRecovery struct {
+	targetQueue string
+	passes      int32
+}
+
+func (b *blockingTopologyRecovery) RecoverTopology(conn *Connection, channels []*Channel) ([]TopologyRecoveryEntity, error) {
+	// Only obstruct the first pass. Later passes run unobstructed so the test can
+	// tell "permanently forgotten" from "still blocked".
+	if atomic.AddInt32(&b.passes, 1) == 1 {
+		if blockerConn, err := DialConfig(amqpURL, Config{Locale: defaultLocale}); err != nil {
+			Logger.Printf("test blocker: DialConfig failed: %v", err)
+		} else {
+			// Release as soon as this recovery pass returns, so the next attempt
+			// is unobstructed.
+			defer func() { _ = blockerConn.Close() }()
+
+			if blockerCh, err := blockerConn.Channel(); err != nil {
+				Logger.Printf("test blocker: Channel failed: %v", err)
+			} else if _, err := blockerCh.Consume(b.targetQueue, "recovery-blocker", true,
+				true /* exclusive */, false, false, nil); err != nil {
+				Logger.Printf("test blocker: Consume failed: %v", err)
+			}
+		}
+	}
+
+	return (&DefaultTopologyRecovery{}).RecoverTopology(conn, channels)
+}
+
+// TestConnectionRecoveryConsumerNotForgottenAfterFailedResubscribe verifies that a
+// consumer whose recovery-time basic.consume fails is still known to the client
+// afterwards, so a later recovery attempt can re-subscribe it.
+//
+// recoverConnectionTopology step 5 iterates ch.consumers.configs, and on failure
+// calls ch.consumers.cancel(tag), which deletes configs[tag] and closes the
+// caller's delivery channel. Because configs is the only record of a consumer
+// (there is no recordConsumer counterpart to recordExchange/recordQueue/
+// recordBinding), that deletion erases the consumer from the very map step 5
+// iterates. Steps 1-4 only log, skip, and reopen the channel, keeping their
+// records so a failed entity is retried on the next attempt; step 5 is the only
+// step that destroys its own retry source.
+//
+// Consequence: a single transient failure on one basic.consume loses the consumer
+// permanently, even though the obstruction was momentary and later attempts would
+// succeed. Recovery reports success and the connection and channel stay open,
+// while the queue is no longer consumed.
+//
+// Note that the loss is reported rather than truly silent: NotifyCancel listeners
+// fire, the delivery channel is closed, and the entity appears in
+// SkippedTopologyEntities. The cancel was added deliberately on that basis, so
+// that an application is told to re-Consume() instead of the library reviving the
+// consumer later.
+//
+// The reason to retry instead is that a failed re-subscribe is not a
+// cancellation, and the reference clients agree. Neither the Java nor the .NET
+// client removes a recorded consumer when the recovery-time basic.consume fails;
+// both report it through their topology recovery exception handler and keep the
+// record, and Java has explicit retry machinery for this case
+// (TopologyRecoveryRetryLogic.RECOVER_CONSUMER). Both remove the record only on a
+// client-initiated basic.cancel or channel teardown. A broker-sent basic.cancel
+// remains a cancellation here too; see dispatch().
+func TestConnectionRecoveryConsumerNotForgottenAfterFailedResubscribe(t *testing.T) {
+	connectionName := "test-recovery-consumer-not-forgotten"
+	properties := NewConnectionProperties()
+	properties.SetClientConnectionName(connectionName)
+
+	queueName := "test_consumer_not_forgotten_q"
+	consumerTag := "consumer-not-forgotten-tag"
+
+	blocker := &blockingTopologyRecovery{targetQueue: queueName}
+
+	conn, err := DialConfig(amqpURL, Config{
+		Recovery: &Recovery{
+			TopologyRecoveryMode: TopologyRecoveryAllEnabled,
+			TopologyRecovery:     blocker,
+			OnTopologyEntityError: func(_ *Connection, _ TopologyRecoveryEntity) bool {
+				return true // skip-and-continue, the default behaviour
+			},
+		},
+		Locale:     defaultLocale,
+		Properties: properties,
+	})
+	if err != nil {
+		t.Fatalf("DialConfig failed: %v", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel creation failed: %v", err)
+	}
+	defer ch.Close()
+
+	// Durable, non-exclusive, not auto-delete: the queue must outlive the
+	// connection drop so the consumer is the only thing that can go missing.
+	// Delete first in case an earlier failed run left it behind with a different
+	// definition.
+	_, _ = ch.QueueDelete(queueName, false, false, false)
+	if _, err := ch.QueueDeclare(queueName, true, false, false, false, nil); err != nil {
+		t.Fatalf("QueueDeclare failed: %v", err)
+	}
+	defer func() {
+		cleanupConn, cerr := DialConfig(amqpURL, Config{Locale: defaultLocale})
+		if cerr != nil {
+			return
+		}
+		defer cleanupConn.Close()
+		cleanupCh, cerr := cleanupConn.Channel()
+		if cerr != nil {
+			return
+		}
+		defer cleanupCh.Close()
+		_, _ = cleanupCh.QueueDelete(queueName, false, false, false)
+	}()
+
+	// Exclusive consumer, so the blocker's exclusive consume during recovery is
+	// refused with 403 ACCESS_REFUSED.
+	deliveries, err := ch.Consume(queueName, consumerTag, true, true /* exclusive */, false, false, nil)
+	if err != nil {
+		t.Fatalf("Consume failed: %v", err)
+	}
+
+	// Sanity check: delivery works before recovery, so a later failure to
+	// deliver cannot be blamed on a broken fixture.
+	if err := ch.Publish("", queueName, false, false, Publishing{Body: []byte("before")}); err != nil {
+		t.Fatalf("Publish (pre-recovery) failed: %v", err)
+	}
+	select {
+	case d, ok := <-deliveries:
+		if !ok {
+			t.Fatalf("delivery channel closed before recovery")
+		}
+		t.Logf("pre-recovery delivery received: %q", d.Body)
+	case <-time.After(10 * time.Second):
+		t.Fatalf("no pre-recovery delivery; test fixture is wrong")
+	}
+
+	stateChanged := make(chan *StateChanged, 20)
+	conn.NotifyStateChange(stateChanged)
+
+	// Drop the connection to drive a full recovery pass, which the wrapper above
+	// obstructs for the consumer only.
+	dropConnection(t, connectionName)
+
+	// Wait for recovery to settle, and confirm the consumer really was the thing
+	// that failed. Without this the test could pass vacuously if the blocker
+	// never won the race.
+	var skippedConsumerSeen bool
+	timeout := time.After(60 * time.Second)
+waitOpen:
+	for {
+		select {
+		case sc := <-stateChanged:
+			t.Logf("Connection state changed: %s", sc)
+			for _, e := range sc.SkippedTopologyEntities {
+				t.Logf("  skipped: %s %q on channel %d: %v", e.EntityType, e.EntityName, e.ChannelID, e.Err)
+				if e.EntityType == TopologyEntityConsumer && e.EntityName == consumerTag {
+					skippedConsumerSeen = true
+				}
+			}
+			if sc.To == StateOpen {
+				break waitOpen
+			}
+		case <-timeout:
+			t.Fatalf("Timeout waiting for connection to recover to StateOpen")
+		}
+	}
+
+	if !skippedConsumerSeen {
+		t.Skipf("consumer re-subscribe was not obstructed (blocker lost the race); nothing to assert")
+	}
+	t.Logf("consumer %q was skipped during recovery, as intended", consumerTag)
+
+	// The blocker released exclusivity when that recovery pass returned, so
+	// nothing stands in the way of re-subscribing the consumer now.
+	if conn.IsClosed() {
+		t.Fatalf("connection is closed after recovery reported StateOpen")
+	}
+	if ch.IsClosed() {
+		t.Fatalf("channel is closed after recovery reported StateOpen")
+	}
+
+	// Force a second, entirely unobstructed reconnect. Every other entity type
+	// keeps its topology record on failure and is retried here; the consumer
+	// must be too.
+	dropConnection(t, connectionName)
+	waitForConnectionOpen(t, stateChanged)
+	time.Sleep(2 * time.Second)
+
+	ch.consumers.Lock()
+	_, cfgFound := ch.consumers.configs[consumerTag]
+	ch.consumers.Unlock()
+	if !cfgFound {
+		t.Errorf("consumer %q was forgotten: ch.consumers.configs no longer has an entry for it, "+
+			"so no later recovery attempt can ever re-subscribe it", consumerTag)
+	}
+
+	// The decisive, behavioural assertion: is the queue being consumed again?
+	pubConn, err := DialConfig(amqpURL, Config{Locale: defaultLocale})
+	if err != nil {
+		t.Fatalf("publisher DialConfig failed: %v", err)
+	}
+	defer pubConn.Close()
+	pubCh, err := pubConn.Channel()
+	if err != nil {
+		t.Fatalf("publisher Channel failed: %v", err)
+	}
+	defer pubCh.Close()
+
+	if err := pubCh.Publish("", queueName, false, false, Publishing{Body: []byte("after")}); err != nil {
+		t.Fatalf("Publish (post-recovery) failed: %v", err)
+	}
+
+	select {
+	case d, ok := <-deliveries:
+		if !ok {
+			t.Fatalf("delivery channel was closed by recovery: the consumer is gone even though "+
+				"the connection and channel are both open, so queue %q is no longer consumed",
+				queueName)
+		}
+		t.Logf("post-recovery delivery received: %q", d.Body)
+	case <-time.After(15 * time.Second):
+		t.Fatalf("no post-recovery delivery: queue %q is no longer consumed on an open connection",
+			queueName)
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was prepared with Claude Code. I directed the investigation, required every claim to be verified against the Java and .NET client sources rather than asserted, and confirmed the findings and the test results myself.

## Proposed Changes

`recoverConnectionTopology` step 5 iterates `ch.consumers.configs` and, when the recovery-time `basic.consume` fails, called `ch.consumers.cancel(tag)`. That deletes `configs[tag]` and closes the caller's delivery channel.

`configs` is the only record this client has of a consumer. There is no `recordConsumer` counterpart to `recordExchange`, `recordQueue` or `recordBinding`. It is also the map step 5 iterates. Deleting the entry therefore erases the consumer from the client's own topology, so no later recovery attempt can retry it. A single transient failure on one `basic.consume`, such as a momentary 403 or a reply lost to the socket read deadline, loses that consumer for the life of the connection, while recovery reports success and the connection and channel both stay open.

Steps 1 through 4 handle a failed entity differently: they log, skip, and keep the record, so the next attempt retries it. Step 5 was the only step that destroyed its own retry source.

This change keeps the config and the delivery channel so a later attempt can re-subscribe.

A broker-sent `basic.cancel` is a different event and is unchanged. The inbound `case *basicCancel:` branch in `dispatch()` still notifies `NotifyCancel` listeners and cancels the consumer. `TestIntegrationCancel` and `TestConsumerCancelNotification` both cover that path and both pass.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Fixes

No existing issue. This corrects behaviour introduced in 3ac961288b, which is in `main` but has not shipped in a release tag.

## Further Comments

### Consistency with the Java and .NET clients

This is the main argument for the change. Both reference clients treat a failed recovery-time `basic.consume` as a retryable failure, not as a cancellation.

**Java** - `AutorecoveringConnection.recoverConsumer` catches the exception, wraps it in a `TopologyRecoveryException`, and hands it to the connection's `ExceptionHandler`. The entry stays in `this.consumers`. There is purpose-built retry machinery for exactly this case in `TopologyRecoveryRetryLogic`: `RECOVER_CONSUMER`, and `RECOVER_PREVIOUS_CONSUMERS`, which re-recovers consumers on the same channel that had already succeeded before a later one failed. `deleteRecordedConsumer` has exactly two callers: `AutorecoveringChannel.basicCancel`, which is client-initiated, and `clean()` on channel teardown.

**.NET** - `AutorecoveringConnection.RecoverConsumersAsync` runs either the configured `ConsumerRecoveryExceptionHandlerAsync` or `HandleTopologyRecoveryException`, which logs and rethrows if the inner exception is a connectivity problem, otherwise logs and ignores. Neither path touches `_recordedConsumers`. `DeleteRecordedConsumerAsync` is called only from `AutorecoveringChannel.BasicCancelAsync`, which is client-initiated, and from `DoDeleteRecordedConsumersAsync` on channel teardown.

Both clients also handle a broker-sent `basic.cancel` by removing the consumer from the *live* dispatch map and notifying the application, while leaving the *recorded* consumer in place. Go conflates the two, because `consumers.configs` serves as both the live map and the only record, so there is no way to stop delivering without also forgetting the consumer permanently. That conflation is what made the failed-re-subscribe path destructive.

### On reversing 3ac961288b

That commit added the cancel deliberately, to match real cancel semantics: the application is told the consumer is gone and must `Consume()` again, rather than having the library silently revive it on some later reconnect. The stated concern was a leaked buffer goroutine and a delivery channel that no broker `basic.cancel` would ever close.

The distinction this PR draws is that a failed re-subscribe RPC is not a `basic.cancel`. When the broker actually sends `basic.cancel`, cancelling is correct and still happens. When our own recovery attempt fails, the consumer has not been cancelled by anything; recovery simply has not finished yet.

The leak concern stays bounded:

- `resetState` deliberately preserves `consumers` across reconnects. That is how the caller's delivery channel stays valid, and it is pre-existing behaviour this PR relies on rather than changes.
- `closeResources`, guarded by `ch.closeOnce`, calls `consumers.close()`, which closes every remaining buffer channel and waits on the `WaitGroup` at final channel teardown.
- A successful re-subscribe on a later attempt reuses the same `configs` entry rather than creating a second one, so retrying does not accumulate goroutines.

The full integration suite is goleak-clean with this change.

The failure also remains visible to applications: it is reported in `SkippedTopologyEntities` on the `StateReconnecting` to `StateOpen` transition, and `OnTopologyEntityError` is consulted as before. What changes is that a reported failure is now also retried.

### The test

`TestConnectionRecoveryConsumerNotForgottenAfterFailedResubscribe` wraps `DefaultTopologyRecovery` and holds an exclusive consumer on the target queue for the duration of the first recovery pass only, so the recovery-time `basic.consume` for that queue fails with 403 `ACCESS_REFUSED`. The blocker is taken immediately before the pass and released immediately after, so the failure is deterministic with no sleeps or timing windows, and the obstruction is provably gone before the second, unobstructed recovery. Anything missing afterwards is missing because recovery forgot it, not because the broker is still refusing.

The decisive assertion is behavioural rather than a check on internal state: after the second recovery, publish from a fresh connection and require a delivery on the caller's original channel.

The test is skipped rather than passed vacuously if the blocker loses the race and the recovery consume succeeds, so a green run cannot hide a non-reproduction.

It uses the repo's existing management-API connection dropping, `internal/utils.DropConnection` via the `dropConnection` helper in `recovery_test.go`, so no new CI service is required. Toxiproxy was considered and not used: the trigger here is a broker 403 rather than a network fault, so it would have added a CI dependency for no gain.

### Verification

| check | result |
| --- | --- |
| test fails on unmodified `connection.go` | yes, on both the `configs` assertion and the delivery assertion, and non-vacuously: the skip guard was reached and passed |
| test passes with the fix | yes |
| full suite, `go test -race -tags integration ./...` | ok, 256s, goleak clean, no races |
| test under `-cpu 1,2 -race`, the Windows CI flags | pass |
| broker-sent `basic.cancel` still cancels | `TestIntegrationCancel`, `TestConsumerCancelNotification`, `TestNotifyClosesAllChansAfterConnectionClose` all pass |
| `make check-fmt`, `gofmt -l .` | clean |
| `golangci-lint run ./...` | only the pre-existing `fuzz.go` `+build` govet finding, confirmed identical on unmodified `main` |
