### PR TITLE
fix: preserve caller-provided SASL credentials across Reconnect()

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -90,9 +90,6 @@ func pickSASLMechanism(client []Authentication, serverMechanisms []string) (auth
 	return
 }
 
-// cloneAuthentications returns a clone of each entry in auths, preserving
-// order. Used to retain an independent copy of caller-provided
-// Authentication candidates that survives credential zeroing.
 func cloneAuthentications(auths []Authentication) []Authentication {
 	if auths == nil {
 		return nil
@@ -104,23 +101,11 @@ func cloneAuthentications(auths []Authentication) []Authentication {
 	return clones
 }
 
-// cloneAuthentication returns a clone of auth. Only *PlainAuth and
-// *AMQPlainAuth are actually copied, since those are the only mechanisms
-// whose credentials the library zeroes out post-handshake (see
-// openComplete); any other implementation is returned as-is: there's no
-// general way to deep-copy an arbitrary caller-supplied Authentication (its
-// concrete fields are unknown to this package). This is safe with respect
-// to the library's own zeroing, which never runs on a custom type, so
-// aliasing it here introduces no corruption on this package's side. It
-// does mean a custom Authentication reused across reconnects is the
-// caller's literal object: if the caller mutates its internal state in
-// place (e.g. rotating a token), that mutation is visible on the next
-// reconnect too, since it's the same instance, not a copy. This makes a
-// custom Authentication the right choice when secrets/passwords rotate over
-// the connection's lifetime (e.g. via UpdateSecret): unlike PlainAuth/
-// AMQPlainAuth, which are frozen as a deep copy at Open time, a custom
-// Authentication that reads its secret dynamically in Response() will
-// always have Reconnect() use the latest value.
+// cloneAuthentication copies *PlainAuth/*AMQPlainAuth, since openComplete
+// zeroes their credentials post-handshake. Other types are returned as-is,
+// so a custom Authentication stays the caller's live instance across
+// reconnects — in-place mutations (e.g. rotating a token) are picked up on
+// the next Reconnect().
 func cloneAuthentication(auth Authentication) Authentication {
 	switch a := auth.(type) {
 	case *PlainAuth:

--- a/auth.go
+++ b/auth.go
@@ -90,7 +90,37 @@ func pickSASLMechanism(client []Authentication, serverMechanisms []string) (auth
 	return
 }
 
-// cloneAuthentication returns a clone of auth.
+// cloneAuthentications returns a clone of each entry in auths, preserving
+// order. Used to retain an independent copy of caller-provided
+// Authentication candidates that survives credential zeroing.
+func cloneAuthentications(auths []Authentication) []Authentication {
+	if auths == nil {
+		return nil
+	}
+	clones := make([]Authentication, len(auths))
+	for i, auth := range auths {
+		clones[i] = cloneAuthentication(auth)
+	}
+	return clones
+}
+
+// cloneAuthentication returns a clone of auth. Only *PlainAuth and
+// *AMQPlainAuth are actually copied, since those are the only mechanisms
+// whose credentials the library zeroes out post-handshake (see
+// openComplete); any other implementation is returned as-is: there's no
+// general way to deep-copy an arbitrary caller-supplied Authentication (its
+// concrete fields are unknown to this package). This is safe with respect
+// to the library's own zeroing, which never runs on a custom type, so
+// aliasing it here introduces no corruption on this package's side. It
+// does mean a custom Authentication reused across reconnects is the
+// caller's literal object: if the caller mutates its internal state in
+// place (e.g. rotating a token), that mutation is visible on the next
+// reconnect too, since it's the same instance, not a copy. This makes a
+// custom Authentication the right choice when secrets/passwords rotate over
+// the connection's lifetime (e.g. via UpdateSecret): unlike PlainAuth/
+// AMQPlainAuth, which are frozen as a deep copy at Open time, a custom
+// Authentication that reads its secret dynamically in Response() will
+// always have Reconnect() use the latest value.
 func cloneAuthentication(auth Authentication) Authentication {
 	switch a := auth.(type) {
 	case *PlainAuth:

--- a/client_test.go
+++ b/client_test.go
@@ -340,6 +340,48 @@ func TestOpenDoesNotMutateCallerProvidedSASLCredentials(t *testing.T) {
 	}
 }
 
+// TestOpenCapturesOriginalSASLClone is a follow-up to the fix for
+// https://github.com/rabbitmq/amqp091-go/issues/387: Open must retain an
+// independent clone of the caller-provided Config.SASL candidates so
+// Reconnect() can later restore them, without that clone aliasing the
+// caller's own Authentication objects.
+func TestOpenCapturesOriginalSASLClone(t *testing.T) {
+	pa := &PlainAuth{Username: defaultLogin, Password: defaultPassword}
+	config := Config{
+		SASL:   []Authentication{pa},
+		Vhost:  "/",
+		Locale: defaultLocale,
+	}
+
+	rwc, srv := newSession(t)
+	t.Cleanup(func() { _ = rwc.Close() })
+	go func() {
+		srv.connectionOpen()
+	}()
+
+	c, err := Open(rwc, config)
+	if err != nil {
+		t.Fatalf("could not create connection: %v (%s)", c, err)
+	}
+
+	if len(c.originalSASL) != 1 {
+		t.Fatalf("expected 1 captured original SASL candidate, got %d", len(c.originalSASL))
+	}
+
+	clonedPa, ok := c.originalSASL[0].(*PlainAuth)
+	if !ok {
+		t.Fatalf("expected *PlainAuth, got %T", c.originalSASL[0])
+	}
+
+	if clonedPa == pa {
+		t.Fatal("expected originalSASL to hold a clone, not the caller's own *PlainAuth pointer")
+	}
+
+	if clonedPa.Username != defaultLogin || clonedPa.Password != defaultPassword {
+		t.Errorf("expected cloned credentials %s:%s, got %s:%s", defaultLogin, defaultPassword, clonedPa.Username, clonedPa.Password)
+	}
+}
+
 func TestOpenClose_ShouldNotPanic(t *testing.T) {
 	rwc, srv := newSession(t)
 	t.Cleanup(func() {

--- a/connection.go
+++ b/connection.go
@@ -174,6 +174,14 @@ type Connection struct {
 
 	Config Config // The negotiated Config after connection.open
 
+	// originalSASL is a clone of the caller-provided Config.SASL candidates,
+	// captured once at initial Open, before openStart narrows Config.SASL
+	// down to the single chosen (and cloned) mechanism and before
+	// openComplete zeroes its credentials. Reconnect() restores Config.SASL
+	// from this instead of re-deriving credentials from the URL, so it
+	// honors whatever Authentication the caller actually configured.
+	originalSASL []Authentication
+
 	url string // Connection URL stored for recovery
 
 	Major      int      // Server's major version
@@ -387,6 +395,7 @@ func Open(conn io.ReadWriteCloser, config Config) (*Connection, error) {
 	}
 	// Before max frame size is negotiated in Tune, the spec sets a ceiling of 4096 bytes
 	c.maxFrameSize.Store(frameMinSize)
+	c.originalSASL = cloneAuthentications(config.SASL)
 	go c.reader(conn)
 	err := c.open(config)
 	if err == nil {
@@ -1602,11 +1611,26 @@ func (c *Connection) Reconnect() (err error) {
 			return err
 		}
 
-		// Reset SASL to recover from zeroed out credentials
-		c.Config.SASL = nil
-		if err = c.Config.setSASL(uri); err != nil {
-			Logger.Printf("Connection recovery failed to set SASL: %v", err)
-			return err
+		// Restore SASL from the clone captured at initial Open, before the
+		// caller-provided credentials were narrowed/zeroed out, so recovery
+		// honors whatever Authentication the caller actually configured.
+		// Only fall back to deriving credentials from the URL if none was
+		// ever configured, matching setSASL's own "if not already set"
+		// contract.
+		if len(c.originalSASL) > 0 {
+			// Clone again rather than aliasing c.originalSASL directly:
+			// Config.SASL is a public field, so external code (or a future
+			// change here) could read/mutate conn.Config.SASL in place. If
+			// that slice were originalSASL itself, such a mutation would
+			// permanently corrupt the retained original and break every
+			// later reconnect, not just this attempt.
+			c.Config.SASL = cloneAuthentications(c.originalSASL)
+		} else {
+			c.Config.SASL = nil
+			if err = c.Config.setSASL(uri); err != nil {
+				Logger.Printf("Connection recovery failed to set SASL: %v", err)
+				return err
+			}
 		}
 
 		addr := net.JoinHostPort(uri.Host, strconv.FormatInt(int64(uri.Port), 10))

--- a/connection_unit_test.go
+++ b/connection_unit_test.go
@@ -156,6 +156,105 @@ func TestReconnectRestoresSASLCredentials(t *testing.T) {
 	}
 }
 
+// customAuth is a stand-in for an Authentication mechanism beyond
+// PlainAuth/AMQPlainAuth/ExternalAuth (e.g. OAuth2 token auth), used to
+// verify Reconnect() preserves it rather than silently falling back to a
+// URL-derived PlainAuth.
+type customAuth struct {
+	token string
+}
+
+func (a *customAuth) Mechanism() string { return "CUSTOM" }
+func (a *customAuth) Response() string  { return a.token }
+
+// TestReconnectRestoresCustomSASLFromOriginalClone is a follow-up to the fix
+// for https://github.com/rabbitmq/amqp091-go/issues/387: Reconnect() must
+// restore Config.SASL from the clone captured at initial Open
+// (c.originalSASL), not re-derive it from the connection URL, so custom
+// Authentication implementations survive reconnects.
+func TestReconnectRestoresCustomSASLFromOriginalClone(t *testing.T) {
+	custom := &customAuth{token: "opaque-token"}
+	c := &Connection{
+		url:       "amqp://guest:guest@localhost:5672/",
+		lifeCycle: newLifeCycle(),
+		Config: Config{
+			Recovery: &Recovery{
+				ReconnectionConfig: &ReconnectionConfig{
+					MaxRetryCount: 1,
+					RetryInterval: 1 * time.Millisecond,
+				},
+			},
+			Dial: func(network, addr string) (net.Conn, error) {
+				return nil, errors.New("mock dial error")
+			},
+		},
+		originalSASL: []Authentication{custom},
+	}
+	c.closed.Store(true)
+
+	// Trigger Reconnect. It will fail due to the mock dialer, but should
+	// restore SASL from originalSASL first.
+	_ = c.Reconnect()
+
+	if len(c.Config.SASL) != 1 {
+		t.Fatalf("expected 1 SASL mechanism after Reconnect, got %d", len(c.Config.SASL))
+	}
+
+	restored, ok := c.Config.SASL[0].(*customAuth)
+	if !ok {
+		t.Fatalf("expected *customAuth after Reconnect, got %T", c.Config.SASL[0])
+	}
+
+	if restored.token != "opaque-token" {
+		t.Errorf("expected custom auth token to survive Reconnect, got %q", restored.token)
+	}
+}
+
+// TestReconnectRestoresOutOfBandPlainAuthOverURL is a follow-up to the fix
+// for https://github.com/rabbitmq/amqp091-go/issues/387: when the caller's
+// PlainAuth credentials were supplied out-of-band (e.g. from secret
+// management) and differ from whatever is embedded in the connection URL,
+// Reconnect() must restore the caller's credentials, not the URL's.
+func TestReconnectRestoresOutOfBandPlainAuthOverURL(t *testing.T) {
+	pa := &PlainAuth{Username: "vault-user", Password: "vault-password"}
+	c := &Connection{
+		url:       "amqp://urluser:urlpassword@localhost:5672/",
+		lifeCycle: newLifeCycle(),
+		Config: Config{
+			Recovery: &Recovery{
+				ReconnectionConfig: &ReconnectionConfig{
+					MaxRetryCount: 1,
+					RetryInterval: 1 * time.Millisecond,
+				},
+			},
+			Dial: func(network, addr string) (net.Conn, error) {
+				return nil, errors.New("mock dial error")
+			},
+		},
+		originalSASL: []Authentication{pa},
+	}
+	c.closed.Store(true)
+
+	_ = c.Reconnect()
+
+	if len(c.Config.SASL) != 1 {
+		t.Fatalf("expected 1 SASL mechanism after Reconnect, got %d", len(c.Config.SASL))
+	}
+
+	restored, ok := c.Config.SASL[0].(*PlainAuth)
+	if !ok {
+		t.Fatalf("expected *PlainAuth after Reconnect, got %T", c.Config.SASL[0])
+	}
+
+	if restored == pa {
+		t.Fatal("expected Reconnect to restore a clone, not the retained originalSASL pointer")
+	}
+
+	if restored.Username != "vault-user" || restored.Password != "vault-password" {
+		t.Errorf("expected out-of-band credentials vault-user:vault-password to survive Reconnect, got %s:%s", restored.Username, restored.Password)
+	}
+}
+
 // TestOpenInitializesMaxFrameSize verifies that Open() initializes the atomic
 // maxFrameSize to frameMinSize before starting the reader goroutine. This ensures
 // the reader will reject oversized frames immediately, even before connection.tune

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -400,15 +400,12 @@ func TestConnectionRecoveryCustomSASLPlainAuth(t *testing.T) {
 		t.Fatalf("Timeout waiting for receive message pre-recovery: %s", preRecoveryMessage)
 	}
 
-	// Register with connection for NotifyStateChange
 	stateChanged := make(chan *StateChanged, 10)
 	conn.NotifyStateChange(stateChanged)
 
-	// Register with channel for NotifyStateChange
 	chanStateChanged := make(chan *StateChanged, 10)
 	ch.NotifyStateChange(chanStateChanged)
 
-	// Call Http API to close the current connection
 	dropConnection(t, connectionName)
 
 	// Wait for connection to reconnect. This requires the real password

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -296,6 +296,161 @@ func TestConnectionRecoveryConsume(t *testing.T) {
 	}
 }
 
+// TestConnectionRecoveryCustomSASLPlainAuth is a follow-up to the fix for
+// https://github.com/rabbitmq/amqp091-go/issues/387: Reconnect() must reuse
+// the Authentication the caller explicitly configured via Config.SASL, not
+// re-derive credentials from the connection URL on every retry.
+//
+// The dial URL below carries the right username but a deliberately wrong
+// password, while the real password is supplied only through Config.SASL.
+// The initial connect succeeds because openStart authenticates from
+// Config.SASL, never from the URL. If Reconnect() ever fell back to
+// re-deriving SASL from this URL, the reconnect attempt would authenticate
+// with the wrong password and fail; with the fix, SASL is restored from the
+// caller-provided clone and reconnect succeeds.
+func TestConnectionRecoveryCustomSASLPlainAuth(t *testing.T) {
+	connectionName := "test-connection-recovery-custom-sasl"
+
+	parsedURL, err := url.Parse(amqpURL)
+	if err != nil {
+		t.Fatalf("failed to parse amqpURL: %v", err)
+	}
+	realUsername := parsedURL.User.Username()
+	realPassword, _ := parsedURL.User.Password()
+
+	parsedURL.User = url.UserPassword(realUsername, "wrong-"+realPassword)
+	urlWithWrongPassword := parsedURL.String()
+
+	properties := NewConnectionProperties()
+	properties.SetClientConnectionName(connectionName)
+	conn, err := DialConfig(urlWithWrongPassword, Config{
+		SASL:       []Authentication{&PlainAuth{Username: realUsername, Password: realPassword}},
+		Recovery:   &Recovery{},
+		Locale:     defaultLocale,
+		Properties: properties,
+	})
+	if err != nil {
+		t.Fatalf("DialConfig failed: %v", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("Channel creation failed: %v", err)
+	}
+	defer ch.Close()
+
+	queueName := "recovery_custom_sasl_queue"
+	_, err = ch.QueueDeclare(
+		queueName, // name
+		true,      // durable
+		false,     // auto-delete
+		false,     // exclusive
+		false,     // no-wait
+		nil,       // arguments
+	)
+	if err != nil {
+		t.Fatalf("QueueDeclare failed: %v", err)
+	}
+	defer func() {
+		_, _ = ch.QueueDelete(queueName, false, false, false)
+	}()
+
+	msgs, err := ch.Consume(
+		queueName,
+		"recovery_custom_sasl_consumer", // consumer tag
+		true,                            // autoAck
+		false,                           // exclusive
+		false,                           // noLocal
+		false,                           // noWait
+		nil,                             // args
+	)
+	if err != nil {
+		t.Fatalf("Consume failed: %v", err)
+	}
+
+	// Publish and receive a message pre-recovery.
+	preRecoveryMessage := "hello custom sasl recovery 1"
+	err = ch.PublishWithContext(
+		context.Background(),
+		"",        // exchange
+		queueName, // routing key = queue name
+		false,
+		false,
+		Publishing{
+			ContentType: "text/plain",
+			Body:        []byte(preRecoveryMessage),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Publish pre-recovery message failed: %v", err)
+	}
+	t.Logf("Published message pre-recovery: %s", preRecoveryMessage)
+
+	select {
+	case d, ok := <-msgs:
+		if !ok {
+			t.Fatalf("Consume channel closed prematurely")
+		}
+		if string(d.Body) != preRecoveryMessage {
+			t.Fatalf("Expected message '%s', got: %s", preRecoveryMessage, string(d.Body))
+		}
+		t.Logf("Received message pre-recovery: %s", string(d.Body))
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Timeout waiting for receive message pre-recovery: %s", preRecoveryMessage)
+	}
+
+	// Register with connection for NotifyStateChange
+	stateChanged := make(chan *StateChanged, 10)
+	conn.NotifyStateChange(stateChanged)
+
+	// Register with channel for NotifyStateChange
+	chanStateChanged := make(chan *StateChanged, 10)
+	ch.NotifyStateChange(chanStateChanged)
+
+	// Call Http API to close the current connection
+	dropConnection(t, connectionName)
+
+	// Wait for connection to reconnect. This requires the real password
+	// supplied via Config.SASL to be honored during recovery.
+	waitForConnectionOpen(t, stateChanged)
+
+	// Verify channel state change notification is received and is reconnecting, followed by open
+	waitForChannelOpen(t, chanStateChanged)
+
+	// Verify Publish and receive a message post-recovery, proving the
+	// connection is fully usable again with the same custom SASL credentials.
+	postRecoveryMessage := "hello custom sasl recovery 2"
+	err = ch.PublishWithContext(
+		context.Background(),
+		"",
+		queueName,
+		false,
+		false,
+		Publishing{
+			ContentType: "text/plain",
+			Body:        []byte(postRecoveryMessage),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Publish post-recovery message failed: %v", err)
+	}
+	t.Logf("Published message post-recovery: %s", postRecoveryMessage)
+
+	select {
+	case d, ok := <-msgs:
+		if !ok {
+			t.Fatalf("Consume channel closed after recovery")
+		}
+		if string(d.Body) != postRecoveryMessage {
+			t.Fatalf("Expected message '%s', got: %s", postRecoveryMessage, string(d.Body))
+		}
+		t.Logf("Received message post-recovery: %s", string(d.Body))
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Timeout waiting for receive message post-recovery: %s", postRecoveryMessage)
+	}
+}
+
 func dropConnection(t *testing.T, name string) {
 	var targetConnName string
 	loopDeadline := time.Now().Add(10 * time.Second)


### PR DESCRIPTION
## Proposed Changes

Reconnect() unconditionally reset Config.SASL to nil and rebuilt it from the connection URL on every retry, discarding whatever Authentication the caller originally configured via DialConfig. This silently replaced custom Authentication implementations (OAuth2, Kerberos, etc.) with a URL-derived PlainAuth, and broke PlainAuth/AMQPlainAuth credentials supplied out-of-band that differed from the URL.

Building on the #388 clone fix (which stops openStart from mutating the caller's own Authentication objects), Connection now retains originalSASL, a clone of Config.SASL captured once at initial Open, before it's narrowed to the chosen mechanism and before openComplete zeroes its credentials. Reconnect() restores Config.SASL from that clone, falling back to deriving credentials from the URL only when none were ever configured.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

