### PR TITLE
chore(deps): reduce github-actions dependabot updates to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
   groups:
     github-actions:
       patterns:


### PR DESCRIPTION
Daily checks were producing frequent low-value bumps (e.g. codeql-action patch releases); weekly cuts noise while still catching updates.